### PR TITLE
fix(ci): promote workflows must check out the version tag, not main

### DIFF
--- a/.github/workflows/android-promote.yml
+++ b/.github/workflows/android-promote.yml
@@ -25,6 +25,13 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      with:
+        # Check out the tag for the version being promoted so the
+        # CHANGELOG entry the awk-extract reads is guaranteed to match
+        # the version. Without this, a release commit that lives only on
+        # the source feature branch (not main) leaves promote-time
+        # release notes empty.
+        ref: android/v${{ inputs.version }}
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@a6e6f86333f0a2523ece813039b8b4be04560854 # v1.190.0
@@ -54,6 +61,12 @@ jobs:
       run: |
         VERSION="${{ inputs.version }}"
         RAW=$(awk "/^## \[${VERSION}\]/{flag=1; next} /^## \[/{flag=0} flag" androidApp/CHANGELOG.md | sed '/^[[:space:]]*$/d')
+        if [ -z "$RAW" ]; then
+          echo "::error::No CHANGELOG entry found for version ${VERSION} in androidApp/CHANGELOG.md." >&2
+          echo "::error::Play Console needs release notes per track; an empty value silently truncates them." >&2
+          echo "::error::Check that the android/v${VERSION} tag points at a commit containing the '## [${VERSION}]' section." >&2
+          exit 1
+        fi
         if [ ${#RAW} -gt 500 ]; then
           RAW="${RAW:0:497}..."
         fi

--- a/.github/workflows/ios-promote.yml
+++ b/.github/workflows/ios-promote.yml
@@ -19,6 +19,14 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       with:
+        # Check out the tag for the version being promoted, not the default
+        # branch. The release commit that adds the version's CHANGELOG entry
+        # lives on the tag — it may not be on main if the feature branch
+        # was squash-merged. Without this, the CHANGELOG awk-extract finds
+        # nothing for the version, RELEASE_NOTES is empty, deliver sets
+        # skip_metadata=true, and ASC rejects the submission with "missing
+        # whatsNew" disguised as an unrelated state error.
+        ref: ios/v${{ inputs.version }}
         fetch-depth: 0
 
     - name: Set up Ruby
@@ -39,6 +47,12 @@ jobs:
       run: |
         VERSION="${{ inputs.version }}"
         RAW=$(awk "/^## \[${VERSION}\]/{flag=1; next} /^## \[/{flag=0} flag" iosApp/CHANGELOG.md | sed '/^[[:space:]]*$/d')
+        if [ -z "$RAW" ]; then
+          echo "::error::No CHANGELOG entry found for version ${VERSION} in iosApp/CHANGELOG.md." >&2
+          echo "::error::Without release notes, fastlane skips metadata and ASC rejects the submission with a misleading state error." >&2
+          echo "::error::Check that the ios/v${VERSION} tag points at a commit containing the '## [${VERSION}]' section." >&2
+          exit 1
+        fi
         if [ ${#RAW} -gt 4000 ]; then
           RAW="${RAW:0:3997}..."
         fi

--- a/iosApp/fastlane/Fastfile
+++ b/iosApp/fastlane/Fastfile
@@ -217,10 +217,14 @@ platform :ios do
       skip_binary_upload: true,
       precheck_include_in_app_purchases: false,
       release_notes: release_notes_hash,
+      # Note: content_rights_contains_third_party_content is *not* included
+      # here. It maps to ASC's contentRightsDeclaration, which can't be
+      # patched once the app has a stable value (already set on this app
+      # from a prior submission). Sending it triggers ASC error 409:
+      # "An attribute value is not acceptable for the current resource state".
       submission_information: {
         add_id_info_uses_idfa: false,
         export_compliance_uses_encryption: false,
-        content_rights_contains_third_party_content: false,
       }
     )
 


### PR DESCRIPTION
## Summary

\`ios-promote.yml\` and \`android-promote.yml\` were checking out the default branch (\`main\`). If the \`chore: release\` commit lives on a feature branch and not on \`main\` (which happens when \`make {ios,android}-release\` runs from a feature branch after a squash-merge), the CHANGELOG awk-extract returns nothing and \`RELEASE_NOTES\` is empty.

For iOS this propagates as:
- Fastfile sees empty release notes → \`skip_metadata: true\`
- \`deliver\` uploads no \`whatsNew\`
- ASC rejects with \`appStoreVersions is not in valid state\` (the real underlying error is "missing required attribute 'whatsNew'", surfaced only via the reviewSubmissionItems endpoint)

## What this PR does

- Both workflows now check out the corresponding version tag (\`ios/v\${version}\` / \`android/v\${version}\`) instead of \`main\`. The tag definitionally contains the matching CHANGELOG entry.
- Both \`Extract release notes\` steps now hard-fail if \`RELEASE_NOTES\` is empty after the awk. Error message points at the version tag so the next time this happens, the diagnosis is two seconds instead of three iterations.

## Repro

iOS 2.28.0 promotion: 3 failed runs against PR #29 today, ultimately submitted via direct API call after patching \`whatsNew\` manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)