### PR TITLE
fix(ios/ci): stop sending content_rights_contains_third_party_content

### DIFF
--- a/iosApp/fastlane/Fastfile
+++ b/iosApp/fastlane/Fastfile
@@ -217,10 +217,14 @@ platform :ios do
       skip_binary_upload: true,
       precheck_include_in_app_purchases: false,
       release_notes: release_notes_hash,
+      # Note: content_rights_contains_third_party_content is *not* included
+      # here. It maps to ASC's contentRightsDeclaration, which can't be
+      # patched once the app has a stable value (already set on this app
+      # from a prior submission). Sending it triggers ASC error 409:
+      # "An attribute value is not acceptable for the current resource state".
       submission_information: {
         add_id_info_uses_idfa: false,
         export_compliance_uses_encryption: false,
-        content_rights_contains_third_party_content: false,
       }
     )
 


### PR DESCRIPTION
## Summary

ASC keeps rejecting the submission with:

\`\`\`
contentRightsDeclaration: An attribute value is not acceptable for the current resource state
\`\`\`

Previous fix removed \`content_rights_has_rights\` but the real culprit is \`content_rights_contains_third_party_content\` itself — once an app has a value set in ASC, the API won't accept a re-patch. The setting is already correct on the app side, so dropping the field is the right move.

## Repro

https://github.com/ds17f/deadly-monorepo/actions/runs/25642365500

🤖 Generated with [Claude Code](https://claude.com/claude-code)