### PR TITLE
fix(ios/ci): pass app_identifier to deliver in promote lane

### DIFF
--- a/iosApp/fastlane/Fastfile
+++ b/iosApp/fastlane/Fastfile
@@ -206,6 +206,7 @@ platform :ios do
 
     deliver(
       api_key: api_key,
+      app_identifier: "com.grateful.deadly",
       app_version: version,
       submit_for_review: true,
       automatic_release: true,


### PR DESCRIPTION
## Summary

iOS promote workflow failed with "Could not infer your App's Bundle Identifier" because there's no `Appfile` in the repo and `deliver` runs non-interactively.

Passes `app_identifier: \"com.grateful.deadly\"` explicitly to match the value in `deadly.xcodeproj/project.pbxproj`.

## Repro

https://github.com/ds17f/deadly-monorepo/actions/runs/25638880438 — failed during the `deliver` step right after the API key was loaded.

## Test plan

- [ ] Merge.
- [ ] Re-run `gh workflow run ios-promote.yml -f version=2.28.0` and watch it get past the `deliver` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)