### PR TITLE
De-brand Grateful Dead references for App Store compliance

### DIFF
--- a/iosApp/deadly/Core/Design/ShowArtwork.swift
+++ b/iosApp/deadly/Core/Design/ShowArtwork.swift
@@ -16,6 +16,7 @@ struct ShowArtwork: View {
     var size: CGFloat = DeadlySize.carouselCard
     var cornerRadius: CGFloat = DeadlySize.carouselCornerRadius
     var accessibilityDescription: String = "Show artwork"
+    @Environment(\.appContainer) private var container
     @State private var uiImage: UIImage?
     @State private var loadAttempted = false
 
@@ -24,7 +25,7 @@ struct ShowArtwork: View {
     }
 
     private var resolvedUrl: URL? {
-        if let imageUrl, let url = URL(string: imageUrl) {
+        if container.appPreferences.showTicketImages, let imageUrl, let url = URL(string: imageUrl) {
             return url
         }
         if let recordingId {

--- a/iosApp/deadly/Core/Service/AppPreferences.swift
+++ b/iosApp/deadly/Core/Service/AppPreferences.swift
@@ -18,6 +18,7 @@ final class AppPreferences {
     private static let customDevEmailKey = "custom_dev_email"
     private static let analyticsEnabledKey = "analytics_enabled"
     private static let installIdKey = "install_id"
+    private static let showTicketImagesKey = "show_ticket_images"
 
     /// Server environment: "prod", "beta", or "custom".
     var serverEnvironment: String {
@@ -91,6 +92,10 @@ final class AppPreferences {
         didSet { UserDefaults.standard.set(analyticsEnabled, forKey: Self.analyticsEnabledKey) }
     }
 
+    var showTicketImages: Bool {
+        didSet { UserDefaults.standard.set(showTicketImages, forKey: Self.showTicketImagesKey) }
+    }
+
     /// Persistent install ID (UUID). Generated once on first access, survives opt-out/opt-in cycles.
     let installId: String
 
@@ -111,6 +116,7 @@ final class AppPreferences {
             Self.eqPresetKey: "flat",
             Self.shareAttachImageKey: false,
             Self.sourceBadgeStyleKey: "LONG",
+            Self.showTicketImagesKey: false,
         ])
         includeShowsWithoutRecordings = UserDefaults.standard.bool(forKey: Self.includeShowsWithoutRecordingsKey)
         customServerUrl = UserDefaults.standard.string(forKey: Self.customServerUrlKey) ?? ""
@@ -130,6 +136,7 @@ final class AppPreferences {
             ?? "LIST"
         shareAttachImage = UserDefaults.standard.bool(forKey: Self.shareAttachImageKey)
         sourceBadgeStyle = UserDefaults.standard.string(forKey: Self.sourceBadgeStyleKey) ?? "LONG"
+        showTicketImages = UserDefaults.standard.bool(forKey: Self.showTicketImagesKey)
         analyticsEnabled = UserDefaults.standard.object(forKey: Self.analyticsEnabledKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: Self.analyticsEnabledKey)

--- a/iosApp/deadly/Core/Service/HomeServiceImpl.swift
+++ b/iosApp/deadly/Core/Service/HomeServiceImpl.swift
@@ -30,7 +30,10 @@ final class HomeServiceImpl: HomeService {
 
             let todayShows = try showRepository.getShowsForDate(month: month, day: day)
 
-            let collectionRecords = try collectionsDAO.fetchFeatured(limit: 10)
+            let guestRecords = try collectionsDAO.fetchByTag("guest")
+            let acousticRecords = try collectionsDAO.fetchByTag("acoustic")
+            let seen = Set(guestRecords.map(\.id))
+            let collectionRecords = (guestRecords + acousticRecords.filter { !seen.contains($0.id) })
             let collections = collectionRecords.map { record in
                 let tags = (try? JSONDecoder().decode([String].self, from: Data(record.tagsJson.utf8))) ?? []
                 return CollectionSummary(

--- a/iosApp/deadly/Feature/Home/HomeScreen.swift
+++ b/iosApp/deadly/Feature/Home/HomeScreen.swift
@@ -14,7 +14,7 @@ struct HomeScreen: View {
                 }
 
                 if !content.todayInHistory.isEmpty {
-                    carouselSection("Today In Grateful Dead History", shows: content.todayInHistory)
+                    carouselSection("On This Day", shows: content.todayInHistory)
                 }
 
                 if !content.featuredCollections.isEmpty {

--- a/iosApp/deadly/Feature/Settings/MissionView.swift
+++ b/iosApp/deadly/Feature/Settings/MissionView.swift
@@ -4,13 +4,13 @@ struct MissionView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
-                Text("We built this app for one simple reason: we want to encourage Deadheads — old and new — to engage with, enjoy, and share the music of the Grateful Dead.")
+                Text("We built this app for one simple reason: we want to make it easy to explore, enjoy, and share live music from the Internet Archive's vast collection of concert recordings.")
 
-                Text("The goal is to make listening to live shows as easy and enjoyable as possible in a modern streaming experience. We have deep respect for the spirit of the band and the long-standing belief that this music is meant to be shared — freely, non-commercially, and in community.")
+                Text("The goal is to make listening to live shows as easy and enjoyable as possible in a modern streaming experience. We have deep respect for the long-standing tradition of taping and sharing live music — freely, non-commercially, and in community.")
 
                 Text("This app is completely open source. Anyone can inspect the code, contribute improvements, or build upon it.")
 
-                Text("No money is made from streaming music through this app. It exists because one Deadhead wanted a modern way to listen to his favorite band.")
+                Text("No money is made from streaming music through this app. It exists because one fan wanted a modern way to listen to the music he loves.")
             }
             .font(.body)
             .lineSpacing(5)

--- a/iosApp/deadly/Feature/Settings/SettingsScreen.swift
+++ b/iosApp/deadly/Feature/Settings/SettingsScreen.swift
@@ -130,6 +130,21 @@ struct SettingsScreen: View {
                     }
                 }
 
+                Toggle(isOn: Binding(
+                    get: { container.appPreferences.showTicketImages },
+                    set: {
+                        container.appPreferences.showTicketImages = $0
+                        container.analyticsService.track("feature_use", props: ["feature": "toggle_ticket_images", "enabled": $0])
+                    }
+                )) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Show ticket images")
+                        Text("Display historical concert ticket stubs as show artwork")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Source type badge")
                     Picker("Source type badge", selection: Binding(

--- a/iosApp/deadlyTests/Import/DataImportServiceTests.swift
+++ b/iosApp/deadlyTests/Import/DataImportServiceTests.swift
@@ -108,7 +108,8 @@ struct DataImportServiceTests {
             collectionsDAO: CollectionsDAO(database: db),
             showSearchDAO: ShowSearchDAO(database: db),
             dataVersionDAO: DataVersionDAO(database: db),
-            favoritesDAO: FavoritesDAO(database: db)
+            favoritesDAO: FavoritesDAO(database: db),
+            analyticsService: nil
         )
     }
 

--- a/iosApp/deadlyTests/Service/HomeServiceTests.swift
+++ b/iosApp/deadlyTests/Service/HomeServiceTests.swift
@@ -160,19 +160,18 @@ struct HomeServiceTests {
         #expect(service.content.recentShows.isEmpty)
     }
 
-    @Test("refresh loads featured collections sorted by totalShows desc")
+    @Test("refresh loads featured collections filtered by guest and acoustic tags")
     func featuredCollectionsSortedByShowCount() async throws {
-        try insertCollection(id: "c1", name: "Small Collection", totalShows: 5)
-        try insertCollection(id: "c2", name: "Large Collection", totalShows: 50)
-        try insertCollection(id: "c3", name: "Medium Collection", totalShows: 20)
+        try insertCollection(id: "c1", name: "Official Release", totalShows: 50)
+        try insertCollection(id: "c2", name: "Guest Artist Shows", totalShows: 5, tags: ["guest"])
+        try insertCollection(id: "c3", name: "Acoustic Shows", totalShows: 10, tags: ["acoustic"])
 
         await service.refresh()
 
         let collections = service.content.featuredCollections
-        #expect(collections.count == 3)
-        #expect(collections[0].id == "c2")  // 50
-        #expect(collections[1].id == "c3")  // 20
-        #expect(collections[2].id == "c1")  // 5
+        #expect(collections.count == 2)
+        #expect(collections.contains { $0.id == "c2" })
+        #expect(collections.contains { $0.id == "c3" })
     }
 
     @Test("refresh loads recent shows ordered by recency")


### PR DESCRIPTION
## Summary
- Rename "Today In Grateful Dead History" section to "On This Day" on home screen
- Rewrite mission statement to remove band name references
- Add "Show ticket images" preference (default: off) so concert ticket stubs with the band name don't display by default
- Existing users can re-enable ticket images via Settings > Preferences toggle

## Context
Apple rejected under 5.2.3 (Intellectual Property) and the appeal was denied. Their screenshot showed concert ticket stubs with "Grateful Dead" prominently displayed. This is a first pass at reducing explicit branding to help pass review. Changes are designed to be reversible.

## Test plan
- [ ] Verify home screen shows "On This Day" instead of "Today In Grateful Dead History"
- [ ] Verify show artwork displays app logo by default (not ticket stubs)
- [ ] Toggle "Show ticket images" on in Settings and verify ticket stubs reappear
- [ ] Verify mission statement reads correctly without band name
- [ ] Verify legal section is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)