### PR TITLE
fix(ios/ci): drop content_rights_has_rights from submission_information

### DIFF
--- a/iosApp/fastlane/Fastfile
+++ b/iosApp/fastlane/Fastfile
@@ -221,7 +221,6 @@ platform :ios do
         add_id_info_uses_idfa: false,
         export_compliance_uses_encryption: false,
         content_rights_contains_third_party_content: false,
-        content_rights_has_rights: true
       }
     )
 


### PR DESCRIPTION
## Summary

ASC rejected the submission with:

\`\`\`
contentRightsDeclaration: An attribute value is not acceptable for the current resource state
\`\`\`

\`content_rights_has_rights: true\` is only meaningful when \`content_rights_contains_third_party_content: true\`. We declare the latter false, so the former is contradictory and ASC rejects the patch.

## Repro

https://github.com/ds17f/deadly-monorepo/actions/runs/25639154701 — failed inside \`submit_for_review > update_submission_information\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)