### PR TITLE
feat(android): add in-app review prompt

### DIFF
--- a/androidApp/app/build.gradle.kts
+++ b/androidApp/app/build.gradle.kts
@@ -209,6 +209,10 @@ dependencies {
     // Kotlin Serialization
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
 
+    // Google Play In-App Review
+    implementation("com.google.android.play:review:2.0.2")
+    implementation("com.google.android.play:review-ktx:2.0.2")
+
     // Hilt
     implementation("com.google.dagger:hilt-android:2.56.1")
     ksp("com.google.dagger:hilt-compiler:2.56.1")

--- a/androidApp/app/build.gradle.kts
+++ b/androidApp/app/build.gradle.kts
@@ -212,6 +212,7 @@ dependencies {
     // Google Play In-App Review
     implementation("com.google.android.play:review:2.0.2")
     implementation("com.google.android.play:review-ktx:2.0.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3")
 
     // Hilt
     implementation("com.google.dagger:hilt-android:2.56.1")

--- a/androidApp/app/src/main/java/com/grateful/deadly/AppViewModel.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/AppViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.grateful.deadly.core.api.favorites.FavoritesService
 import com.grateful.deadly.core.database.AnalyticsService
 import com.grateful.deadly.core.database.AppPreferences
+import com.grateful.deadly.core.database.AppReviewManager
 import com.grateful.deadly.core.domain.repository.ShowRepository
 import com.grateful.deadly.core.miniplayer.LastPlayedTrackService
 import com.grateful.deadly.core.model.Show
@@ -24,7 +25,8 @@ class AppViewModel @Inject constructor(
     private val analyticsService: AnalyticsService,
     private val lastPlayedTrackService: LastPlayedTrackService,
     private val showRepository: ShowRepository,
-    private val favoritesService: FavoritesService
+    private val favoritesService: FavoritesService,
+    private val appReviewManager: AppReviewManager
 ) : ViewModel() {
 
     val isOffline: StateFlow<Boolean> = combine(
@@ -49,4 +51,13 @@ class AppViewModel @Inject constructor(
     fun trackFeature(feature: String) {
         analyticsService.track("feature_use", mapOf("feature" to feature))
     }
+
+    // ── In-App Review ────────────────────────────────────────────────
+
+    val showReviewDialog: StateFlow<Boolean> = appReviewManager.showPrePromptDialog
+    val launchInAppReview: StateFlow<Boolean> = appReviewManager.launchInAppReview
+
+    fun onReviewYes() = appReviewManager.onUserSaidYes()
+    fun onReviewDismiss() = appReviewManager.onUserSaidNotReally()
+    fun onInAppReviewLaunched() = appReviewManager.onInAppReviewLaunched()
 }

--- a/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
@@ -40,6 +40,7 @@ import com.grateful.deadly.feature.settings.SettingsScreen
 import com.grateful.deadly.feature.settings.navigation.settingsGraph
 import android.app.Activity
 import com.google.android.play.core.review.ReviewManagerFactory
+import com.google.android.play.core.review.testing.FakeReviewManager
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import com.grateful.deadly.feature.splash.navigation.splashGraph
@@ -322,7 +323,11 @@ fun MainNavigation(
         if (launchReview && activity != null) {
             appViewModel.onInAppReviewLaunched()
             try {
-                val manager = ReviewManagerFactory.create(activity)
+                val manager = if (BuildConfig.DEBUG) {
+                    FakeReviewManager(activity)
+                } else {
+                    ReviewManagerFactory.create(activity)
+                }
                 val reviewInfo = manager.requestReviewFlow().await()
                 manager.launchReviewFlow(activity, reviewInfo).await()
             } catch (_: Exception) {

--- a/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
@@ -319,22 +319,20 @@ fun MainNavigation(
     }
 
     val activity = LocalContext.current as? Activity
-    if (launchReview && activity != null) {
-        LaunchedEffect(Unit) {
-            try {
-                val manager = if (BuildConfig.DEBUG) {
-                    FakeReviewManager(activity)
-                } else {
-                    ReviewManagerFactory.create(activity)
-                }
-                val reviewInfo = manager.requestReviewFlow().await()
-                manager.launchReviewFlow(activity, reviewInfo).await()
-            } catch (_: Exception) {
-                // Google silently suppresses if quota exceeded; nothing to handle
-            } finally {
-                appViewModel.onInAppReviewLaunched()
+    LaunchedEffect(launchReview) {
+        if (!launchReview || activity == null) return@LaunchedEffect
+        try {
+            val manager = if (BuildConfig.DEBUG) {
+                FakeReviewManager(activity)
+            } else {
+                ReviewManagerFactory.create(activity)
             }
+            val reviewInfo = manager.requestReviewFlow().await()
+            manager.launchReviewFlow(activity, reviewInfo).await()
+        } catch (_: Exception) {
+            // Google silently suppresses if quota exceeded; nothing to handle
         }
+        appViewModel.onInAppReviewLaunched()
     }
 
     pendingDeepLink?.let { deepLink ->

--- a/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
@@ -40,7 +40,6 @@ import com.grateful.deadly.feature.settings.SettingsScreen
 import com.grateful.deadly.feature.settings.navigation.settingsGraph
 import android.app.Activity
 import com.google.android.play.core.review.ReviewManagerFactory
-import com.google.android.play.core.review.testing.FakeReviewManager
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import com.grateful.deadly.feature.splash.navigation.splashGraph
@@ -319,20 +318,29 @@ fun MainNavigation(
     }
 
     val activity = LocalContext.current as? Activity
-    LaunchedEffect(launchReview) {
-        if (!launchReview || activity == null) return@LaunchedEffect
-        try {
-            val manager = if (BuildConfig.DEBUG) {
-                FakeReviewManager(activity)
-            } else {
-                ReviewManagerFactory.create(activity)
+    if (launchReview && activity != null) {
+        if (BuildConfig.DEBUG) {
+            AlertDialog(
+                onDismissRequest = { appViewModel.onInAppReviewLaunched() },
+                title = { Text("[Debug] In-App Review") },
+                text = { Text("In production, the Google Play review dialog would appear here.") },
+                confirmButton = {
+                    TextButton(onClick = { appViewModel.onInAppReviewLaunched() }) {
+                        Text("OK")
+                    }
+                }
+            )
+        } else {
+            LaunchedEffect(Unit) {
+                try {
+                    val manager = ReviewManagerFactory.create(activity)
+                    val reviewInfo = manager.requestReviewFlow().await()
+                    manager.launchReviewFlow(activity, reviewInfo).await()
+                } catch (_: Exception) {
+                }
+                appViewModel.onInAppReviewLaunched()
             }
-            val reviewInfo = manager.requestReviewFlow().await()
-            manager.launchReviewFlow(activity, reviewInfo).await()
-        } catch (_: Exception) {
-            // Google silently suppresses if quota exceeded; nothing to handle
         }
-        appViewModel.onInAppReviewLaunched()
     }
 
     pendingDeepLink?.let { deepLink ->

--- a/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.filled.WifiOff
 import androidx.activity.compose.BackHandler
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -37,7 +38,10 @@ import com.grateful.deadly.core.model.Show
 import com.grateful.deadly.feature.home.navigation.homeGraph
 import com.grateful.deadly.feature.settings.SettingsScreen
 import com.grateful.deadly.feature.settings.navigation.settingsGraph
+import android.app.Activity
+import com.google.android.play.core.review.ReviewManagerFactory
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 import com.grateful.deadly.feature.splash.navigation.splashGraph
 import com.grateful.deadly.feature.search.navigation.searchGraph
 import com.grateful.deadly.feature.playlist.navigation.playlistGraph
@@ -289,6 +293,43 @@ fun MainNavigation(
         }
     }
     } // ModalNavigationDrawer
+
+    // ── In-App Review ────────────────────────────────────────────────
+
+    val showReviewDialog by appViewModel.showReviewDialog.collectAsState()
+    val launchReview by appViewModel.launchInAppReview.collectAsState()
+
+    if (showReviewDialog) {
+        AlertDialog(
+            onDismissRequest = { appViewModel.onReviewDismiss() },
+            title = { Text("Enjoying Deadly?") },
+            text = { Text("Would you mind taking a moment to rate it? Your feedback helps other Deadheads find the app.") },
+            confirmButton = {
+                TextButton(onClick = { appViewModel.onReviewYes() }) {
+                    Text("Yes!")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { appViewModel.onReviewDismiss() }) {
+                    Text("Not really")
+                }
+            }
+        )
+    }
+
+    val activity = LocalContext.current as? Activity
+    LaunchedEffect(launchReview) {
+        if (launchReview && activity != null) {
+            appViewModel.onInAppReviewLaunched()
+            try {
+                val manager = ReviewManagerFactory.create(activity)
+                val reviewInfo = manager.requestReviewFlow().await()
+                manager.launchReviewFlow(activity, reviewInfo).await()
+            } catch (_: Exception) {
+                // Google silently suppresses if quota exceeded; nothing to handle
+            }
+        }
+    }
 
     pendingDeepLink?.let { deepLink ->
         DeepLinkActionSheet(

--- a/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
@@ -319,9 +319,8 @@ fun MainNavigation(
     }
 
     val activity = LocalContext.current as? Activity
-    LaunchedEffect(launchReview) {
-        if (launchReview && activity != null) {
-            appViewModel.onInAppReviewLaunched()
+    if (launchReview && activity != null) {
+        LaunchedEffect(Unit) {
             try {
                 val manager = if (BuildConfig.DEBUG) {
                     FakeReviewManager(activity)
@@ -332,6 +331,8 @@ fun MainNavigation(
                 manager.launchReviewFlow(activity, reviewInfo).await()
             } catch (_: Exception) {
                 // Google silently suppresses if quota exceeded; nothing to handle
+            } finally {
+                appViewModel.onInAppReviewLaunched()
             }
         }
     }

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
@@ -47,6 +47,10 @@ class AppPreferences @Inject constructor(
         private const val KEY_CUSTOM_DEV_EMAIL = "custom_dev_email"
         private const val KEY_ANALYTICS_ENABLED = "analytics_enabled"
         private const val KEY_INSTALL_ID = "install_id"
+        private const val KEY_INSTALL_DATE = "install_date"
+        private const val KEY_UNIQUE_SHOWS_PLAYED = "unique_shows_played"
+        private const val KEY_LAST_REVIEW_PROMPT_TIME = "last_review_prompt_time"
+        private const val KEY_HAS_ADDED_FAVORITE = "has_added_favorite"
     }
 
     private val _includeShowsWithoutRecordings = MutableStateFlow(
@@ -178,6 +182,44 @@ class AppPreferences @Inject constructor(
             prefs.edit().putString(KEY_INSTALL_ID, newId).apply()
             newId
         }
+    }
+
+    // ── In-App Review ────────────────────────────────────────────────
+
+    val installDate: Long = run {
+        val existing = prefs.getLong(KEY_INSTALL_DATE, 0L)
+        if (existing != 0L) {
+            existing
+        } else {
+            val now = System.currentTimeMillis()
+            prefs.edit().putLong(KEY_INSTALL_DATE, now).apply()
+            now
+        }
+    }
+
+    private val uniqueShowsPlayedSet: MutableSet<String> =
+        (prefs.getStringSet(KEY_UNIQUE_SHOWS_PLAYED, emptySet()) ?: emptySet()).toMutableSet()
+
+    val uniqueShowsPlayedCount: Int
+        @Synchronized get() = uniqueShowsPlayedSet.size
+
+    @Synchronized
+    fun recordShowPlayed(showId: String) {
+        if (uniqueShowsPlayedSet.add(showId)) {
+            prefs.edit().putStringSet(KEY_UNIQUE_SHOWS_PLAYED, uniqueShowsPlayedSet.toSet()).apply()
+        }
+    }
+
+    fun getLastReviewPromptTime(): Long = prefs.getLong(KEY_LAST_REVIEW_PROMPT_TIME, 0L)
+
+    fun setLastReviewPromptTime(time: Long) {
+        prefs.edit().putLong(KEY_LAST_REVIEW_PROMPT_TIME, time).apply()
+    }
+
+    fun getHasAddedFavorite(): Boolean = prefs.getBoolean(KEY_HAS_ADDED_FAVORITE, false)
+
+    fun setHasAddedFavorite(value: Boolean) {
+        prefs.edit().putBoolean(KEY_HAS_ADDED_FAVORITE, value).apply()
     }
 
     // ── Server Environment ───────────────────────────────────────────

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
@@ -51,6 +51,7 @@ class AppPreferences @Inject constructor(
         private const val KEY_UNIQUE_SHOWS_PLAYED = "unique_shows_played"
         private const val KEY_LAST_REVIEW_PROMPT_TIME = "last_review_prompt_time"
         private const val KEY_HAS_ADDED_FAVORITE = "has_added_favorite"
+        private const val KEY_DEVELOPER_MODE_UNLOCKED = "developer_mode_unlocked"
     }
 
     private val _includeShowsWithoutRecordings = MutableStateFlow(
@@ -220,6 +221,17 @@ class AppPreferences @Inject constructor(
 
     fun setHasAddedFavorite(value: Boolean) {
         prefs.edit().putBoolean(KEY_HAS_ADDED_FAVORITE, value).apply()
+    }
+
+    private val _developerModeUnlocked = MutableStateFlow(
+        prefs.getBoolean(KEY_DEVELOPER_MODE_UNLOCKED, false)
+    )
+
+    val developerModeUnlocked: StateFlow<Boolean> = _developerModeUnlocked.asStateFlow()
+
+    fun setDeveloperModeUnlocked(value: Boolean) {
+        prefs.edit().putBoolean(KEY_DEVELOPER_MODE_UNLOCKED, value).apply()
+        _developerModeUnlocked.value = value
     }
 
     // ── Server Environment ───────────────────────────────────────────

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppReviewManager.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppReviewManager.kt
@@ -30,6 +30,10 @@ class AppReviewManager @Inject constructor(
         analyticsService.track("review_prompt_shown")
     }
 
+    fun forcePrompt() {
+        _showPrePromptDialog.value = true
+    }
+
     fun onUserSaidYes() {
         _showPrePromptDialog.value = false
         _launchInAppReview.value = true

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppReviewManager.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppReviewManager.kt
@@ -1,0 +1,68 @@
+package com.grateful.deadly.core.database
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AppReviewManager @Inject constructor(
+    private val appPreferences: AppPreferences,
+    private val analyticsService: AnalyticsService
+) {
+    companion object {
+        private const val INSTALL_AGE_DAYS = 7
+        private const val MIN_UNIQUE_SHOWS = 3
+        private const val COOLDOWN_DAYS = 90
+        private const val MILLIS_PER_DAY = 1000L * 60 * 60 * 24
+    }
+
+    private val _showPrePromptDialog = MutableStateFlow(false)
+    val showPrePromptDialog: StateFlow<Boolean> = _showPrePromptDialog.asStateFlow()
+
+    private val _launchInAppReview = MutableStateFlow(false)
+    val launchInAppReview: StateFlow<Boolean> = _launchInAppReview.asStateFlow()
+
+    fun checkAndMaybePrompt() {
+        if (!areConditionsMet()) return
+        _showPrePromptDialog.value = true
+        analyticsService.track("review_prompt_shown")
+    }
+
+    fun onUserSaidYes() {
+        _showPrePromptDialog.value = false
+        _launchInAppReview.value = true
+        appPreferences.setLastReviewPromptTime(System.currentTimeMillis())
+        analyticsService.track("review_prompt_accepted")
+    }
+
+    fun onUserSaidNotReally() {
+        _showPrePromptDialog.value = false
+        appPreferences.setLastReviewPromptTime(System.currentTimeMillis())
+        analyticsService.track("review_prompt_declined")
+    }
+
+    fun onInAppReviewLaunched() {
+        _launchInAppReview.value = false
+    }
+
+    private fun areConditionsMet(): Boolean {
+        val now = System.currentTimeMillis()
+
+        val daysSinceInstall = (now - appPreferences.installDate) / MILLIS_PER_DAY
+        if (daysSinceInstall < INSTALL_AGE_DAYS) return false
+
+        if (!appPreferences.getHasAddedFavorite()) return false
+
+        if (appPreferences.uniqueShowsPlayedCount < MIN_UNIQUE_SHOWS) return false
+
+        val lastPrompt = appPreferences.getLastReviewPromptTime()
+        if (lastPrompt > 0) {
+            val daysSinceLastPrompt = (now - lastPrompt) / MILLIS_PER_DAY
+            if (daysSinceLastPrompt < COOLDOWN_DAYS) return false
+        }
+
+        return true
+    }
+}

--- a/androidApp/core/favorites/src/main/java/com/grateful/deadly/core/favorites/service/FavoritesServiceImpl.kt
+++ b/androidApp/core/favorites/src/main/java/com/grateful/deadly/core/favorites/service/FavoritesServiceImpl.kt
@@ -2,6 +2,8 @@ package com.grateful.deadly.core.favorites.service
 
 import android.util.Log
 import com.grateful.deadly.core.database.AnalyticsService
+import com.grateful.deadly.core.database.AppPreferences
+import com.grateful.deadly.core.database.AppReviewManager
 import com.grateful.deadly.core.api.favorites.FavoritesService
 import com.grateful.deadly.core.domain.repository.ShowRepository
 import com.grateful.deadly.core.media.download.MediaDownloadManager
@@ -36,6 +38,8 @@ class FavoritesServiceImpl @Inject constructor(
     private val shareService: ShareService,
     private val mediaDownloadManager: MediaDownloadManager,
     private val analyticsService: AnalyticsService,
+    private val appPreferences: AppPreferences,
+    private val appReviewManager: AppReviewManager,
     @Named("FavoritesApplicationScope") private val coroutineScope: CoroutineScope
 ) : FavoritesService {
 
@@ -88,7 +92,11 @@ class FavoritesServiceImpl @Inject constructor(
     override suspend fun addToFavorites(showId: String): Result<Unit> {
         Log.d(TAG, "addToFavorites('$showId') - using FavoritesRepository")
         val result = favoritesRepository.addShowToFavorites(showId)
-        if (result.isSuccess) analyticsService.track("feature_use", mapOf("feature" to "add_favorite"))
+        if (result.isSuccess) {
+            analyticsService.track("feature_use", mapOf("feature" to "add_favorite"))
+            appPreferences.setHasAddedFavorite(true)
+            appReviewManager.checkAndMaybePrompt()
+        }
         return result
     }
 

--- a/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/di/MediaModule.kt
+++ b/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/di/MediaModule.kt
@@ -2,6 +2,7 @@ package com.grateful.deadly.core.media.di
 
 import android.content.Context
 import com.grateful.deadly.core.database.AnalyticsService
+import com.grateful.deadly.core.database.AppPreferences
 import com.grateful.deadly.core.media.repository.MediaControllerRepository
 import com.grateful.deadly.core.network.archive.service.ArchiveService
 import dagger.Module
@@ -23,8 +24,9 @@ object MediaModule {
     fun provideMediaControllerRepository(
         @ApplicationContext context: Context,
         archiveService: ArchiveService,
-        analyticsService: AnalyticsService
+        analyticsService: AnalyticsService,
+        appPreferences: AppPreferences
     ): MediaControllerRepository {
-        return MediaControllerRepository(context, archiveService, analyticsService)
+        return MediaControllerRepository(context, archiveService, analyticsService, appPreferences)
     }
 }

--- a/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/repository/MediaControllerRepository.kt
+++ b/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/repository/MediaControllerRepository.kt
@@ -15,6 +15,7 @@ import com.grateful.deadly.core.model.PlaybackStatus
 import com.grateful.deadly.core.model.PlaybackState
 import com.grateful.deadly.core.model.Track
 import com.grateful.deadly.core.database.AnalyticsService
+import com.grateful.deadly.core.database.AppPreferences
 import com.grateful.deadly.core.network.archive.service.ArchiveService
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
@@ -42,7 +43,8 @@ import javax.inject.Singleton
 class MediaControllerRepository @Inject constructor(
     @ApplicationContext private val context: Context,
     private val archiveService: ArchiveService,
-    private val analyticsService: AnalyticsService
+    private val analyticsService: AnalyticsService,
+    private val appPreferences: AppPreferences
 ) {
     companion object {
         private const val TAG = "MediaControllerRepository"
@@ -209,6 +211,7 @@ class MediaControllerRepository @Inject constructor(
                                 "recording_id" to recordingId,
                                 "track_index" to 1
                             ))
+                            appPreferences.recordShowPlayed(showId)
                         } else {
                             Log.d(TAG, "🕒🎵 [URL] Recording loaded at position $startPosition (paused) at ${System.currentTimeMillis()}")
                         }
@@ -316,6 +319,7 @@ class MediaControllerRepository @Inject constructor(
                                     "recording_id" to recordingId,
                                     "track_index" to (trackIndex + 1)
                                 ))
+                                appPreferences.recordShowPlayed(showId)
                             } else {
                                 Log.d(TAG, "🕒🎵 [URL] Track $trackIndex loaded at position $position (paused) at ${System.currentTimeMillis()}")
                             }

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/navigation/SettingsNavigation.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/navigation/SettingsNavigation.kt
@@ -63,7 +63,7 @@ fun NavGraphBuilder.developerScreen(
     onNavigateBack: () -> Unit
 ) {
     composable(route = DEVELOPER_ROUTE) {
-        DeveloperScreen()
+        DeveloperScreen(onNavigateBack = onNavigateBack)
     }
 }
 

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/developer/DeveloperScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/developer/DeveloperScreen.kt
@@ -92,6 +92,15 @@ fun DeveloperScreen(
 
         item { HorizontalDivider() }
 
+        item {
+            DevRow(
+                title = "Trigger review prompt",
+                onClick = { viewModel.triggerReviewPrompt() }
+            )
+        }
+
+        item { HorizontalDivider() }
+
         item { ClearArchiveCacheRow() }
 
         item { HorizontalDivider() }

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/developer/DeveloperScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/developer/DeveloperScreen.kt
@@ -18,7 +18,8 @@ import com.grateful.deadly.feature.settings.SettingsViewModel
 
 @Composable
 fun DeveloperScreen(
-    viewModel: SettingsViewModel = hiltViewModel()
+    viewModel: SettingsViewModel = hiltViewModel(),
+    onNavigateBack: () -> Unit = {}
 ) {
     val forceOnline by viewModel.forceOnline.collectAsState()
 
@@ -130,7 +131,10 @@ fun DeveloperScreen(
             DevRow(
                 title = "Hide developer settings",
                 titleColor = MaterialTheme.colorScheme.error,
-                onClick = { viewModel.lockDeveloperMode() }
+                onClick = {
+                    viewModel.lockDeveloperMode()
+                    onNavigateBack()
+                }
             )
         }
     }

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/developer/DeveloperScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/developer/DeveloperScreen.kt
@@ -123,6 +123,16 @@ fun DeveloperScreen(
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
             )
         }
+
+        item { HorizontalDivider() }
+
+        item {
+            DevRow(
+                title = "Hide developer settings",
+                titleColor = MaterialTheme.colorScheme.error,
+                onClick = { viewModel.lockDeveloperMode() }
+            )
+        }
     }
 }
 

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
@@ -185,33 +185,35 @@ fun SettingsScreen(
         item { SectionHeader("About") }
 
         item {
-            PreferenceRow(
-                title = "Version $version",
-                onClick = {
-                    if (developerModeUnlocked) {
-                        val url = "https://github.com/ds17f/deadly-monorepo/releases/tag/android%2Fv$version"
-                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
-                    } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
                         versionTapCount++
                         val remaining = 7 - versionTapCount
-                        if (remaining <= 0) {
+                        if (remaining <= 0 && !developerModeUnlocked) {
                             viewModel.unlockDeveloperMode()
                             Toast.makeText(context, "Developer mode enabled", Toast.LENGTH_SHORT).show()
-                        } else if (remaining <= 3) {
+                        } else if (remaining in 1..3 && !developerModeUnlocked) {
                             Toast.makeText(context, "$remaining taps to enable developer mode", Toast.LENGTH_SHORT).show()
                         }
                     }
-                },
-                trailing = if (developerModeUnlocked) {
-                    {
-                        Icon(
-                            painter = IconResources.Navigation.ChevronRight(),
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+                    .padding(horizontal = 16.dp, vertical = 14.dp)
+            ) {
+                Text(
+                    text = "Version $version",
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Text(
+                    text = "Release notes",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.clickable {
+                        val url = "https://github.com/ds17f/deadly-monorepo/releases/tag/android%2Fv$version"
+                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
                     }
-                } else null
-            )
+                )
+            }
         }
 
         item {

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
@@ -38,7 +38,7 @@ fun SettingsScreen(
     val serverEnvironment by viewModel.serverEnvironment.collectAsState()
     val developerModeUnlocked by viewModel.developerModeUnlocked.collectAsState()
     val version = BuildConfig.VERSION_NAME
-    var versionTapCount by remember { mutableIntStateOf(0) }
+    var versionTapCount by remember(developerModeUnlocked) { mutableIntStateOf(0) }
 
     LazyColumn(modifier = Modifier.fillMaxSize()) {
 

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
@@ -36,7 +36,9 @@ fun SettingsScreen(
     val sourceBadgeStyle by viewModel.sourceBadgeStyle.collectAsState()
     val authState by viewModel.authState.collectAsState()
     val serverEnvironment by viewModel.serverEnvironment.collectAsState()
+    val developerModeUnlocked by viewModel.developerModeUnlocked.collectAsState()
     val version = BuildConfig.VERSION_NAME
+    var versionTapCount by remember { mutableIntStateOf(0) }
 
     LazyColumn(modifier = Modifier.fillMaxSize()) {
 
@@ -186,16 +188,29 @@ fun SettingsScreen(
             PreferenceRow(
                 title = "Version $version",
                 onClick = {
-                    val url = "https://github.com/ds17f/deadly-monorepo/releases/tag/android%2Fv$version"
-                    context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                    if (developerModeUnlocked) {
+                        val url = "https://github.com/ds17f/deadly-monorepo/releases/tag/android%2Fv$version"
+                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                    } else {
+                        versionTapCount++
+                        val remaining = 7 - versionTapCount
+                        if (remaining <= 0) {
+                            viewModel.unlockDeveloperMode()
+                            Toast.makeText(context, "Developer mode enabled", Toast.LENGTH_SHORT).show()
+                        } else if (remaining <= 3) {
+                            Toast.makeText(context, "$remaining taps to enable developer mode", Toast.LENGTH_SHORT).show()
+                        }
+                    }
                 },
-                trailing = {
-                    Icon(
-                        painter = IconResources.Navigation.ChevronRight(),
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
+                trailing = if (developerModeUnlocked) {
+                    {
+                        Icon(
+                            painter = IconResources.Navigation.ChevronRight(),
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                } else null
             )
         }
 
@@ -246,18 +261,20 @@ fun SettingsScreen(
             )
         }
 
-        item {
-            PreferenceRow(
-                title = "Developer",
-                onClick = onNavigateToDeveloper,
-                trailing = {
-                    Icon(
-                        painter = IconResources.Navigation.ChevronRight(),
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            )
+        if (developerModeUnlocked) {
+            item {
+                PreferenceRow(
+                    title = "Developer",
+                    onClick = onNavigateToDeveloper,
+                    trailing = {
+                        Icon(
+                            painter = IconResources.Navigation.ChevronRight(),
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                )
+            }
         }
 
         item { HorizontalDivider() }

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
@@ -185,35 +185,36 @@ fun SettingsScreen(
         item { SectionHeader("About") }
 
         item {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable {
-                        versionTapCount++
-                        val remaining = 7 - versionTapCount
-                        if (remaining <= 0 && !developerModeUnlocked) {
-                            viewModel.unlockDeveloperMode()
-                            Toast.makeText(context, "Developer mode enabled", Toast.LENGTH_SHORT).show()
-                        } else if (remaining in 1..3 && !developerModeUnlocked) {
-                            Toast.makeText(context, "$remaining taps to enable developer mode", Toast.LENGTH_SHORT).show()
-                        }
+            PreferenceRow(
+                title = "Version $version",
+                onClick = {
+                    versionTapCount++
+                    val remaining = 7 - versionTapCount
+                    if (remaining <= 0 && !developerModeUnlocked) {
+                        viewModel.unlockDeveloperMode()
+                        Toast.makeText(context, "Developer mode enabled", Toast.LENGTH_SHORT).show()
+                    } else if (remaining in 1..3 && !developerModeUnlocked) {
+                        Toast.makeText(context, "$remaining taps to enable developer mode", Toast.LENGTH_SHORT).show()
                     }
-                    .padding(horizontal = 16.dp, vertical = 14.dp)
-            ) {
-                Text(
-                    text = "Version $version",
-                    style = MaterialTheme.typography.bodyLarge
-                )
-                Text(
-                    text = "Release notes",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.clickable {
-                        val url = "https://github.com/ds17f/deadly-monorepo/releases/tag/android%2Fv$version"
-                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
-                    }
-                )
-            }
+                }
+            )
+        }
+
+        item {
+            PreferenceRow(
+                title = "Release Notes",
+                onClick = {
+                    val url = "https://github.com/ds17f/deadly-monorepo/releases/tag/android%2Fv$version"
+                    context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                },
+                trailing = {
+                    Icon(
+                        painter = IconResources.Navigation.ChevronRight(),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            )
         }
 
         item {

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
@@ -129,6 +129,12 @@ class SettingsViewModel @Inject constructor(
         appReviewManager.forcePrompt()
     }
 
+    val developerModeUnlocked: StateFlow<Boolean> = appPreferences.developerModeUnlocked
+
+    fun unlockDeveloperMode() {
+        appPreferences.setDeveloperModeUnlocked(true)
+    }
+
     fun signInWithGoogle(activity: android.app.Activity, onError: (String) -> Unit) {
         viewModelScope.launch {
             try {

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
@@ -9,6 +9,7 @@ import com.grateful.deadly.core.api.auth.AuthService
 import com.grateful.deadly.core.api.auth.AuthState
 import com.grateful.deadly.core.database.AnalyticsService
 import com.grateful.deadly.core.database.AppPreferences
+import com.grateful.deadly.core.database.AppReviewManager
 import com.grateful.deadly.core.database.migration.MigrationImportService
 import com.grateful.deadly.core.database.migration.MigrationResult
 import com.grateful.deadly.core.database.service.BackupImportExportService
@@ -35,6 +36,7 @@ class SettingsViewModel @Inject constructor(
     private val appPreferences: AppPreferences,
     private val authService: AuthService,
     private val analyticsService: AnalyticsService,
+    private val appReviewManager: AppReviewManager,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
@@ -121,6 +123,10 @@ class SettingsViewModel @Inject constructor(
 
     fun toggleForceOnline() {
         appPreferences.setForceOnline(!appPreferences.forceOnline.value)
+    }
+
+    fun triggerReviewPrompt() {
+        appReviewManager.forcePrompt()
     }
 
     fun signInWithGoogle(activity: android.app.Activity, onError: (String) -> Unit) {

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
@@ -135,6 +135,10 @@ class SettingsViewModel @Inject constructor(
         appPreferences.setDeveloperModeUnlocked(true)
     }
 
+    fun lockDeveloperMode() {
+        appPreferences.setDeveloperModeUnlocked(false)
+    }
+
     fun signInWithGoogle(activity: android.app.Activity, onError: (String) -> Unit) {
         viewModelScope.launch {
             try {


### PR DESCRIPTION
## Summary
- In-app review prompt gated behind engagement signals (7+ days, 3+ shows played, 1+ favorite, 90-day cooldown)
- Triggers after adding a favorite with a pre-prompt ("Enjoying Deadly?") before the Google review flow
- Debug builds show a placeholder dialog; release builds use the real Play Store review API
- Developer settings hidden behind 7-tap version easter egg (with hide/re-enable support)
- "Trigger review prompt" button in developer settings for testing

## Changes
- **AppPreferences** — install date, unique shows played, review prompt cooldown, favorite flag, developer mode unlock
- **AppReviewManager** (new) — condition checker, dialog state, force-prompt for dev testing
- **MediaControllerRepository** — records unique shows played on playback start
- **FavoritesServiceImpl** — triggers review check after adding a favorite
- **AppViewModel / MainNavigation** — review dialog + Google review flow (debug placeholder in debug builds)
- **SettingsScreen** — version row (easter egg), separate "Release Notes >" row, conditional developer row
- **DeveloperScreen** — "Trigger review prompt" button, "Hide developer settings" button
- **build.gradle.kts** — `play-review`, `play-review-ktx`, `kotlinx-coroutines-play-services`

## Test plan
- [x] Trigger review prompt from developer settings
- [x] "Yes!" shows debug review dialog (placeholder in debug, real Play dialog in release)
- [x] "Not really" dismisses and records cooldown
- [x] 7-tap version number unlocks developer settings
- [x] "Hide developer settings" exits and re-hides the dev menu
- [x] "Release Notes >" opens GitHub release page
- [ ] Verify dialog does not reappear within 90-day cooldown
- [ ] Verify unique shows counter increments across playback sessions
- [ ] Verify real Google review flow works in production/Play Store install

🤖 Generated with [Claude Code](https://claude.com/claude-code)