### PR TITLE
feat(web/admin): Recent Listening, per-install profile, watched installs

### DIFF
--- a/api/src/db/analytics.ts
+++ b/api/src/db/analytics.ts
@@ -754,6 +754,12 @@ export function getLiveListeners(): LiveListener[] {
 
   // Pull `sid` too so we can resolve the bitmap for *this* listening session
   // of this show (rather than every time the listener has ever played it).
+  //
+  // A user can only listen to one thing at a time. The unmatched-start filter
+  // can leave multiple ghosts per iid when the client emits a new
+  // `playback_start` without a corresponding `playback_end` for the previous
+  // one (force-quit, crash, network drop, rapid show switches). Take only the
+  // most recent unmatched start per iid as the listener's current state.
   const rows = db
     .prepare(
       `SELECT
@@ -777,9 +783,24 @@ export function getLiveListeners(): LiveListener[] {
              AND json_extract(e.props, '$.show_id') = json_extract(s.props, '$.show_id')
              AND json_extract(e.props, '$.track_index') = json_extract(s.props, '$.track_index')
          )
+         AND s.ts = (
+           SELECT MAX(s2.ts) FROM analytics_events s2
+           WHERE s2.event = 'playback_start'
+             AND s2.iid = s.iid
+             AND s2.ts >= ?
+             AND NOT EXISTS (
+               SELECT 1 FROM analytics_events e2
+               WHERE e2.event = 'playback_end'
+                 AND e2.iid = s2.iid
+                 AND e2.sid = s2.sid
+                 AND e2.ts >= s2.ts
+                 AND json_extract(e2.props, '$.show_id') = json_extract(s2.props, '$.show_id')
+                 AND json_extract(e2.props, '$.track_index') = json_extract(s2.props, '$.track_index')
+             )
+         )
        ORDER BY s.ts DESC`,
     )
-    .all(windowStart) as Array<{
+    .all(windowStart, windowStart) as Array<{
       iid: string;
       sid: string;
       platform: string;

--- a/api/src/db/analytics.ts
+++ b/api/src/db/analytics.ts
@@ -792,55 +792,14 @@ export function getLiveListeners(): LiveListener[] {
     }>;
 
   // For each live listener, materialize the bitmap for their current
-  // (iid, sid, show_id) by replaying the same per-track outcome rules
-  // used by getShowPlaybackSummary. Look back 6h so a long jam session
-  // earlier in the same sid still contributes to the bar.
+  // (iid, sid, show_id). Look back 6h so a long jam session earlier in
+  // the same sid still contributes to the bar.
   const sessionLookback = Date.now() - 6 * 3600 * 1000;
-  const trackQuery = db.prepare(
-    `SELECT
-       event, ts,
-       COALESCE(CAST(json_extract(props, '$.track_index') AS INTEGER), 0) AS track_index,
-       json_extract(props, '$.reason') AS reason
-     FROM analytics_events
-     WHERE iid = ? AND sid = ?
-       AND json_extract(props, '$.show_id') = ?
-       AND event IN ('playback_start', 'playback_end')
-       AND ts >= ?
-     ORDER BY ts ASC`,
-  );
 
   return rows.map((r) => {
-    let tracks: TrackPlay[] = [];
-    if (r.show_id) {
-      const events = trackQuery.all(
-        r.iid,
-        r.sid,
-        r.show_id,
-        sessionLookback,
-      ) as Array<{
-        event: string;
-        ts: number;
-        track_index: number;
-        reason: string | null;
-      }>;
-      const acc = new Map<number, { ts: number; outcome: TrackOutcome }>();
-      for (const e of events) {
-        const prior = acc.get(e.track_index);
-        if (e.event === "playback_start") {
-          if (!prior) acc.set(e.track_index, { ts: e.ts, outcome: "partial" });
-          continue;
-        }
-        if (!prior || e.ts >= prior.ts) {
-          acc.set(e.track_index, {
-            ts: e.ts,
-            outcome: reasonToOutcome(e.reason),
-          });
-        }
-      }
-      tracks = Array.from(acc.entries())
-        .map(([index, v]) => ({ index, outcome: v.outcome }))
-        .sort((a, b) => a.index - b.index);
-    }
+    const tracks = r.show_id
+      ? buildTrackBitmap(r.iid, r.sid, r.show_id, sessionLookback)
+      : [];
     return {
       iid: r.iid,
       platform: r.platform,
@@ -1110,6 +1069,199 @@ function reasonToOutcome(reason: string | null): TrackOutcome {
       // some of the track but didn't finish it.
       return "partial";
   }
+}
+
+/**
+ * Replay playback_start / playback_end events for an (iid, show_id) into a
+ * per-track outcome bitmap. When `sid` is provided, only that session is
+ * considered (Listening Now — single live session). When `sid` is null, all
+ * sessions for this user/show are merged (Recent Listening — cumulative
+ * listening across app launches).
+ */
+function buildTrackBitmap(
+  iid: string,
+  sid: string | null,
+  showId: string,
+  sinceMs: number,
+): TrackPlay[] {
+  const db = getAnalyticsDb();
+  const sql = `SELECT
+         event, ts,
+         COALESCE(CAST(json_extract(props, '$.track_index') AS INTEGER), 0) AS track_index,
+         json_extract(props, '$.reason') AS reason
+       FROM analytics_events
+       WHERE iid = ?${sid != null ? " AND sid = ?" : ""}
+         AND json_extract(props, '$.show_id') = ?
+         AND event IN ('playback_start', 'playback_end')
+         AND ts >= ?
+       ORDER BY ts ASC`;
+  const params = sid != null ? [iid, sid, showId, sinceMs] : [iid, showId, sinceMs];
+  const events = db.prepare(sql).all(...params) as Array<{
+    event: string;
+    ts: number;
+    track_index: number;
+    reason: string | null;
+  }>;
+
+  const acc = new Map<number, { ts: number; outcome: TrackOutcome }>();
+  for (const e of events) {
+    const prior = acc.get(e.track_index);
+    if (e.event === "playback_start") {
+      if (!prior) acc.set(e.track_index, { ts: e.ts, outcome: "partial" });
+      continue;
+    }
+    if (!prior || e.ts >= prior.ts) {
+      acc.set(e.track_index, { ts: e.ts, outcome: reasonToOutcome(e.reason) });
+    }
+  }
+  return Array.from(acc.entries())
+    .map(([index, v]) => ({ index, outcome: v.outcome }))
+    .sort((a, b) => a.index - b.index);
+}
+
+// ── Recent Listening ───────────────────────────────────────────────
+
+export interface RecentListeningSession {
+  iid: string;
+  platform: string;
+  app_version: string;
+  /** Earliest playback_start across all sessions of this (iid, show_id). */
+  started_at: number;
+  /** Most recent playback event across all sessions of this (iid, show_id). */
+  last_event_at: number;
+  show_id: string | null;
+  recording_id: string | null;
+  /** track_index of the most recent playback event. */
+  track_index: number | null;
+  /** source from the first playback_start across all sessions. */
+  source: string | null;
+  /** Per-track outcomes merged across all sessions of this (iid, show_id). */
+  tracks: TrackPlay[];
+  /** Number of distinct sids (app sessions) the user used for this show. */
+  session_count: number;
+  /** True if any session has a playback_end. */
+  ended: boolean;
+}
+
+/**
+ * Recent listening, deduped by (iid, show_id). One row per user-show pair —
+ * if the same install listened to the same show across multiple app sessions
+ * (sids) in the window, those are merged into a single row with cumulative
+ * track bitmap and earliest/latest timestamps. Excludes any (iid, show_id)
+ * still considered live by getLiveListeners() to avoid double-counting.
+ */
+export function getRecentListening(
+  hours = 24,
+  limit = 100,
+): RecentListeningSession[] {
+  const db = getAnalyticsDb();
+  const now = Date.now();
+  const windowStart = now - hours * 3600 * 1000;
+  const liveWindowStart = now - 45 * 60 * 1000;
+
+  const rows = db
+    .prepare(
+      `WITH show_events AS (
+         SELECT
+           iid,
+           sid,
+           json_extract(props, '$.show_id') AS show_id,
+           event,
+           ts,
+           platform,
+           app_version,
+           json_extract(props, '$.recording_id') AS recording_id,
+           CAST(json_extract(props, '$.track_index') AS INTEGER) AS track_index,
+           json_extract(props, '$.source') AS source
+         FROM analytics_events
+         WHERE event IN ('playback_start', 'playback_end')
+           AND ts >= ?
+           AND json_extract(props, '$.show_id') IS NOT NULL
+       ),
+       agg AS (
+         SELECT
+           iid,
+           show_id,
+           MIN(ts) AS started_at,
+           MAX(ts) AS last_event_at,
+           COUNT(DISTINCT sid) AS session_count,
+           MAX(CASE WHEN event = 'playback_end' THEN 1 ELSE 0 END) AS has_end,
+           MAX(CASE WHEN event = 'playback_start' THEN ts ELSE 0 END) AS last_start_ts
+         FROM show_events
+         GROUP BY iid, show_id
+       )
+       SELECT
+         a.iid,
+         a.show_id,
+         a.started_at,
+         a.last_event_at,
+         a.session_count,
+         a.has_end,
+         (SELECT platform FROM show_events
+            WHERE iid = a.iid AND show_id = a.show_id
+            ORDER BY ts DESC LIMIT 1) AS platform,
+         (SELECT app_version FROM show_events
+            WHERE iid = a.iid AND show_id = a.show_id
+            ORDER BY ts DESC LIMIT 1) AS app_version,
+         (SELECT recording_id FROM show_events
+            WHERE iid = a.iid AND show_id = a.show_id
+              AND event = 'playback_start'
+            ORDER BY ts ASC LIMIT 1) AS recording_id,
+         (SELECT track_index FROM show_events
+            WHERE iid = a.iid AND show_id = a.show_id
+            ORDER BY ts DESC LIMIT 1) AS track_index,
+         (SELECT source FROM show_events
+            WHERE iid = a.iid AND show_id = a.show_id
+              AND event = 'playback_start'
+            ORDER BY ts ASC LIMIT 1) AS source
+       FROM agg a
+       WHERE NOT EXISTS (
+         SELECT 1 FROM analytics_events s
+         WHERE s.event = 'playback_start'
+           AND s.iid = a.iid
+           AND json_extract(s.props, '$.show_id') = a.show_id
+           AND s.ts >= ?
+           AND NOT EXISTS (
+             SELECT 1 FROM analytics_events e
+             WHERE e.event = 'playback_end'
+               AND e.iid = s.iid
+               AND e.sid = s.sid
+               AND e.ts >= s.ts
+               AND json_extract(e.props, '$.show_id') = json_extract(s.props, '$.show_id')
+               AND json_extract(e.props, '$.track_index') = json_extract(s.props, '$.track_index')
+           )
+       )
+       ORDER BY a.last_event_at DESC
+       LIMIT ?`,
+    )
+    .all(windowStart, liveWindowStart, limit) as Array<{
+      iid: string;
+      show_id: string;
+      started_at: number;
+      last_event_at: number;
+      session_count: number;
+      has_end: number;
+      platform: string;
+      app_version: string;
+      recording_id: string | null;
+      track_index: number | null;
+      source: string | null;
+    }>;
+
+  return rows.map((r) => ({
+    iid: r.iid,
+    platform: r.platform,
+    app_version: r.app_version,
+    started_at: r.started_at,
+    last_event_at: r.last_event_at,
+    show_id: r.show_id,
+    recording_id: r.recording_id,
+    track_index: r.track_index,
+    source: r.source,
+    tracks: buildTrackBitmap(r.iid, null, r.show_id, r.started_at),
+    session_count: r.session_count,
+    ended: r.has_end === 1,
+  }));
 }
 
 export function getShowPlaybackSummary(days: number): ShowPlaybackSummary {

--- a/api/src/db/analytics.ts
+++ b/api/src/db/analytics.ts
@@ -77,7 +77,60 @@ function initSchema(db: Database.Database): void {
       props_summary TEXT,
       PRIMARY KEY (day, event, platform, app_version)
     );
+
+    CREATE TABLE IF NOT EXISTS watched_installs (
+      iid TEXT PRIMARY KEY,
+      name TEXT,
+      notes TEXT,
+      watched_at INTEGER NOT NULL
+    );
   `);
+}
+
+// ── Watched installs ──────────────────────────────────────────────────
+
+export interface WatchedInstall {
+  iid: string;
+  name: string | null;
+  notes: string | null;
+  watched_at: number;
+}
+
+export function getWatchedInstalls(): WatchedInstall[] {
+  const db = getAnalyticsDb();
+  return db
+    .prepare(
+      `SELECT iid, name, notes, watched_at
+       FROM watched_installs
+       ORDER BY watched_at DESC`,
+    )
+    .all() as WatchedInstall[];
+}
+
+export function setWatchedInstall(
+  iid: string,
+  name: string | null,
+  notes: string | null,
+): WatchedInstall {
+  const db = getAnalyticsDb();
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO watched_installs (iid, name, notes, watched_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(iid) DO UPDATE SET
+       name = excluded.name,
+       notes = excluded.notes`,
+  ).run(iid, name, notes, now);
+  return db
+    .prepare(
+      `SELECT iid, name, notes, watched_at FROM watched_installs WHERE iid = ?`,
+    )
+    .get(iid) as WatchedInstall;
+}
+
+export function removeWatchedInstall(iid: string): void {
+  const db = getAnalyticsDb();
+  db.prepare(`DELETE FROM watched_installs WHERE iid = ?`).run(iid);
 }
 
 // ── Valid events and their allowed prop keys ─────────────────────────

--- a/api/src/routes/analytics.ts
+++ b/api/src/routes/analytics.ts
@@ -16,6 +16,7 @@ import {
   getRetentionCohorts,
   getSearchQuality,
   getLiveListeners,
+  getRecentListening,
   getGrowthByPlatform,
   getTopShows,
 } from "../db/analytics.js";
@@ -671,6 +672,72 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
       preHandler: requireAdmin,
     },
     async () => ({ listeners: getLiveListeners() }),
+  );
+
+  // GET /api/analytics/recent-listening — finished sessions in the last N hours.
+  app.get(
+    "/api/analytics/recent-listening",
+    {
+      schema: {
+        tags: ["analytics"],
+        summary: "Recent listening sessions (admin)",
+        querystring: {
+          type: "object",
+          properties: {
+            hours: { type: "number", default: 24 },
+            limit: { type: "number", default: 100 },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              sessions: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    iid: { type: "string" },
+                    platform: { type: "string" },
+                    app_version: { type: "string" },
+                    started_at: { type: "number" },
+                    last_event_at: { type: "number" },
+                    show_id: { type: ["string", "null"] },
+                    recording_id: { type: ["string", "null"] },
+                    track_index: { type: ["number", "null"] },
+                    source: { type: ["string", "null"] },
+                    session_count: { type: "number" },
+                    ended: { type: "boolean" },
+                    tracks: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          index: { type: "number" },
+                          outcome: { type: "string" },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      preHandler: requireAdmin,
+    },
+    async (request) => {
+      const { hours, limit } = request.query as {
+        hours?: number;
+        limit?: number;
+      };
+      const clampedHours = Math.min(Math.max(hours ?? 24, 1), 168);
+      const clampedLimit = Math.min(Math.max(limit ?? 100, 1), 500);
+      return {
+        sessions: getRecentListening(clampedHours, clampedLimit),
+      };
+    },
   );
 
   // GET /api/analytics/search-quality — zero-result + abandon + ranking-quality stats.

--- a/api/src/routes/analytics.ts
+++ b/api/src/routes/analytics.ts
@@ -19,6 +19,9 @@ import {
   getRecentListening,
   getGrowthByPlatform,
   getTopShows,
+  getWatchedInstalls,
+  setWatchedInstall,
+  removeWatchedInstall,
 } from "../db/analytics.js";
 import { requireAdmin } from "../auth/middleware.js";
 import { ANALYTICS_WATERSHED } from "../analytics-watershed.js";
@@ -846,6 +849,66 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
       preHandler: requireAdmin,
     },
     async () => ({ entries: ANALYTICS_WATERSHED }),
+  );
+
+  // ── Watched installs ──────────────────────────────────────────────
+
+  // GET /api/analytics/watched — list of flagged installs with optional names.
+  app.get(
+    "/api/analytics/watched",
+    {
+      schema: {
+        tags: ["analytics"],
+        summary: "Watched installs (admin)",
+      },
+      preHandler: requireAdmin,
+    },
+    async () => ({ watched: getWatchedInstalls() }),
+  );
+
+  // PUT /api/analytics/watched/:iid — upsert a watched install. Body may
+  // include { name, notes }; both optional and may be null.
+  app.put<{
+    Params: { iid: string };
+    Body: { name?: string | null; notes?: string | null };
+  }>(
+    "/api/analytics/watched/:iid",
+    {
+      schema: {
+        tags: ["analytics"],
+        summary: "Flag an install for monitoring (admin)",
+        body: {
+          type: "object",
+          properties: {
+            name: { type: ["string", "null"] },
+            notes: { type: ["string", "null"] },
+          },
+        },
+      },
+      preHandler: requireAdmin,
+    },
+    async (request) => {
+      const { iid } = request.params;
+      const name = request.body?.name ?? null;
+      const notes = request.body?.notes ?? null;
+      return setWatchedInstall(iid, name, notes);
+    },
+  );
+
+  // DELETE /api/analytics/watched/:iid — remove watch flag.
+  app.delete<{ Params: { iid: string } }>(
+    "/api/analytics/watched/:iid",
+    {
+      schema: {
+        tags: ["analytics"],
+        summary: "Unflag an install (admin)",
+      },
+      preHandler: requireAdmin,
+    },
+    async (request, reply) => {
+      removeWatchedInstall(request.params.iid);
+      reply.code(204).send();
+    },
   );
 }
 

--- a/ui/src/app/admin/analytics/AnalyticsDashboard.tsx
+++ b/ui/src/app/admin/analytics/AnalyticsDashboard.tsx
@@ -1,17 +1,18 @@
 "use client";
 
 import { useAuth } from "@/contexts/AuthContext";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState, useCallback, useMemo } from "react";
 import MetricCard from "./components/MetricCard";
-import DetailPanel from "./components/DetailPanel";
-import InstallDetailPanel from "./components/InstallDetailPanel";
+import InstallDetailView from "./components/InstallDetailView";
+import MetricDetailView from "./components/MetricDetailView";
 import TopShowsList from "./components/TopShowsList";
 import PlatformChart from "./components/PlatformChart";
 import RetentionCohorts from "./components/RetentionCohorts";
 import SearchQuality from "./components/SearchQuality";
 import PlaysBySource from "./components/PlaysBySource";
 import ListeningNow from "./components/ListeningNow";
+import RecentListening from "./components/RecentListening";
 import GrowthChart from "./components/GrowthChart";
 import FeatureAdoption from "./components/FeatureAdoption";
 import CollapsibleSection from "./components/CollapsibleSection";
@@ -105,10 +106,12 @@ const METRIC_LABELS: Record<DetailMetric, string> = {
 };
 
 const REFRESH_INTERVAL = 30_000;
+const DASH_SCROLL_KEY = "__analytics_dashboard_scroll";
 
 export default function AnalyticsDashboard({ showNames }: { showNames: ShowName[] }) {
   const { user, isLoading: authLoading } = useAuth();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [data, setData] = useState<AnalyticsSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -118,16 +121,28 @@ export default function AnalyticsDashboard({ showNames }: { showNames: ShowName[
   const [dauTs, setDauTs] = useState<TimeseriesPoint[]>([]);
   const [eventsTs, setEventsTs] = useState<TimeseriesPoint[]>([]);
 
-  // Detail panel state
-  const [activeMetric, setActiveMetric] = useState<DetailMetric | null>(null);
-  const [activeFilter, setActiveFilter] = useState<string | undefined>(undefined);
-  const [detailRows, setDetailRows] = useState<DetailRow[]>([]);
-  const [detailLoading, setDetailLoading] = useState(false);
+  // URL-driven detail views — ?install=<iid> or ?metric=<m>&filter=<f>
+  const activeInstall = searchParams.get("install");
+  const activeMetric = searchParams.get("metric") as DetailMetric | null;
+  const activeFilter = searchParams.get("filter") ?? undefined;
 
-  // Install detail modal — opened from any iid reference in the dashboard
-  const [activeInstall, setActiveInstall] = useState<string | null>(null);
-  const openInstall = useCallback((iid: string) => setActiveInstall(iid), []);
-  const closeInstall = useCallback(() => setActiveInstall(null), []);
+  const openInstall = useCallback(
+    (iid: string) => {
+      sessionStorage.setItem(DASH_SCROLL_KEY, String(window.scrollY));
+      router.push(`/admin/analytics?install=${encodeURIComponent(iid)}`);
+    },
+    [router],
+  );
+
+  const openDetail = useCallback(
+    (metric: DetailMetric, filter?: string) => {
+      sessionStorage.setItem(DASH_SCROLL_KEY, String(window.scrollY));
+      const params = new URLSearchParams({ metric });
+      if (filter) params.set("filter", filter);
+      router.push(`/admin/analytics?${params.toString()}`);
+    },
+    [router],
+  );
 
   // Collapse all state
   const [allCollapsed, setAllCollapsed] = useState(false);
@@ -170,36 +185,6 @@ export default function AnalyticsDashboard({ showNames }: { showNames: ShowName[
     }
   }, []);
 
-  const fetchDetail = useCallback(async (metric: DetailMetric, filter?: string) => {
-    setDetailLoading(true);
-    try {
-      const params = new URLSearchParams({ metric });
-      if (filter) params.set("filter", filter);
-      const res = await fetch(`/api/analytics/detail?${params}`, { credentials: "include" });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setDetailRows(await res.json());
-    } catch {
-      setDetailRows([]);
-    } finally {
-      setDetailLoading(false);
-    }
-  }, []);
-
-  const openDetail = useCallback(
-    (metric: DetailMetric, filter?: string) => {
-      setActiveMetric(metric);
-      setActiveFilter(filter);
-      fetchDetail(metric, filter);
-    },
-    [fetchDetail],
-  );
-
-  const closeDetail = useCallback(() => {
-    setActiveMetric(null);
-    setActiveFilter(undefined);
-    setDetailRows([]);
-  }, []);
-
   // Auth + initial load
   useEffect(() => {
     if (authLoading) return;
@@ -216,12 +201,51 @@ export default function AnalyticsDashboard({ showNames }: { showNames: ShowName[
     return () => clearInterval(interval);
   }, [authLoading, user?.isAdmin, router, fetchSummary, fetchTimeseries]);
 
-  // Auto-refresh detail when open
+  // Restore dashboard scroll position when returning from a detail view.
+  // Panels (ListeningNow, RecentListening, TopShowsList) fetch their own
+  // data after mount, so the document height grows over time. Poll until
+  // the page is tall enough to actually reach the saved Y, then scroll.
   useEffect(() => {
-    if (!activeMetric) return;
-    const interval = setInterval(() => fetchDetail(activeMetric, activeFilter), REFRESH_INTERVAL);
-    return () => clearInterval(interval);
-  }, [activeMetric, activeFilter, fetchDetail]);
+    if (activeInstall || activeMetric) return;
+    if (!data) return;
+    const saved = sessionStorage.getItem(DASH_SCROLL_KEY);
+    if (saved == null) return;
+    sessionStorage.removeItem(DASH_SCROLL_KEY);
+    const targetY = parseInt(saved, 10);
+    if (!Number.isFinite(targetY)) return;
+
+    let attempts = 0;
+    let cancelled = false;
+    const tryScroll = () => {
+      if (cancelled) return;
+      const maxY =
+        document.documentElement.scrollHeight - window.innerHeight;
+      if (maxY >= targetY || attempts >= 30) {
+        window.scrollTo(0, Math.min(targetY, Math.max(0, maxY)));
+        return;
+      }
+      attempts++;
+      setTimeout(tryScroll, 100);
+    };
+    tryScroll();
+    return () => {
+      cancelled = true;
+    };
+  }, [data, activeInstall, activeMetric]);
+
+  // Route to detail views based on URL
+  if (activeInstall) {
+    return <InstallDetailView iid={activeInstall} backHref="/admin/analytics" />;
+  }
+  if (activeMetric) {
+    return (
+      <MetricDetailView
+        metric={activeMetric}
+        filter={activeFilter}
+        backHref="/admin/analytics"
+      />
+    );
+  }
 
   if (authLoading || (!user?.isAdmin && !error)) {
     return (
@@ -253,7 +277,7 @@ export default function AnalyticsDashboard({ showNames }: { showNames: ShowName[
   const forceOpen = collapseToggle === 0 ? undefined : !allCollapsed;
 
   return (
-    <div className="min-h-screen bg-deadly-bg p-4 sm:p-6 max-w-5xl mx-auto">
+    <div className="min-h-screen bg-deadly-bg p-4 sm:p-6 max-w-5xl mx-auto overflow-x-hidden">
       {/* Header */}
       <div className="flex items-center justify-between mb-6 sm:mb-8">
         <div className="flex items-center gap-4">
@@ -280,7 +304,12 @@ export default function AnalyticsDashboard({ showNames }: { showNames: ShowName[
 
       {/* Listening Now */}
       <CollapsibleSection title="Listening Now (last 45 min)" forceOpen={forceOpen}>
-        <ListeningNow showMap={showMap} />
+        <ListeningNow showMap={showMap} onOpenInstall={openInstall} />
+      </CollapsibleSection>
+
+      {/* Recent Listening (finished sessions, last 24h) */}
+      <CollapsibleSection title="Recent Listening (24h)" forceOpen={forceOpen}>
+        <RecentListening showMap={showMap} onOpenInstall={openInstall} />
       </CollapsibleSection>
 
       {/* Most-listened shows */}
@@ -417,23 +446,6 @@ export default function AnalyticsDashboard({ showNames }: { showNames: ShowName[
         />
       </CollapsibleSection>
 
-      {/* Detail Panel */}
-      {activeMetric && (
-        <DetailPanel
-          title={METRIC_LABELS[activeMetric]}
-          filter={activeFilter}
-          rows={detailRows}
-          loading={detailLoading}
-          onClose={closeDetail}
-          onClearFilter={activeFilter ? () => openDetail(activeMetric) : undefined}
-          onOpenInstall={openInstall}
-        />
-      )}
-
-      {/* Install Detail (stacks on top of DetailPanel when both open) */}
-      {activeInstall && (
-        <InstallDetailPanel iid={activeInstall} onClose={closeInstall} />
-      )}
     </div>
   );
 }

--- a/ui/src/app/admin/analytics/AnalyticsDashboard.tsx
+++ b/ui/src/app/admin/analytics/AnalyticsDashboard.tsx
@@ -17,6 +17,8 @@ import GrowthChart from "./components/GrowthChart";
 import FeatureAdoption from "./components/FeatureAdoption";
 import CollapsibleSection from "./components/CollapsibleSection";
 import ShowEngagement, { TopShowsByAction } from "./components/ShowEngagement";
+import { WatchedInstallsProvider } from "./components/WatchedInstallsContext";
+import WatchedInstallsPanel from "./components/WatchedInstallsPanel";
 
 interface FeatureAdoptionEntry {
   feature: string;
@@ -108,7 +110,15 @@ const METRIC_LABELS: Record<DetailMetric, string> = {
 const REFRESH_INTERVAL = 30_000;
 const DASH_SCROLL_KEY = "__analytics_dashboard_scroll";
 
-export default function AnalyticsDashboard({ showNames }: { showNames: ShowName[] }) {
+export default function AnalyticsDashboard(props: { showNames: ShowName[] }) {
+  return (
+    <WatchedInstallsProvider>
+      <AnalyticsDashboardInner {...props} />
+    </WatchedInstallsProvider>
+  );
+}
+
+function AnalyticsDashboardInner({ showNames }: { showNames: ShowName[] }) {
   const { user, isLoading: authLoading } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -147,6 +157,10 @@ export default function AnalyticsDashboard({ showNames }: { showNames: ShowName[
   // Collapse all state
   const [allCollapsed, setAllCollapsed] = useState(false);
   const [collapseToggle, setCollapseToggle] = useState(0);
+
+  // Page-wide "watched only" filter — when on, hide aggregate panels and
+  // restrict iid lists (Listening Now / Recent Listening) to flagged installs.
+  const [watchedOnly, setWatchedOnly] = useState(false);
 
   const showMap = useMemo(() => {
     const m = new Map<string, ShowName>();
@@ -235,7 +249,13 @@ export default function AnalyticsDashboard({ showNames }: { showNames: ShowName[
 
   // Route to detail views based on URL
   if (activeInstall) {
-    return <InstallDetailView iid={activeInstall} backHref="/admin/analytics" />;
+    return (
+      <InstallDetailView
+        iid={activeInstall}
+        backHref="/admin/analytics"
+        showMap={showMap}
+      />
+    );
   }
   if (activeMetric) {
     return (
@@ -284,7 +304,22 @@ export default function AnalyticsDashboard({ showNames }: { showNames: ShowName[
           <h1 className="text-xl sm:text-2xl font-bold text-deadly-red">Analytics</h1>
           <a href="/admin/beta" className="text-sm text-zinc-500 hover:text-zinc-300">Beta &rarr;</a>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 flex-wrap">
+          <button
+            onClick={() => setWatchedOnly((v) => !v)}
+            className={`text-xs px-2 py-1 rounded border transition-colors ${
+              watchedOnly
+                ? "border-amber-500/60 bg-amber-500/10 text-amber-300"
+                : "border-zinc-700 text-zinc-400 hover:bg-zinc-800"
+            }`}
+            title={
+              watchedOnly
+                ? "Showing only watched installs — click to show all"
+                : "Filter to watched installs"
+            }
+          >
+            ★ {watchedOnly ? "Watched only" : "Watched"}
+          </button>
           <button
             onClick={() => { setAllCollapsed((c) => !c); setCollapseToggle((t) => t + 1); }}
             className="text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
@@ -302,16 +337,30 @@ export default function AnalyticsDashboard({ showNames }: { showNames: ShowName[
         </div>
       </div>
 
+      {/* Watched installs */}
+      <CollapsibleSection title="Watched installs" forceOpen={forceOpen}>
+        <WatchedInstallsPanel onOpenInstall={openInstall} />
+      </CollapsibleSection>
+
       {/* Listening Now */}
       <CollapsibleSection title="Listening Now (last 45 min)" forceOpen={forceOpen}>
-        <ListeningNow showMap={showMap} onOpenInstall={openInstall} />
+        <ListeningNow
+          showMap={showMap}
+          onOpenInstall={openInstall}
+          watchedOnly={watchedOnly}
+        />
       </CollapsibleSection>
 
       {/* Recent Listening (finished sessions, last 24h) */}
       <CollapsibleSection title="Recent Listening (24h)" forceOpen={forceOpen}>
-        <RecentListening showMap={showMap} onOpenInstall={openInstall} />
+        <RecentListening
+          showMap={showMap}
+          onOpenInstall={openInstall}
+          watchedOnly={watchedOnly}
+        />
       </CollapsibleSection>
 
+      {watchedOnly ? null : <>
       {/* Most-listened shows */}
       <CollapsibleSection
         title="Most-listened shows"
@@ -445,6 +494,7 @@ export default function AnalyticsDashboard({ showNames }: { showNames: ShowName[
           onFeatureClick={(f) => openDetail("feature_adoption", f)}
         />
       </CollapsibleSection>
+      </>}
 
     </div>
   );

--- a/ui/src/app/admin/analytics/components/DetailPanel.tsx
+++ b/ui/src/app/admin/analytics/components/DetailPanel.tsx
@@ -90,18 +90,28 @@ export default function DetailPanel({
     return () => window.removeEventListener("keydown", handleKey);
   }, [onClose]);
 
+  // Lock body scroll while panel is open so the page behind doesn't scroll
+  // when the user tries to scroll the panel content (touch & wheel).
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
+
   return (
     <>
       {/* Backdrop */}
       <div className="fixed inset-0 bg-black/50 z-40" onClick={onClose} />
 
-      {/* Panel — bottom sheet on mobile, side panel on desktop */}
+      {/* Panel — bottom sheet on phones, side panel on tablet/desktop */}
       <div className="fixed z-50 bg-deadly-surface flex flex-col
         inset-x-0 bottom-0 h-[85vh] rounded-t-2xl
-        lg:inset-x-auto lg:right-0 lg:top-0 lg:bottom-0 lg:h-full lg:w-[560px] lg:rounded-none lg:rounded-l-2xl
+        sm:inset-x-auto sm:right-0 sm:top-0 sm:bottom-0 sm:h-full sm:w-[560px] sm:max-w-[100vw] sm:rounded-none sm:rounded-l-2xl
       ">
-        {/* Drag indicator (mobile) */}
-        <div className="lg:hidden flex justify-center py-2">
+        {/* Drag indicator (phones only) */}
+        <div className="sm:hidden flex justify-center py-2">
           <div className="w-10 h-1 bg-zinc-600 rounded-full" />
         </div>
 
@@ -137,7 +147,7 @@ export default function DetailPanel({
         </div>
 
         {/* Content */}
-        <div className="flex-1 overflow-auto">
+        <div className="flex-1 overflow-y-auto overflow-x-hidden overscroll-contain">
           {loading ? (
             <div className="flex items-center justify-center p-12">
               <p className="text-zinc-400">Loading...</p>
@@ -182,12 +192,12 @@ export default function DetailPanel({
                   return (
                     <div
                       key={i}
-                      className="bg-zinc-800/50 rounded-lg p-3 hover:bg-zinc-800 active:bg-zinc-700/50 cursor-pointer"
+                      className="bg-zinc-800/50 rounded-lg p-3 hover:bg-zinc-800 active:bg-zinc-700/50 cursor-pointer overflow-hidden"
                       onClick={() => onOpenInstall(row.iid)}
                     >
                       {detail && (
-                        <div className="flex items-baseline justify-between gap-3 mb-1.5">
-                          <span className="text-sm text-zinc-100 break-all">
+                        <div className="flex items-baseline justify-between gap-3 mb-1.5 min-w-0">
+                          <span className="text-sm text-zinc-100 break-words min-w-0 flex-1 [overflow-wrap:anywhere]">
                             {detailIsShow ? (
                               <ShowLink id={detail} />
                             ) : (
@@ -199,9 +209,9 @@ export default function DetailPanel({
                           </span>
                         </div>
                       )}
-                      <div className="flex items-center justify-between gap-2 text-xs">
+                      <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-2 text-xs">
                         <button
-                          className="text-deadly-blue hover:text-white transition-colors flex items-center gap-1 min-w-0"
+                          className="text-deadly-blue hover:text-white transition-colors flex items-center gap-1 min-w-0 self-start"
                           onClick={(e) => {
                             e.stopPropagation();
                             onOpenInstall(row.iid);
@@ -210,12 +220,12 @@ export default function DetailPanel({
                           <span>{emojiForId(row.iid)}</span>
                           <span className="font-mono">{row.iid?.slice(0, 8)}</span>
                         </button>
-                        <div className="flex items-center gap-2 text-zinc-400 flex-shrink-0">
+                        <div className="flex items-center flex-wrap gap-x-2 gap-y-0.5 text-zinc-400 sm:flex-shrink-0 sm:flex-nowrap">
                           <span>{row.platform}</span>
                           <span className="text-zinc-500">v{row.app_version}</span>
                           <span className="text-zinc-500">{relativeTime(row.last_seen)}</span>
                           {!detail && (
-                            <span className="text-zinc-300 tabular-nums ml-1">
+                            <span className="text-zinc-300 tabular-nums sm:ml-1">
                               {row.event_count}
                             </span>
                           )}

--- a/ui/src/app/admin/analytics/components/InstallDetailPanel.tsx
+++ b/ui/src/app/admin/analytics/components/InstallDetailPanel.tsx
@@ -54,6 +54,16 @@ export default function InstallDetailPanel({ iid, zIndexBase = 60, onClose }: Pr
     return () => window.removeEventListener("keydown", handleKey);
   }, [onClose]);
 
+  // Lock body scroll while panel is open so the page behind doesn't scroll
+  // when the user tries to scroll the panel content.
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
+
   const filteredEvents = useMemo(() => {
     if (!data) return [];
     if (!eventFilter) return data.events;
@@ -75,11 +85,11 @@ export default function InstallDetailPanel({ iid, zIndexBase = 60, onClose }: Pr
       <div
         className="fixed bg-deadly-surface flex flex-col
           inset-x-0 bottom-0 h-[85vh] rounded-t-2xl
-          lg:inset-x-auto lg:right-0 lg:top-0 lg:bottom-0 lg:h-full lg:w-[560px] lg:rounded-none lg:rounded-l-2xl
+          sm:inset-x-auto sm:right-0 sm:top-0 sm:bottom-0 sm:h-full sm:w-[560px] sm:max-w-[100vw] sm:rounded-none sm:rounded-l-2xl
         "
         style={{ zIndex: zIndexBase + 1 }}
       >
-        <div className="lg:hidden flex justify-center py-2">
+        <div className="sm:hidden flex justify-center py-2">
           <div className="w-10 h-1 bg-zinc-600 rounded-full" />
         </div>
 
@@ -100,7 +110,7 @@ export default function InstallDetailPanel({ iid, zIndexBase = 60, onClose }: Pr
         </div>
 
         {/* Content */}
-        <div className="flex-1 overflow-auto">
+        <div className="flex-1 overflow-y-auto overflow-x-hidden overscroll-contain">
           {loading && !data ? (
             <div className="flex items-center justify-center p-12">
               <p className="text-zinc-400">Loading events...</p>

--- a/ui/src/app/admin/analytics/components/InstallDetailView.tsx
+++ b/ui/src/app/admin/analytics/components/InstallDetailView.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { emojiForId } from "./emojiId";
 import InstallEventTimeline, { InstallEvent } from "./InstallEventTimeline";
+import InstallOverview from "./InstallOverview";
+import WatchToggle from "./WatchToggle";
+import { useWatchedInstalls } from "./WatchedInstallsContext";
 
 interface InstallData {
   iid: string;
@@ -15,18 +18,34 @@ interface InstallData {
   events: InstallEvent[];
 }
 
+interface ShowName {
+  id: string;
+  d: string;
+  v: string;
+  c: string;
+  s: string;
+  tc: number;
+  img: string | null;
+}
+
 interface Props {
   iid: string;
   backHref: string;
+  showMap?: Map<string, ShowName>;
 }
 
-export default function InstallDetailView({ iid, backHref }: Props) {
+type Tab = "overview" | "events";
+
+export default function InstallDetailView({ iid, backHref, showMap }: Props) {
+  const router = useRouter();
+  const { isWatched, nameFor } = useWatchedInstalls();
+  const watched = isWatched(iid);
+  const friendlyName = nameFor(iid);
   const [data, setData] = useState<InstallData | null>(null);
   const [loading, setLoading] = useState(false);
+  const [tab, setTab] = useState<Tab>("overview");
   const [eventFilter, setEventFilter] = useState<string | null>(null);
 
-  // Always start the detail page at the top — same pathname as the dashboard
-  // means the browser doesn't reset scroll for us.
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [iid]);
@@ -36,7 +55,10 @@ export default function InstallDetailView({ iid, backHref }: Props) {
     setLoading(true);
     setData(null);
     setEventFilter(null);
-    fetch(`/api/analytics/install/${encodeURIComponent(iid)}`, { credentials: "include" })
+    setTab("overview");
+    fetch(`/api/analytics/install/${encodeURIComponent(iid)}`, {
+      credentials: "include",
+    })
       .then((r) => (r.ok ? r.json() : null))
       .then((d: InstallData | null) => {
         if (!cancelled) setData(d);
@@ -67,35 +89,61 @@ export default function InstallDetailView({ iid, backHref }: Props) {
     <div className="min-h-screen bg-deadly-bg">
       <div className="max-w-3xl mx-auto p-4 sm:p-6">
         {/* Header */}
-        <div className="mb-4 flex items-center gap-3">
-          <Link
-            href={backHref}
+        <div className="mb-3 flex items-center gap-3">
+          <button
+            onClick={() => router.push(backHref)}
             className="text-zinc-400 hover:text-white text-sm flex items-center gap-1"
           >
             <span>&larr;</span> Back
-          </Link>
+          </button>
         </div>
-        <h1 className="text-lg font-semibold text-white flex items-center gap-2 mb-4 flex-wrap">
-          <span className="text-xl">{emojiForId(iid)}</span>
-          <span className="font-mono text-sm text-zinc-300 break-all">{iid}</span>
-        </h1>
+        <div className="flex items-start justify-between gap-3 mb-4 flex-wrap">
+          <h1 className="text-lg font-semibold text-white flex items-center gap-2 flex-wrap min-w-0">
+            {watched && <span className="text-amber-400">★</span>}
+            <span className="text-xl">{emojiForId(iid)}</span>
+            {friendlyName ? (
+              <>
+                <span className="text-zinc-100">{friendlyName}</span>
+                <span className="font-mono text-xs text-zinc-500 [overflow-wrap:anywhere]">
+                  {iid}
+                </span>
+              </>
+            ) : (
+              <span className="font-mono text-sm text-zinc-300 [overflow-wrap:anywhere]">
+                {iid}
+              </span>
+            )}
+          </h1>
+          <WatchToggle iid={iid} />
+        </div>
+
+        {/* Tabs */}
+        <div className="flex items-center gap-1 mb-4 border-b border-zinc-800">
+          <TabButton active={tab === "overview"} onClick={() => setTab("overview")}>
+            Overview
+          </TabButton>
+          <TabButton active={tab === "events"} onClick={() => setTab("events")}>
+            Events
+            {data && (
+              <span className="ml-1 text-zinc-600 tabular-nums">
+                {data.total_events}
+              </span>
+            )}
+          </TabButton>
+        </div>
 
         {loading && !data ? (
-          <p className="text-zinc-400 py-8 text-center">Loading events…</p>
-        ) : data ? (
+          <p className="text-zinc-400 py-8 text-center">Loading…</p>
+        ) : !data ? (
+          <p className="text-zinc-500 py-8 text-center">No data</p>
+        ) : tab === "overview" ? (
+          <InstallOverview data={data} showMap={showMap} />
+        ) : (
           <>
-            {/* Metadata */}
-            <div className="grid grid-cols-2 gap-3 mb-4">
-              <Meta label="Platform" value={data.platform} />
-              <Meta label="Version" value={data.app_version} />
-              <Meta label="First Seen" value={data.first_seen} />
-              <Meta label="Last Seen" value={data.last_seen} />
-            </div>
-
-            {/* Event filter */}
             <div className="flex items-center justify-between mb-3 gap-2">
               <span className="text-xs text-zinc-500">
-                {filteredEvents.length} event{filteredEvents.length !== 1 ? "s" : ""}
+                {filteredEvents.length} event
+                {filteredEvents.length !== 1 ? "s" : ""}
               </span>
               <select
                 value={eventFilter ?? ""}
@@ -110,22 +158,33 @@ export default function InstallDetailView({ iid, backHref }: Props) {
                 ))}
               </select>
             </div>
-
             <InstallEventTimeline events={filteredEvents} />
           </>
-        ) : (
-          <p className="text-zinc-500 py-8 text-center">No data</p>
         )}
       </div>
     </div>
   );
 }
 
-function Meta({ label, value }: { label: string; value: string }) {
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
   return (
-    <div className="min-w-0">
-      <p className="text-xs text-zinc-500 uppercase tracking-wider">{label}</p>
-      <p className="text-sm text-white break-words">{value}</p>
-    </div>
+    <button
+      onClick={onClick}
+      className={`px-3 py-1.5 text-sm border-b-2 -mb-px transition-colors ${
+        active
+          ? "border-deadly-blue text-white"
+          : "border-transparent text-zinc-400 hover:text-zinc-200"
+      }`}
+    >
+      {children}
+    </button>
   );
 }

--- a/ui/src/app/admin/analytics/components/InstallDetailView.tsx
+++ b/ui/src/app/admin/analytics/components/InstallDetailView.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { emojiForId } from "./emojiId";
+import InstallEventTimeline, { InstallEvent } from "./InstallEventTimeline";
+
+interface InstallData {
+  iid: string;
+  platform: string;
+  app_version: string;
+  first_seen: string;
+  last_seen: string;
+  total_events: number;
+  events: InstallEvent[];
+}
+
+interface Props {
+  iid: string;
+  backHref: string;
+}
+
+export default function InstallDetailView({ iid, backHref }: Props) {
+  const [data, setData] = useState<InstallData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [eventFilter, setEventFilter] = useState<string | null>(null);
+
+  // Always start the detail page at the top — same pathname as the dashboard
+  // means the browser doesn't reset scroll for us.
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [iid]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setData(null);
+    setEventFilter(null);
+    fetch(`/api/analytics/install/${encodeURIComponent(iid)}`, { credentials: "include" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d: InstallData | null) => {
+        if (!cancelled) setData(d);
+      })
+      .catch(() => {
+        /* ignore */
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [iid]);
+
+  const filteredEvents = useMemo(() => {
+    if (!data) return [];
+    if (!eventFilter) return data.events;
+    return data.events.filter((e) => e.event === eventFilter);
+  }, [data, eventFilter]);
+
+  const eventTypes = useMemo(() => {
+    if (!data) return [];
+    return Array.from(new Set(data.events.map((e) => e.event))).sort();
+  }, [data]);
+
+  return (
+    <div className="min-h-screen bg-deadly-bg">
+      <div className="max-w-3xl mx-auto p-4 sm:p-6">
+        {/* Header */}
+        <div className="mb-4 flex items-center gap-3">
+          <Link
+            href={backHref}
+            className="text-zinc-400 hover:text-white text-sm flex items-center gap-1"
+          >
+            <span>&larr;</span> Back
+          </Link>
+        </div>
+        <h1 className="text-lg font-semibold text-white flex items-center gap-2 mb-4 flex-wrap">
+          <span className="text-xl">{emojiForId(iid)}</span>
+          <span className="font-mono text-sm text-zinc-300 break-all">{iid}</span>
+        </h1>
+
+        {loading && !data ? (
+          <p className="text-zinc-400 py-8 text-center">Loading events…</p>
+        ) : data ? (
+          <>
+            {/* Metadata */}
+            <div className="grid grid-cols-2 gap-3 mb-4">
+              <Meta label="Platform" value={data.platform} />
+              <Meta label="Version" value={data.app_version} />
+              <Meta label="First Seen" value={data.first_seen} />
+              <Meta label="Last Seen" value={data.last_seen} />
+            </div>
+
+            {/* Event filter */}
+            <div className="flex items-center justify-between mb-3 gap-2">
+              <span className="text-xs text-zinc-500">
+                {filteredEvents.length} event{filteredEvents.length !== 1 ? "s" : ""}
+              </span>
+              <select
+                value={eventFilter ?? ""}
+                onChange={(e) => setEventFilter(e.target.value || null)}
+                className="bg-zinc-800 text-xs text-zinc-300 rounded px-2 py-1 border border-zinc-700"
+              >
+                <option value="">All events</option>
+                {eventTypes.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <InstallEventTimeline events={filteredEvents} />
+          </>
+        ) : (
+          <p className="text-zinc-500 py-8 text-center">No data</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Meta({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0">
+      <p className="text-xs text-zinc-500 uppercase tracking-wider">{label}</p>
+      <p className="text-sm text-white break-words">{value}</p>
+    </div>
+  );
+}

--- a/ui/src/app/admin/analytics/components/InstallEventTimeline.tsx
+++ b/ui/src/app/admin/analytics/components/InstallEventTimeline.tsx
@@ -369,10 +369,10 @@ function PlaybackPairCard({
     (start?.props && start.props !== "{}") || (end?.props && end.props !== "{}");
 
   return (
-    <div className="relative pl-4">
+    <div className="relative pl-4 min-w-0">
       <div className={`absolute left-0 top-0 bottom-0 w-1 rounded-full ${style.edge}`} />
       <div
-        className={`bg-zinc-800/50 rounded-lg p-2.5 ${
+        className={`bg-zinc-800/50 rounded-lg p-2.5 overflow-hidden ${
           hasExpandable ? "cursor-pointer hover:bg-zinc-800" : ""
         }`}
         onClick={hasExpandable ? () => setExpanded((v) => !v) : undefined}
@@ -385,7 +385,7 @@ function PlaybackPairCard({
             {timeOfDay(tsForTime)}
           </span>
         </div>
-        <div className="text-sm text-zinc-200 break-words flex flex-wrap items-baseline gap-x-1">
+        <div className="text-sm text-zinc-200 [overflow-wrap:anywhere] flex flex-wrap items-baseline gap-x-1 min-w-0">
           {isShowId(showId) ? (
             <ShowLink id={showId} />
           ) : (
@@ -437,11 +437,11 @@ function EventCard({ evt }: { evt: InstallEvent }) {
   const hasProps = !!evt.props && evt.props !== "{}";
 
   return (
-    <div className="relative pl-4">
+    <div className="relative pl-4 min-w-0">
       {/* Left edge color bar */}
       <div className={`absolute left-0 top-0 bottom-0 w-1 rounded-full ${style.edge}`} />
       <div
-        className={`bg-zinc-800/50 rounded-lg p-2.5 ${hasProps ? "cursor-pointer hover:bg-zinc-800" : ""}`}
+        className={`bg-zinc-800/50 rounded-lg p-2.5 overflow-hidden ${hasProps ? "cursor-pointer hover:bg-zinc-800" : ""}`}
         onClick={hasProps ? () => setExpanded((v) => !v) : undefined}
       >
         <div className="flex items-baseline justify-between gap-2 mb-0.5">
@@ -452,7 +452,7 @@ function EventCard({ evt }: { evt: InstallEvent }) {
             {timeOfDay(evt.ts)}
           </span>
         </div>
-        <div className="text-sm text-zinc-200 break-words">{eventSummary(evt)}</div>
+        <div className="text-sm text-zinc-200 [overflow-wrap:anywhere]">{eventSummary(evt)}</div>
         {hasProps && expanded && evt.props && (
           <p className="text-xs text-zinc-600 font-mono mt-2 break-all border-t border-zinc-700/50 pt-2">
             <PropsRaw propsStr={evt.props} />
@@ -475,15 +475,15 @@ function SessionGroup({ session, defaultOpen }: { session: Session; defaultOpen:
     <div className="bg-zinc-900/40 rounded-lg overflow-hidden border border-zinc-800">
       <button
         onClick={() => setOpen((v) => !v)}
-        className="w-full px-3 py-2 flex items-center justify-between gap-2 hover:bg-zinc-800/50 transition-colors"
+        className="w-full px-3 py-2 flex items-start sm:items-center justify-between gap-2 hover:bg-zinc-800/50 transition-colors text-left"
       >
-        <div className="flex items-center gap-2 min-w-0">
-          <span className="text-zinc-500 text-xs">{open ? "▾" : "▸"}</span>
-          <span className="text-sm text-zinc-200">
+        <div className="flex items-center gap-2 min-w-0 flex-wrap">
+          <span className="text-zinc-500 text-xs flex-shrink-0">{open ? "▾" : "▸"}</span>
+          <span className="text-sm text-zinc-200 whitespace-nowrap">
             {dateStr} {timeOfDay(session.startTs)}
           </span>
-          <span className="text-xs text-zinc-500">· {formatMs(duration)}</span>
-          <span className="text-xs text-zinc-500">· {session.events.length} events</span>
+          <span className="text-xs text-zinc-500 whitespace-nowrap">· {formatMs(duration)}</span>
+          <span className="text-xs text-zinc-500 whitespace-nowrap">· {session.events.length} events</span>
         </div>
         <span className="text-xs text-zinc-500 flex-shrink-0">
           {relativeTime(session.startTs)}

--- a/ui/src/app/admin/analytics/components/InstallEventTimeline.tsx
+++ b/ui/src/app/admin/analytics/components/InstallEventTimeline.tsx
@@ -303,10 +303,15 @@ function groupBySession(events: InstallEvent[]): Session[] {
   const sessions: Session[] = [];
   for (const [sid, list] of bySid) {
     const sorted = [...list].sort((a, b) => a.ts - b.ts);
+    // Build the timeline in asc order so playback_start → playback_end pairing
+    // works (it scans forward), then flip for display so the most recent event
+    // in the session is at the top — matching the session ordering on the page.
+    const items = buildTimeline(sorted);
+    items.reverse();
     sessions.push({
       sid,
       events: sorted,
-      items: buildTimeline(sorted),
+      items,
       startTs: sorted[0]!.ts,
       endTs: sorted[sorted.length - 1]!.ts,
       platform: sorted[0]!.platform,

--- a/ui/src/app/admin/analytics/components/InstallOverview.tsx
+++ b/ui/src/app/admin/analytics/components/InstallOverview.tsx
@@ -1,0 +1,569 @@
+"use client";
+
+import { useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { InstallEvent } from "./InstallEventTimeline";
+import { ListeningRow, type TrackPlay, type TrackOutcome } from "./listeningRow";
+import FeatureAdoption from "./FeatureAdoption";
+
+interface ShowName {
+  id: string;
+  d: string;
+  v: string;
+  c: string;
+  s: string;
+  tc: number;
+  img: string | null;
+}
+
+interface InstallData {
+  iid: string;
+  platform: string;
+  app_version: string;
+  first_seen: string;
+  last_seen: string;
+  total_events: number;
+  events: InstallEvent[];
+}
+
+interface FeatureAdoptionEntry {
+  feature: string;
+  uses: number;
+}
+
+interface FeatureAdoptionBuckets {
+  action: FeatureAdoptionEntry[];
+  preference: FeatureAdoptionEntry[];
+  navigation: FeatureAdoptionEntry[];
+  uncategorized: FeatureAdoptionEntry[];
+}
+
+const SHOW_ID_RE = /^\d{4}-\d{2}-\d{2}(-[\w-]+)?$/;
+function isShowId(value: unknown): value is string {
+  return typeof value === "string" && SHOW_ID_RE.test(value);
+}
+
+function parseProps(propsStr: string | null): Record<string, unknown> {
+  if (!propsStr) return {};
+  try {
+    return JSON.parse(propsStr) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+  auto_advance: "auto-advance",
+  restore: "restore",
+  browse: "show detail",
+  library_favorites: "favorites",
+  deeplink: "deep link",
+  search_result: "search",
+};
+
+function relativeAge(ts: number): string {
+  const ms = Date.now() - ts;
+  if (ms < 60_000) return `${Math.floor(ms / 1000)}s ago`;
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`;
+  if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h ago`;
+  return `${Math.floor(ms / 86_400_000)}d ago`;
+}
+
+function reasonToOutcome(reason: string | null): TrackOutcome {
+  switch (reason) {
+    case "completed":
+      return "complete";
+    case "skipped_next":
+    case "skipped_prev":
+      return "skipped";
+    case "network_error":
+      return "error";
+    default:
+      return "partial";
+  }
+}
+
+function formatDate(d: string): string {
+  const date = new Date(d + "T00:00:00");
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function Section({
+  title,
+  children,
+  count,
+}: {
+  title: string;
+  children: React.ReactNode;
+  count?: number;
+}) {
+  return (
+    <section className="mb-6">
+      <div className="flex items-baseline justify-between mb-2">
+        <h2 className="text-xs uppercase tracking-wider text-zinc-500">
+          {title}
+        </h2>
+        {count != null && (
+          <span className="text-xs text-zinc-600">{count}</span>
+        )}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+interface ShowAgg {
+  show_id: string;
+  latestTs: number;
+  earliestTs: number;
+  latestTrackIndex: number | null;
+  latestSource: string | null;
+  trackPlays: number; // total playback_start events for this show
+  completionSum: number; // sum of clamped(listened_ms / duration_ms)
+  completionN: number; // n of valid playback_end with listened+duration >= 60s
+  // Per-track outcome map merged across all sids for this user/show.
+  trackOutcomes: Map<number, { ts: number; outcome: TrackOutcome }>;
+}
+
+export default function InstallOverview({
+  data,
+  showMap,
+}: {
+  data: InstallData;
+  showMap?: Map<string, ShowName>;
+}) {
+  const router = useRouter();
+
+  const agg = useMemo(() => {
+    const sessions = new Set<string>();
+    const showAggs = new Map<string, ShowAgg>();
+    const sourceCounts = new Map<string, number>();
+    const searches: Array<{
+      ts: number;
+      query: string | null;
+      result_count: number | null;
+      selected_index: number | null;
+    }> = [];
+    const featureMap = new Map<
+      string,
+      { uses: number; category: string | null }
+    >();
+    const errors: Array<{
+      ts: number;
+      source: string | null;
+      message: string | null;
+    }> = [];
+
+    // Helper to get-or-create a show aggregate.
+    const showAgg = (show_id: string): ShowAgg => {
+      let a = showAggs.get(show_id);
+      if (!a) {
+        a = {
+          show_id,
+          latestTs: 0,
+          earliestTs: Infinity,
+          latestTrackIndex: null,
+          latestSource: null,
+          trackPlays: 0,
+          completionSum: 0,
+          completionN: 0,
+          trackOutcomes: new Map(),
+        };
+        showAggs.set(show_id, a);
+      }
+      return a;
+    };
+
+    for (const e of data.events) {
+      sessions.add(e.sid);
+      const p = parseProps(e.props);
+
+      switch (e.event) {
+        case "playback_start": {
+          const show_id = isShowId(p.show_id) ? p.show_id : null;
+          if (!show_id) break;
+          const a = showAgg(show_id);
+          a.trackPlays += 1;
+          if (e.ts > a.latestTs) {
+            a.latestTs = e.ts;
+            a.latestTrackIndex =
+              typeof p.track_index === "number" ? p.track_index : null;
+            a.latestSource =
+              typeof p.source === "string" ? p.source : null;
+          }
+          if (e.ts < a.earliestTs) a.earliestTs = e.ts;
+          const track_index =
+            typeof p.track_index === "number" ? p.track_index : 0;
+          // Only set partial if no event recorded yet for this track.
+          if (!a.trackOutcomes.has(track_index)) {
+            a.trackOutcomes.set(track_index, { ts: e.ts, outcome: "partial" });
+          }
+          const src = typeof p.source === "string" ? p.source : "unknown";
+          sourceCounts.set(src, (sourceCounts.get(src) ?? 0) + 1);
+          break;
+        }
+        case "playback_end": {
+          const show_id = isShowId(p.show_id) ? p.show_id : null;
+          if (!show_id) break;
+          const a = showAgg(show_id);
+          if (e.ts > a.latestTs) {
+            a.latestTs = e.ts;
+          }
+          const track_index =
+            typeof p.track_index === "number" ? p.track_index : 0;
+          const reason = typeof p.reason === "string" ? p.reason : null;
+          const outcome = reasonToOutcome(reason);
+          const prior = a.trackOutcomes.get(track_index);
+          if (!prior || e.ts >= prior.ts) {
+            a.trackOutcomes.set(track_index, { ts: e.ts, outcome });
+          }
+          // Completion accumulation: require both ≥60s, clamp listened ≤ duration.
+          const listened =
+            typeof p.listened_ms === "number" ? p.listened_ms : null;
+          const duration =
+            typeof p.duration_ms === "number" ? p.duration_ms : null;
+          if (
+            listened != null &&
+            duration != null &&
+            listened >= 60_000 &&
+            duration >= 60_000
+          ) {
+            const clamped = Math.min(listened, duration);
+            a.completionSum += clamped / duration;
+            a.completionN += 1;
+          }
+          break;
+        }
+        case "search":
+          searches.push({
+            ts: e.ts,
+            query: typeof p.query === "string" ? p.query : null,
+            result_count:
+              typeof p.result_count === "number" ? p.result_count : null,
+            selected_index:
+              typeof p.selected_index === "number" ? p.selected_index : null,
+          });
+          break;
+        case "feature_use": {
+          const feature = typeof p.feature === "string" ? p.feature : null;
+          if (!feature) break;
+          const category =
+            typeof p.category === "string" ? p.category : null;
+          const prior = featureMap.get(feature);
+          featureMap.set(feature, {
+            uses: (prior?.uses ?? 0) + 1,
+            category: prior?.category ?? category,
+          });
+          break;
+        }
+        case "error":
+          errors.push({
+            ts: e.ts,
+            source: typeof p.source === "string" ? p.source : null,
+            message: typeof p.message === "string" ? p.message : null,
+          });
+          break;
+      }
+    }
+
+    // Recent plays (deduped by show) — top 10 by latestTs DESC.
+    const recentPlays = Array.from(showAggs.values())
+      .sort((a, b) => b.latestTs - a.latestTs)
+      .slice(0, 10);
+
+    // Top shows — sort by trackPlays DESC, then latestTs DESC.
+    const topShows = Array.from(showAggs.values())
+      .sort((a, b) => {
+        if (b.trackPlays !== a.trackPlays) return b.trackPlays - a.trackPlays;
+        return b.latestTs - a.latestTs;
+      })
+      .slice(0, 10);
+
+    const totalSourcePlays = Array.from(sourceCounts.values()).reduce(
+      (a, b) => a + b,
+      0,
+    );
+    const playsBySource = Array.from(sourceCounts.entries()).sort(
+      (a, b) => b[1] - a[1],
+    );
+
+    // Feature buckets matching the server's /api/analytics/summary shape.
+    const featureBuckets: FeatureAdoptionBuckets = {
+      action: [],
+      preference: [],
+      navigation: [],
+      uncategorized: [],
+    };
+    const sortedFeatures = Array.from(featureMap.entries()).sort(
+      (a, b) => b[1].uses - a[1].uses,
+    );
+    for (const [feature, { uses, category }] of sortedFeatures) {
+      const bucket =
+        category === "action" ||
+        category === "preference" ||
+        category === "navigation"
+          ? category
+          : "uncategorized";
+      featureBuckets[bucket].push({ feature, uses });
+    }
+
+    return {
+      sessionCount: sessions.size,
+      recentPlays,
+      topShows,
+      playsBySource,
+      totalSourcePlays,
+      searches: searches.slice(0, 10),
+      featureBuckets,
+      errors: errors.slice(0, 5),
+    };
+  }, [data.events]);
+
+  return (
+    <div>
+      {/* Meta grid */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-5">
+        <Meta label="Joined" value={data.first_seen} />
+        <Meta label="Last seen" value={data.last_seen} />
+        <Meta label="Platform" value={data.platform} />
+        <Meta label="Version" value={data.app_version} />
+        <Meta label="Sessions" value={String(agg.sessionCount)} />
+        <Meta label="Events" value={String(data.total_events)} />
+      </div>
+
+      {/* Recent plays — uses the same ListeningRow as the main dashboard */}
+      <Section title="Recent plays" count={agg.recentPlays.length}>
+        {agg.recentPlays.length === 0 ? (
+          <p className="text-xs text-zinc-600 italic">No plays recorded.</p>
+        ) : (
+          <div className="space-y-1">
+            {agg.recentPlays.map((p) => {
+              const tracks: TrackPlay[] = Array.from(p.trackOutcomes.entries())
+                .map(([index, v]) => ({ index, outcome: v.outcome }))
+                .sort((a, b) => a.index - b.index);
+              return (
+                <ListeningRow
+                  key={p.show_id}
+                  rowKey={p.show_id}
+                  iid={data.iid}
+                  platform={data.platform}
+                  app_version={data.app_version}
+                  ts={p.latestTs}
+                  show_id={p.show_id}
+                  track_index={p.latestTrackIndex}
+                  source={p.latestSource}
+                  tracks={tracks}
+                  totalTracks={showMap?.get(p.show_id)?.tc}
+                />
+              );
+            })}
+          </div>
+        )}
+      </Section>
+
+      {/* Top shows — matches TopShowsList card style */}
+      <Section title="Top shows played" count={agg.topShows.length}>
+        {agg.topShows.length === 0 ? (
+          <p className="text-xs text-zinc-600 italic">No shows played.</p>
+        ) : (
+          <div className="space-y-1">
+            {agg.topShows.map((s, i) => {
+              const info = showMap?.get(s.show_id);
+              const completion =
+                s.completionN > 0 ? s.completionSum / s.completionN : null;
+              return (
+                <div
+                  key={s.show_id}
+                  className="bg-deadly-surface rounded-lg p-2 flex items-center gap-3"
+                >
+                  <span className="text-zinc-500 text-sm font-mono w-5 text-right shrink-0 tabular-nums">
+                    {i + 1}
+                  </span>
+                  {info?.img ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={info.img}
+                      alt=""
+                      loading="lazy"
+                      className="w-10 h-10 object-cover rounded shrink-0 bg-zinc-800"
+                    />
+                  ) : (
+                    <div className="w-10 h-10 rounded bg-zinc-800 shrink-0" />
+                  )}
+                  <a
+                    href={`/shows/${s.show_id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="min-w-0 flex-1 hover:text-deadly-blue transition-colors"
+                  >
+                    {info ? (
+                      <>
+                        <p className="text-sm text-zinc-200">
+                          {formatDate(info.d)}
+                        </p>
+                        <p className="text-xs text-zinc-400 truncate">
+                          {info.v} &mdash; {info.c}, {info.s}
+                        </p>
+                      </>
+                    ) : (
+                      <p className="text-sm text-zinc-300 font-mono break-all">
+                        {s.show_id}
+                      </p>
+                    )}
+                  </a>
+                  <div className="flex flex-col items-end shrink-0 tabular-nums">
+                    <span className="text-sm text-zinc-300">
+                      {s.trackPlays} track{s.trackPlays !== 1 ? "s" : ""}
+                    </span>
+                    <span
+                      className="text-xs text-zinc-500"
+                      title="Average of MIN(listened, duration)/duration across this install's playback_end events"
+                    >
+                      {completion != null ? (
+                        `${Math.round(completion * 100)}% completed`
+                      ) : (
+                        <span className="text-zinc-600">— completion</span>
+                      )}
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </Section>
+
+      {/* Plays by source */}
+      <Section title="Plays by source" count={agg.playsBySource.length}>
+        {agg.playsBySource.length === 0 ? (
+          <p className="text-xs text-zinc-600 italic">No plays.</p>
+        ) : (
+          <div className="space-y-2">
+            {agg.playsBySource.map(([source, count]) => {
+              const pct = agg.totalSourcePlays
+                ? count / agg.totalSourcePlays
+                : 0;
+              return (
+                <div key={source}>
+                  <div className="flex items-baseline justify-between text-xs mb-0.5">
+                    <span className="text-zinc-300">
+                      {SOURCE_LABELS[source] ?? source}
+                    </span>
+                    <span className="text-zinc-500 tabular-nums">
+                      {count} ({Math.round(pct * 100)}%)
+                    </span>
+                  </div>
+                  <div className="h-1.5 rounded-full bg-zinc-800 overflow-hidden">
+                    <div
+                      className="h-full bg-deadly-blue"
+                      style={{ width: `${Math.max(2, pct * 100)}%` }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </Section>
+
+      {/* Searches — link the query to the search-result feature filter when possible */}
+      <Section title="Recent searches" count={agg.searches.length}>
+        {agg.searches.length === 0 ? (
+          <p className="text-xs text-zinc-600 italic">No searches.</p>
+        ) : (
+          <div className="space-y-1">
+            {agg.searches.map((s, i) => (
+              <div
+                key={i}
+                className="bg-zinc-800/40 rounded px-2.5 py-1.5 text-sm flex items-center gap-2 flex-wrap"
+              >
+                <span className="text-zinc-200 [overflow-wrap:anywhere]">
+                  {s.query ? (
+                    `“${s.query}”`
+                  ) : (
+                    <em className="text-zinc-500">empty</em>
+                  )}
+                </span>
+                {s.result_count != null && (
+                  <span className="text-xs text-zinc-500">
+                    · {s.result_count} result{s.result_count === 1 ? "" : "s"}
+                  </span>
+                )}
+                {s.selected_index != null && (
+                  <span className="text-xs text-zinc-500">
+                    · picked #{s.selected_index + 1}
+                  </span>
+                )}
+                <span className="ml-auto text-xs text-zinc-600 tabular-nums">
+                  {relativeAge(s.ts)}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </Section>
+
+      {/* Features used — same component as main dashboard */}
+      <Section title="Features used">
+        {agg.featureBuckets.action.length +
+          agg.featureBuckets.preference.length +
+          agg.featureBuckets.navigation.length +
+          agg.featureBuckets.uncategorized.length ===
+        0 ? (
+          <p className="text-xs text-zinc-600 italic">
+            No feature usage recorded.
+          </p>
+        ) : (
+          <FeatureAdoption
+            data={agg.featureBuckets}
+            onFeatureClick={(f) =>
+              router.push(
+                `/admin/analytics?metric=feature_adoption&filter=${encodeURIComponent(f)}`,
+              )
+            }
+          />
+        )}
+      </Section>
+
+      {/* Errors (only if any) */}
+      {agg.errors.length > 0 && (
+        <Section title="Recent errors" count={agg.errors.length}>
+          <div className="space-y-1">
+            {agg.errors.map((e, i) => (
+              <div
+                key={i}
+                className="bg-red-950/30 border-l-2 border-red-500 rounded px-2.5 py-1.5 text-xs"
+              >
+                {e.source && (
+                  <span className="text-red-300">{e.source}</span>
+                )}
+                {e.message && (
+                  <span className="text-zinc-400 [overflow-wrap:anywhere]">
+                    {e.source ? " · " : ""}
+                    {e.message}
+                  </span>
+                )}
+                <span className="text-zinc-500 ml-2">
+                  {relativeAge(e.ts)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+    </div>
+  );
+}
+
+function Meta({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0">
+      <p className="text-xs text-zinc-500 uppercase tracking-wider">{label}</p>
+      <p className="text-sm text-white break-words">{value}</p>
+    </div>
+  );
+}

--- a/ui/src/app/admin/analytics/components/ListeningNow.tsx
+++ b/ui/src/app/admin/analytics/components/ListeningNow.tsx
@@ -1,14 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { emojiForId } from "./emojiId";
-
-type TrackOutcome = "complete" | "skipped" | "error" | "partial";
-
-interface TrackPlay {
-  index: number;
-  outcome: TrackOutcome;
-}
+import { ListeningRow, type TrackPlay } from "./listeningRow";
 
 interface LiveListener {
   iid: string;
@@ -31,107 +24,14 @@ interface ShowName {
   tc: number;
 }
 
-const OUTCOME_COLOR: Record<TrackOutcome, string> = {
-  complete: "bg-emerald-500",
-  skipped: "bg-amber-400",
-  error: "bg-red-500",
-  partial: "bg-sky-400",
-};
-
-const OUTCOME_LABEL: Record<TrackOutcome, string> = {
-  complete: "complete",
-  skipped: "skipped",
-  error: "error",
-  partial: "partial",
-};
-
-const SEVERITY: Record<TrackOutcome, number> = {
-  partial: 0,
-  complete: 1,
-  skipped: 2,
-  error: 3,
-};
-
-/**
- * Same bar shape as the Show Listening panel: each slot is one of the
- * show's actual tracks (when total track count is known) so an unplayed
- * track 8 of 12 reads as four trailing dim slots, not a missing tail.
- * Falls back to length-of-events when track count is unavailable.
- */
-function TrackOutcomeBar({
-  tracks,
-  totalTracks,
-}: {
-  tracks: TrackPlay[];
-  totalTracks: number | undefined;
-}) {
-  if (tracks.length === 0 && !totalTracks) return null;
-  const outcomeByPos = new Map<number, TrackOutcome>();
-  for (const t of tracks) {
-    const pos = t.index > 0 ? t.index - 1 : t.index;
-    const prior = outcomeByPos.get(pos);
-    if (!prior || SEVERITY[t.outcome] > SEVERITY[prior]) {
-      outcomeByPos.set(pos, t.outcome);
-    }
-  }
-  const heard = outcomeByPos.size;
-  const maxPos = heard > 0 ? Math.max(...outcomeByPos.keys()) + 1 : 0;
-  const total = totalTracks && totalTracks > 0 ? totalTracks : maxPos;
-  if (total === 0) return null;
-
-  return (
-    <div className="flex items-center gap-2">
-      <div className="flex gap-px" title={`${heard} of ${total} tracks`}>
-        {Array.from({ length: total }, (_, i) => {
-          const outcome = outcomeByPos.get(i);
-          const cls = outcome ? OUTCOME_COLOR[outcome] : "bg-zinc-700";
-          const label = outcome
-            ? `track ${i + 1}: ${OUTCOME_LABEL[outcome]}`
-            : `track ${i + 1}: not played`;
-          return (
-            <div
-              key={i}
-              title={label}
-              className={`h-3 rounded-sm ${cls}`}
-              style={{ width: `${Math.max(Math.min(120 / total, 8), 2)}px` }}
-            />
-          );
-        })}
-      </div>
-      <span className="text-xs text-zinc-500 whitespace-nowrap">
-        {heard}/{total}
-      </span>
-    </div>
-  );
-}
-
 const POLL_INTERVAL_MS = 15_000;
-
-const SOURCE_LABELS: Record<string, string> = {
-  auto_advance: "auto-advance",
-  restore: "restore",
-  browse: "show detail",
-  library_favorites: "favorites",
-  deeplink: "deep link",
-  search_result: "search",
-};
-
-function relativeAge(startedAt: number): string {
-  const ageMs = Date.now() - startedAt;
-  if (ageMs < 60_000) return `${Math.floor(ageMs / 1000)}s ago`;
-  return `${Math.floor(ageMs / 60_000)}m ago`;
-}
-
-function formatShowDate(showId: string | null): string {
-  if (!showId) return "—";
-  const m = showId.match(/^(\d{4}-\d{2}-\d{2})/);
-  return m ? m[1] : showId.slice(0, 24);
-}
 
 export default function ListeningNow({
   showMap,
+  onOpenInstall,
 }: {
   showMap?: Map<string, ShowName>;
+  onOpenInstall?: (iid: string) => void;
 } = {}) {
   const [listeners, setListeners] = useState<LiveListener[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -174,39 +74,20 @@ export default function ListeningNow({
         window covers the longest Dead jams; killed sessions ghost up to 45 min
       </p>
       {listeners.map((l) => (
-        <div
+        <ListeningRow
           key={`${l.iid}-${l.started_at}`}
-          className="bg-deadly-surface rounded-lg px-2 py-1.5 text-sm flex items-center gap-3"
-        >
-          <span
-            className="inline-flex items-center gap-1 shrink-0 w-24"
-            title={l.iid}
-          >
-            <span>{emojiForId(l.iid)}</span>
-            <span className="font-mono text-xs text-zinc-400">
-              {l.iid.slice(0, 8)}
-            </span>
-          </span>
-          <span className="font-mono text-xs text-zinc-500 w-20 shrink-0 tabular-nums">
-            {relativeAge(l.started_at)}
-          </span>
-          <span className="text-zinc-300 w-24 shrink-0">
-            {formatShowDate(l.show_id)}
-          </span>
-          <span className="text-zinc-500 w-14 shrink-0">
-            {l.track_index != null ? `track ${l.track_index}` : "—"}
-          </span>
-          <span className="text-zinc-500 w-24 shrink-0 truncate">
-            {l.source ? (SOURCE_LABELS[l.source] ?? l.source) : "—"}
-          </span>
-          <TrackOutcomeBar
-            tracks={l.tracks}
-            totalTracks={l.show_id ? showMap?.get(l.show_id)?.tc : undefined}
-          />
-          <span className="text-xs text-zinc-600 ml-auto truncate shrink-0">
-            {l.platform} {l.app_version}
-          </span>
-        </div>
+          rowKey={`${l.iid}-${l.started_at}`}
+          iid={l.iid}
+          platform={l.platform}
+          app_version={l.app_version}
+          ts={l.started_at}
+          show_id={l.show_id}
+          track_index={l.track_index}
+          source={l.source}
+          tracks={l.tracks}
+          totalTracks={l.show_id ? showMap?.get(l.show_id)?.tc : undefined}
+          onClick={onOpenInstall ? () => onOpenInstall(l.iid) : undefined}
+        />
       ))}
     </div>
   );

--- a/ui/src/app/admin/analytics/components/ListeningNow.tsx
+++ b/ui/src/app/admin/analytics/components/ListeningNow.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { ListeningRow, type TrackPlay } from "./listeningRow";
+import { useWatchedInstalls } from "./WatchedInstallsContext";
 
 interface LiveListener {
   iid: string;
@@ -29,10 +30,13 @@ const POLL_INTERVAL_MS = 15_000;
 export default function ListeningNow({
   showMap,
   onOpenInstall,
+  watchedOnly = false,
 }: {
   showMap?: Map<string, ShowName>;
   onOpenInstall?: (iid: string) => void;
+  watchedOnly?: boolean;
 } = {}) {
+  const { isWatched } = useWatchedInstalls();
   const [listeners, setListeners] = useState<LiveListener[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -59,10 +63,16 @@ export default function ListeningNow({
   if (listeners === null)
     return <p className="text-sm text-zinc-500">Loading…</p>;
 
-  if (listeners.length === 0) {
+  const visible = watchedOnly
+    ? listeners.filter((l) => isWatched(l.iid))
+    : listeners;
+
+  if (visible.length === 0) {
     return (
       <p className="text-sm text-zinc-500 italic">
-        No active sessions in the last 5 minutes.
+        {watchedOnly
+          ? "No watched installs are currently listening."
+          : "No active sessions in the last 5 minutes."}
       </p>
     );
   }
@@ -70,10 +80,10 @@ export default function ListeningNow({
   return (
     <div className="space-y-1">
       <p className="text-xs text-zinc-500 mb-2">
-        {listeners.length} active session{listeners.length !== 1 ? "s" : ""} ·
-        window covers the longest Dead jams; killed sessions ghost up to 45 min
+        {visible.length} active session{visible.length !== 1 ? "s" : ""}
+        {watchedOnly ? " (watched only)" : " · window covers the longest Dead jams; killed sessions ghost up to 45 min"}
       </p>
-      {listeners.map((l) => (
+      {visible.map((l) => (
         <ListeningRow
           key={`${l.iid}-${l.started_at}`}
           rowKey={`${l.iid}-${l.started_at}`}

--- a/ui/src/app/admin/analytics/components/MetricDetailView.tsx
+++ b/ui/src/app/admin/analytics/components/MetricDetailView.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { emojiForId } from "./emojiId";
+import { useWatchedInstalls } from "./WatchedInstallsContext";
 
 const SHOW_ID_RE = /^\d{4}-\d{2}-\d{2}(-[\w-]+)?$/;
 function isShowId(value: string): boolean {
@@ -67,6 +67,7 @@ interface Props {
 
 export default function MetricDetailView({ metric, filter, backHref }: Props) {
   const router = useRouter();
+  const { isWatched, nameFor, setWatched, unwatch } = useWatchedInstalls();
   const [rows, setRows] = useState<DetailRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [sortKey, setSortKey] = useState<SortKey>("last_seen");
@@ -119,12 +120,12 @@ export default function MetricDetailView({ metric, filter, backHref }: Props) {
       <div className="max-w-3xl mx-auto p-4 sm:p-6">
         {/* Header */}
         <div className="mb-3 flex items-center gap-3">
-          <Link
-            href={backHref}
+          <button
+            onClick={() => router.push(backHref)}
             className="text-zinc-400 hover:text-white text-sm flex items-center gap-1"
           >
             <span>&larr;</span> Back
-          </Link>
+          </button>
         </div>
         <div className="mb-3 flex items-baseline justify-between gap-2 flex-wrap">
           <h1 className="text-lg font-semibold text-white">
@@ -137,12 +138,12 @@ export default function MetricDetailView({ metric, filter, backHref }: Props) {
           </h1>
           <div className="flex items-center gap-3">
             {filter && (
-              <Link
-                href={`/admin/analytics?metric=${metric}`}
+              <button
+                onClick={() => router.push(`/admin/analytics?metric=${metric}`)}
                 className="text-xs text-zinc-400 hover:text-white"
               >
                 clear filter
-              </Link>
+              </button>
             )}
             <span className="text-xs text-zinc-500">{rows.length} rows</span>
           </div>
@@ -183,15 +184,28 @@ export default function MetricDetailView({ metric, filter, backHref }: Props) {
               {sortedRows.map((row, i) => {
                 const detail = row.detail;
                 const detailIsShow = detail != null && isShowId(detail);
+                const rowWatched = isWatched(row.iid);
                 return (
-                  <button
+                  <div
                     key={i}
+                    role="button"
+                    tabIndex={0}
                     onClick={() =>
                       router.push(
                         `/admin/analytics?install=${encodeURIComponent(row.iid)}`,
                       )
                     }
-                    className="w-full text-left bg-zinc-800/50 hover:bg-zinc-800 active:bg-zinc-700/50 rounded px-2.5 py-1.5 flex flex-col gap-0.5"
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        router.push(
+                          `/admin/analytics?install=${encodeURIComponent(row.iid)}`,
+                        );
+                      }
+                    }}
+                    className={`w-full text-left bg-zinc-800/50 hover:bg-zinc-800 active:bg-zinc-700/50 rounded px-2.5 py-1.5 flex flex-col gap-0.5 cursor-pointer ${
+                      rowWatched ? "ring-1 ring-amber-500/40" : ""
+                    }`}
                   >
                     {detail && (
                       <div className="flex items-baseline justify-between gap-2 min-w-0 text-sm">
@@ -205,8 +219,32 @@ export default function MetricDetailView({ metric, filter, backHref }: Props) {
                     )}
                     <div className="flex items-center justify-between gap-2 text-xs">
                       <span className="flex items-center gap-1 min-w-0 text-deadly-blue">
-                        <span>{emojiForId(row.iid)}</span>
-                        <span className="font-mono">{row.iid?.slice(0, 8)}</span>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (rowWatched) unwatch(row.iid);
+                            else setWatched(row.iid, null, null);
+                          }}
+                          title={rowWatched ? "Stop watching" : "Watch this install"}
+                          aria-label={rowWatched ? "Unwatch" : "Watch"}
+                          className={`shrink-0 w-4 text-center leading-none transition-colors ${
+                            rowWatched
+                              ? "text-amber-400 hover:text-amber-300"
+                              : "text-zinc-600 hover:text-amber-300"
+                          }`}
+                        >
+                          {rowWatched ? "★" : "☆"}
+                        </button>
+                        <span className="shrink-0">{emojiForId(row.iid)}</span>
+                        {nameFor(row.iid) ? (
+                          <span className="text-zinc-200 truncate min-w-0">
+                            {nameFor(row.iid)}
+                          </span>
+                        ) : (
+                          <span className="font-mono shrink-0">
+                            {row.iid?.slice(0, 8)}
+                          </span>
+                        )}
                       </span>
                       <span className="flex items-center gap-1.5 text-zinc-500 flex-shrink-0">
                         <span>{row.platform}</span>
@@ -219,7 +257,7 @@ export default function MetricDetailView({ metric, filter, backHref }: Props) {
                         )}
                       </span>
                     </div>
-                  </button>
+                  </div>
                 );
               })}
             </div>

--- a/ui/src/app/admin/analytics/components/MetricDetailView.tsx
+++ b/ui/src/app/admin/analytics/components/MetricDetailView.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { emojiForId } from "./emojiId";
+
+const SHOW_ID_RE = /^\d{4}-\d{2}-\d{2}(-[\w-]+)?$/;
+function isShowId(value: string): boolean {
+  return SHOW_ID_RE.test(value);
+}
+
+function ShowLink({ id }: { id: string }) {
+  return (
+    <a
+      href={`/shows/${id}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={(e) => e.stopPropagation()}
+      className="text-deadly-blue hover:text-white underline decoration-dotted underline-offset-2 [overflow-wrap:anywhere]"
+    >
+      {id}
+    </a>
+  );
+}
+
+interface DetailRow {
+  iid: string;
+  platform: string;
+  app_version: string;
+  last_seen: string;
+  event_count: number;
+  detail?: string;
+}
+
+type SortKey = keyof DetailRow;
+type SortDir = "asc" | "desc";
+
+const METRIC_LABELS: Record<string, string> = {
+  dau: "Daily Active Users",
+  wau: "Weekly Active Users",
+  mau: "Monthly Active Users",
+  total_installs: "Total Installs",
+  stale_installs: "Stale Installs (30d)",
+  events_today: "Events Today",
+  top_shows: "Most-listened shows (30d)",
+  feature_adoption: "Feature Adoption (30d)",
+  platform_split: "Active installs by platform (30d)",
+  playback: "Playback (30d)",
+  playback_source: "Plays by Source (30d)",
+  new_installs: "New Installs",
+};
+
+function relativeTime(iso: string): string {
+  const ms = Date.now() - new Date(iso + "Z").getTime();
+  if (ms < 60_000) return "just now";
+  if (ms < 3600_000) return `${Math.floor(ms / 60_000)}m`;
+  if (ms < 86400_000) return `${Math.floor(ms / 3600_000)}h`;
+  return `${Math.floor(ms / 86400_000)}d`;
+}
+
+interface Props {
+  metric: string;
+  filter?: string;
+  backHref: string;
+}
+
+export default function MetricDetailView({ metric, filter, backHref }: Props) {
+  const router = useRouter();
+  const [rows, setRows] = useState<DetailRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [sortKey, setSortKey] = useState<SortKey>("last_seen");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [metric, filter]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    const params = new URLSearchParams({ metric });
+    if (filter) params.set("filter", filter);
+    fetch(`/api/analytics/detail?${params}`, { credentials: "include" })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data: DetailRow[]) => {
+        if (!cancelled) setRows(data);
+      })
+      .catch(() => {
+        if (!cancelled) setRows([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [metric, filter]);
+
+  const sortedRows = useMemo(() => {
+    const sorted = [...rows];
+    sorted.sort((a, b) => {
+      const aVal = a[sortKey] ?? "";
+      const bVal = b[sortKey] ?? "";
+      if (typeof aVal === "number" && typeof bVal === "number") {
+        return sortDir === "asc" ? aVal - bVal : bVal - aVal;
+      }
+      const cmp = String(aVal).localeCompare(String(bVal));
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+    return sorted;
+  }, [rows, sortKey, sortDir]);
+
+  const title = METRIC_LABELS[metric] ?? metric;
+  const hasDetail = sortedRows.some((r) => r.detail != null);
+
+  return (
+    <div className="min-h-screen bg-deadly-bg">
+      <div className="max-w-3xl mx-auto p-4 sm:p-6">
+        {/* Header */}
+        <div className="mb-3 flex items-center gap-3">
+          <Link
+            href={backHref}
+            className="text-zinc-400 hover:text-white text-sm flex items-center gap-1"
+          >
+            <span>&larr;</span> Back
+          </Link>
+        </div>
+        <div className="mb-3 flex items-baseline justify-between gap-2 flex-wrap">
+          <h1 className="text-lg font-semibold text-white">
+            {title}
+            {filter && (
+              <span className="text-sm font-normal text-zinc-400 ml-2 [overflow-wrap:anywhere]">
+                &mdash; {filter}
+              </span>
+            )}
+          </h1>
+          <div className="flex items-center gap-3">
+            {filter && (
+              <Link
+                href={`/admin/analytics?metric=${metric}`}
+                className="text-xs text-zinc-400 hover:text-white"
+              >
+                clear filter
+              </Link>
+            )}
+            <span className="text-xs text-zinc-500">{rows.length} rows</span>
+          </div>
+        </div>
+
+        {loading ? (
+          <p className="text-zinc-400 py-8 text-center">Loading…</p>
+        ) : sortedRows.length === 0 ? (
+          <p className="text-zinc-500 py-8 text-center">No data</p>
+        ) : (
+          <>
+            {/* Sort controls */}
+            <div className="flex items-center gap-2 mb-2 text-xs text-zinc-500">
+              <span>Sort</span>
+              <select
+                value={sortKey}
+                onChange={(e) => setSortKey(e.target.value as SortKey)}
+                className="bg-zinc-800 text-zinc-300 rounded px-2 py-1 border border-zinc-700"
+              >
+                {hasDetail && <option value="detail">Detail</option>}
+                <option value="iid">Install</option>
+                <option value="platform">Platform</option>
+                <option value="app_version">Version</option>
+                <option value="last_seen">Last seen</option>
+                <option value="event_count">Count</option>
+              </select>
+              <button
+                onClick={() => setSortDir((d) => (d === "asc" ? "desc" : "asc"))}
+                className="text-zinc-300 hover:text-white px-2 py-1 rounded border border-zinc-700 bg-zinc-800"
+                aria-label="Toggle sort direction"
+              >
+                {sortDir === "asc" ? "▲" : "▼"}
+              </button>
+            </div>
+
+            {/* Compact rows */}
+            <div className="space-y-1">
+              {sortedRows.map((row, i) => {
+                const detail = row.detail;
+                const detailIsShow = detail != null && isShowId(detail);
+                return (
+                  <button
+                    key={i}
+                    onClick={() =>
+                      router.push(
+                        `/admin/analytics?install=${encodeURIComponent(row.iid)}`,
+                      )
+                    }
+                    className="w-full text-left bg-zinc-800/50 hover:bg-zinc-800 active:bg-zinc-700/50 rounded px-2.5 py-1.5 flex flex-col gap-0.5"
+                  >
+                    {detail && (
+                      <div className="flex items-baseline justify-between gap-2 min-w-0 text-sm">
+                        <span className="text-zinc-100 min-w-0 flex-1 [overflow-wrap:anywhere]">
+                          {detailIsShow ? <ShowLink id={detail} /> : detail}
+                        </span>
+                        <span className="text-zinc-300 tabular-nums flex-shrink-0">
+                          {row.event_count}
+                        </span>
+                      </div>
+                    )}
+                    <div className="flex items-center justify-between gap-2 text-xs">
+                      <span className="flex items-center gap-1 min-w-0 text-deadly-blue">
+                        <span>{emojiForId(row.iid)}</span>
+                        <span className="font-mono">{row.iid?.slice(0, 8)}</span>
+                      </span>
+                      <span className="flex items-center gap-1.5 text-zinc-500 flex-shrink-0">
+                        <span>{row.platform}</span>
+                        <span>v{row.app_version}</span>
+                        <span>{relativeTime(row.last_seen)}</span>
+                        {!detail && (
+                          <span className="text-zinc-300 tabular-nums">
+                            {row.event_count}
+                          </span>
+                        )}
+                      </span>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/app/admin/analytics/components/RecentListening.tsx
+++ b/ui/src/app/admin/analytics/components/RecentListening.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { ListeningRow, type TrackPlay } from "./listeningRow";
+import { useWatchedInstalls } from "./WatchedInstallsContext";
 
 const INITIAL_VISIBLE = 10;
 
@@ -34,10 +35,13 @@ const POLL_INTERVAL_MS = 60_000;
 export default function RecentListening({
   showMap,
   onOpenInstall,
+  watchedOnly = false,
 }: {
   showMap?: Map<string, ShowName>;
   onOpenInstall?: (iid: string) => void;
+  watchedOnly?: boolean;
 } = {}) {
+  const { isWatched } = useWatchedInstalls();
   const [sessions, setSessions] = useState<RecentSession[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState(false);
@@ -78,13 +82,27 @@ export default function RecentListening({
     );
   }
 
-  const visible = expanded ? sessions : sessions.slice(0, INITIAL_VISIBLE);
-  const hiddenCount = sessions.length - visible.length;
+  const filtered = watchedOnly
+    ? sessions.filter((s) => isWatched(s.iid))
+    : sessions;
+  const visible = expanded ? filtered : filtered.slice(0, INITIAL_VISIBLE);
+  const hiddenCount = filtered.length - visible.length;
+
+  if (filtered.length === 0) {
+    return (
+      <p className="text-sm text-zinc-500 italic">
+        {watchedOnly
+          ? "No watched installs have played in the last 24h."
+          : "No completed listening sessions in the last 24 hours."}
+      </p>
+    );
+  }
 
   return (
     <div className="space-y-1">
       <p className="text-xs text-zinc-500 mb-2">
-        {sessions.length} session{sessions.length !== 1 ? "s" : ""} in the last 24h
+        {filtered.length} session{filtered.length !== 1 ? "s" : ""} in the last 24h
+        {watchedOnly ? " (watched only)" : ""}
       </p>
       {visible.map((s) => (
         <ListeningRow
@@ -102,7 +120,7 @@ export default function RecentListening({
           onClick={onOpenInstall ? () => onOpenInstall(s.iid) : undefined}
         />
       ))}
-      {sessions.length > INITIAL_VISIBLE && (
+      {filtered.length > INITIAL_VISIBLE && (
         <button
           onClick={() => setExpanded((v) => !v)}
           className="w-full text-xs text-zinc-400 hover:text-white py-2 mt-1 transition-colors"

--- a/ui/src/app/admin/analytics/components/RecentListening.tsx
+++ b/ui/src/app/admin/analytics/components/RecentListening.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ListeningRow, type TrackPlay } from "./listeningRow";
+
+const INITIAL_VISIBLE = 10;
+
+interface RecentSession {
+  iid: string;
+  platform: string;
+  app_version: string;
+  started_at: number;
+  last_event_at: number;
+  show_id: string | null;
+  recording_id: string | null;
+  track_index: number | null;
+  source: string | null;
+  tracks: TrackPlay[];
+  session_count: number;
+  ended: boolean;
+}
+
+interface ShowName {
+  id: string;
+  d: string;
+  v: string;
+  c: string;
+  s: string;
+  tc: number;
+}
+
+const POLL_INTERVAL_MS = 60_000;
+
+export default function RecentListening({
+  showMap,
+  onOpenInstall,
+}: {
+  showMap?: Map<string, ShowName>;
+  onOpenInstall?: (iid: string) => void;
+} = {}) {
+  const [sessions, setSessions] = useState<RecentSession[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(false);
+
+  const fetchData = async () => {
+    try {
+      const res = await fetch(
+        "/api/analytics/recent-listening?hours=24",
+        { credentials: "include" },
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = (await res.json()) as { sessions: RecentSession[] };
+      setSessions(body.sessions);
+      setError(null);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+    const id = setInterval(fetchData, POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  if (error)
+    return (
+      <p className="text-sm text-red-400">Recent Listening error: {error}</p>
+    );
+  if (sessions === null)
+    return <p className="text-sm text-zinc-500">Loading…</p>;
+
+  if (sessions.length === 0) {
+    return (
+      <p className="text-sm text-zinc-500 italic">
+        No completed listening sessions in the last 24 hours.
+      </p>
+    );
+  }
+
+  const visible = expanded ? sessions : sessions.slice(0, INITIAL_VISIBLE);
+  const hiddenCount = sessions.length - visible.length;
+
+  return (
+    <div className="space-y-1">
+      <p className="text-xs text-zinc-500 mb-2">
+        {sessions.length} session{sessions.length !== 1 ? "s" : ""} in the last 24h
+      </p>
+      {visible.map((s) => (
+        <ListeningRow
+          key={`${s.iid}-${s.started_at}`}
+          rowKey={`${s.iid}-${s.started_at}`}
+          iid={s.iid}
+          platform={s.platform}
+          app_version={s.app_version}
+          ts={s.last_event_at}
+          show_id={s.show_id}
+          track_index={s.track_index}
+          source={s.source}
+          tracks={s.tracks}
+          totalTracks={s.show_id ? showMap?.get(s.show_id)?.tc : undefined}
+          onClick={onOpenInstall ? () => onOpenInstall(s.iid) : undefined}
+        />
+      ))}
+      {sessions.length > INITIAL_VISIBLE && (
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          className="w-full text-xs text-zinc-400 hover:text-white py-2 mt-1 transition-colors"
+        >
+          {expanded ? "Show less" : `Show ${hiddenCount} more`}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/ui/src/app/admin/analytics/components/ShowEngagement.tsx
+++ b/ui/src/app/admin/analytics/components/ShowEngagement.tsx
@@ -59,7 +59,13 @@ function ShowRow({
       <span className="text-zinc-500 text-sm font-mono w-5 text-right flex-shrink-0 pt-0.5">
         {rank}
       </span>
-      <div className="min-w-0 flex-1">
+      <a
+        href={`/shows/${row.show_id}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        className="min-w-0 flex-1 hover:text-deadly-blue transition-colors"
+      >
         {info ? (
           <>
             <p className="text-sm text-zinc-200">{formatDate(info.d)}</p>
@@ -68,9 +74,9 @@ function ShowRow({
             </p>
           </>
         ) : (
-          <p className="text-sm text-zinc-300 font-mono">{row.show_id}</p>
+          <p className="text-sm text-zinc-300 font-mono break-all">{row.show_id}</p>
         )}
-      </div>
+      </a>
       <span className="text-sm text-zinc-400 flex-shrink-0 tabular-nums">
         {row.users} user{row.users !== 1 ? "s" : ""}
       </span>

--- a/ui/src/app/admin/analytics/components/TopShowsList.tsx
+++ b/ui/src/app/admin/analytics/components/TopShowsList.tsx
@@ -111,7 +111,13 @@ export default function TopShowsList({ showMap, onShowClick }: TopShowsListProps
                 ) : (
                   <div className="w-10 h-10 rounded bg-zinc-800 shrink-0" />
                 )}
-                <div className="min-w-0 flex-1">
+                <a
+                  href={`/shows/${show.show_id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={(e) => e.stopPropagation()}
+                  className="min-w-0 flex-1 hover:text-deadly-blue transition-colors"
+                >
                   {info ? (
                     <>
                       <p className="text-sm text-zinc-200">{formatDate(info.d)}</p>
@@ -120,9 +126,9 @@ export default function TopShowsList({ showMap, onShowClick }: TopShowsListProps
                       </p>
                     </>
                   ) : (
-                    <p className="text-sm text-zinc-300 font-mono">{show.show_id}</p>
+                    <p className="text-sm text-zinc-300 font-mono break-all">{show.show_id}</p>
                   )}
-                </div>
+                </a>
                 <div className="flex flex-col items-end shrink-0 tabular-nums">
                   <span className="text-sm text-zinc-300">
                     {show.listeners} listener{show.listeners !== 1 ? "s" : ""}

--- a/ui/src/app/admin/analytics/components/WatchToggle.tsx
+++ b/ui/src/app/admin/analytics/components/WatchToggle.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useWatchedInstalls } from "./WatchedInstallsContext";
+
+export default function WatchToggle({ iid }: { iid: string }) {
+  const { isWatched, nameFor, setWatched, unwatch } = useWatchedInstalls();
+  const watched = isWatched(iid);
+  const currentName = nameFor(iid);
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(currentName ?? "");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    setName(currentName ?? "");
+  }, [currentName]);
+
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
+
+  const handleToggle = async () => {
+    if (watched) {
+      await unwatch(iid);
+      setEditing(false);
+    } else {
+      // First watch: flag it, then open the name editor as a soft prompt.
+      await setWatched(iid, null, null);
+      setEditing(true);
+    }
+  };
+
+  const handleSave = async () => {
+    const trimmed = name.trim();
+    await setWatched(iid, trimmed || null, null);
+    setEditing(false);
+  };
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <button
+        onClick={handleToggle}
+        className={`text-sm flex items-center gap-1 px-2 py-1 rounded border transition-colors ${
+          watched
+            ? "border-amber-500/60 bg-amber-500/10 text-amber-300 hover:bg-amber-500/20"
+            : "border-zinc-700 text-zinc-300 hover:bg-zinc-800"
+        }`}
+        title={watched ? "Stop watching this install" : "Watch this install"}
+      >
+        <span>{watched ? "★" : "☆"}</span>
+        <span>{watched ? "Watching" : "Watch"}</span>
+      </button>
+
+      {watched && !editing && (
+        <button
+          onClick={() => setEditing(true)}
+          className="text-xs text-zinc-400 hover:text-white"
+        >
+          {currentName ? `“${currentName}” — rename` : "+ add name"}
+        </button>
+      )}
+
+      {watched && editing && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSave();
+          }}
+          className="flex items-center gap-1"
+        >
+          <input
+            ref={inputRef}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="friendly name (optional)"
+            className="bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-sm text-white placeholder:text-zinc-500 w-48"
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                e.preventDefault();
+                setName(currentName ?? "");
+                setEditing(false);
+              }
+            }}
+          />
+          <button
+            type="submit"
+            className="text-xs text-zinc-300 hover:text-white px-2 py-1 rounded border border-zinc-700 bg-zinc-800"
+          >
+            save
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setName(currentName ?? "");
+              setEditing(false);
+            }}
+            className="text-xs text-zinc-500 hover:text-zinc-300 px-1"
+          >
+            cancel
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/ui/src/app/admin/analytics/components/WatchedInstallsContext.tsx
+++ b/ui/src/app/admin/analytics/components/WatchedInstallsContext.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+export interface WatchedInstall {
+  iid: string;
+  name: string | null;
+  notes: string | null;
+  watched_at: number;
+}
+
+interface WatchedContextValue {
+  /** Lookup by iid. Always reflects latest server state. */
+  watched: Map<string, WatchedInstall>;
+  isWatched: (iid: string) => boolean;
+  nameFor: (iid: string) => string | null;
+  /** Upsert a watch flag for `iid`. name/notes may be null. */
+  setWatched: (
+    iid: string,
+    name: string | null,
+    notes: string | null,
+  ) => Promise<void>;
+  /** Remove the watch flag. */
+  unwatch: (iid: string) => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+const WatchedInstallsContext = createContext<WatchedContextValue | null>(null);
+
+export function WatchedInstallsProvider({ children }: { children: ReactNode }) {
+  const [list, setList] = useState<WatchedInstall[]>([]);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch("/api/analytics/watched", {
+        credentials: "include",
+      });
+      if (!res.ok) return;
+      const body = (await res.json()) as { watched: WatchedInstall[] };
+      setList(body.watched);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const watched = useMemo(() => {
+    const m = new Map<string, WatchedInstall>();
+    for (const w of list) m.set(w.iid, w);
+    return m;
+  }, [list]);
+
+  const isWatched = useCallback((iid: string) => watched.has(iid), [watched]);
+  const nameFor = useCallback(
+    (iid: string) => watched.get(iid)?.name ?? null,
+    [watched],
+  );
+
+  const setWatched = useCallback(
+    async (iid: string, name: string | null, notes: string | null) => {
+      const res = await fetch(
+        `/api/analytics/watched/${encodeURIComponent(iid)}`,
+        {
+          method: "PUT",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, notes }),
+        },
+      );
+      if (!res.ok) return;
+      const updated = (await res.json()) as WatchedInstall;
+      setList((prev) => {
+        const next = prev.filter((w) => w.iid !== iid);
+        next.unshift(updated);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const unwatch = useCallback(async (iid: string) => {
+    const res = await fetch(
+      `/api/analytics/watched/${encodeURIComponent(iid)}`,
+      {
+        method: "DELETE",
+        credentials: "include",
+      },
+    );
+    if (!res.ok && res.status !== 204) return;
+    setList((prev) => prev.filter((w) => w.iid !== iid));
+  }, []);
+
+  const value: WatchedContextValue = useMemo(
+    () => ({ watched, isWatched, nameFor, setWatched, unwatch, refresh }),
+    [watched, isWatched, nameFor, setWatched, unwatch, refresh],
+  );
+
+  return (
+    <WatchedInstallsContext.Provider value={value}>
+      {children}
+    </WatchedInstallsContext.Provider>
+  );
+}
+
+export function useWatchedInstalls(): WatchedContextValue {
+  const ctx = useContext(WatchedInstallsContext);
+  if (!ctx) {
+    throw new Error(
+      "useWatchedInstalls must be used inside <WatchedInstallsProvider>",
+    );
+  }
+  return ctx;
+}

--- a/ui/src/app/admin/analytics/components/WatchedInstallsPanel.tsx
+++ b/ui/src/app/admin/analytics/components/WatchedInstallsPanel.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { emojiForId } from "./emojiId";
+import { useWatchedInstalls } from "./WatchedInstallsContext";
+
+function relativeAge(ts: number): string {
+  const ms = Date.now() - ts;
+  if (ms < 60_000) return `${Math.floor(ms / 1000)}s ago`;
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`;
+  if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h ago`;
+  return `${Math.floor(ms / 86_400_000)}d ago`;
+}
+
+export default function WatchedInstallsPanel({
+  onOpenInstall,
+}: {
+  onOpenInstall?: (iid: string) => void;
+}) {
+  const { watched, unwatch } = useWatchedInstalls();
+  const list = Array.from(watched.values()).sort(
+    (a, b) => b.watched_at - a.watched_at,
+  );
+
+  if (list.length === 0) {
+    return (
+      <p className="text-sm text-zinc-500 italic">
+        No watched installs. Open any install detail page and click ☆ Watch to
+        flag it.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      {list.map((w) => (
+        <div
+          key={w.iid}
+          className="bg-deadly-surface rounded-lg px-3 py-2 flex items-center gap-3 ring-1 ring-amber-500/40"
+        >
+          <span className="text-amber-400">★</span>
+          <span>{emojiForId(w.iid)}</span>
+          <button
+            onClick={() => onOpenInstall?.(w.iid)}
+            className="flex-1 min-w-0 text-left hover:text-deadly-blue transition-colors"
+          >
+            {w.name ? (
+              <>
+                <p className="text-sm text-zinc-100 truncate">{w.name}</p>
+                <p className="font-mono text-xs text-zinc-500 truncate">
+                  {w.iid.slice(0, 16)}…
+                </p>
+              </>
+            ) : (
+              <p className="font-mono text-sm text-zinc-300 truncate">
+                {w.iid.slice(0, 16)}…
+              </p>
+            )}
+          </button>
+          <span className="text-xs text-zinc-500 tabular-nums shrink-0">
+            flagged {relativeAge(w.watched_at)}
+          </span>
+          <button
+            onClick={() => unwatch(w.iid)}
+            className="text-xs text-zinc-500 hover:text-red-400 shrink-0"
+            title="Stop watching"
+          >
+            unwatch
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/ui/src/app/admin/analytics/components/listeningRow.tsx
+++ b/ui/src/app/admin/analytics/components/listeningRow.tsx
@@ -53,6 +53,28 @@ export function formatShowDate(showId: string | null): string {
   return m ? m[1] : showId.slice(0, 24);
 }
 
+function ShowDateLink({
+  showId,
+  className,
+}: {
+  showId: string | null;
+  className?: string;
+}) {
+  const label = formatShowDate(showId);
+  if (!showId) return <span className={className}>{label}</span>;
+  return (
+    <a
+      href={`/shows/${showId}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={(e) => e.stopPropagation()}
+      className={`${className ?? ""} hover:text-deadly-blue hover:underline decoration-dotted underline-offset-2 transition-colors`}
+    >
+      {label}
+    </a>
+  );
+}
+
 /**
  * Same bar shape as the Show Listening panel: each slot is one of the
  * show's actual tracks (when total track count is known) so an unplayed
@@ -150,7 +172,6 @@ export function ListeningRow({
   const interactive = !!onClick;
   const sourceLabel = source ? (SOURCE_LABELS[source] ?? source) : "—";
   const age = relativeAge(ts);
-  const showDate = formatShowDate(show_id);
   const trackLabel = track_index != null ? `track ${track_index}` : "—";
 
   return (
@@ -169,7 +190,7 @@ export function ListeningRow({
               {iid.slice(0, 8)}
             </span>
           </span>
-          <span className="text-zinc-300 ml-1">{showDate}</span>
+          <ShowDateLink showId={show_id} className="text-zinc-300 ml-1" />
           <span className="font-mono text-xs text-zinc-500 ml-auto tabular-nums">
             {age}
           </span>
@@ -198,7 +219,7 @@ export function ListeningRow({
         <span className="font-mono text-xs text-zinc-500 w-20 shrink-0 tabular-nums">
           {age}
         </span>
-        <span className="text-zinc-300 w-24 shrink-0">{showDate}</span>
+        <ShowDateLink showId={show_id} className="text-zinc-300 w-24 shrink-0" />
         <span className="text-zinc-500 w-14 shrink-0">{trackLabel}</span>
         <span className="text-zinc-500 w-24 shrink-0 truncate">
           {sourceLabel}

--- a/ui/src/app/admin/analytics/components/listeningRow.tsx
+++ b/ui/src/app/admin/analytics/components/listeningRow.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { emojiForId } from "./emojiId";
+
+export type TrackOutcome = "complete" | "skipped" | "error" | "partial";
+
+export interface TrackPlay {
+  index: number;
+  outcome: TrackOutcome;
+}
+
+const OUTCOME_COLOR: Record<TrackOutcome, string> = {
+  complete: "bg-emerald-500",
+  skipped: "bg-amber-400",
+  error: "bg-red-500",
+  partial: "bg-sky-400",
+};
+
+const OUTCOME_LABEL: Record<TrackOutcome, string> = {
+  complete: "complete",
+  skipped: "skipped",
+  error: "error",
+  partial: "partial",
+};
+
+const SEVERITY: Record<TrackOutcome, number> = {
+  partial: 0,
+  complete: 1,
+  skipped: 2,
+  error: 3,
+};
+
+export const SOURCE_LABELS: Record<string, string> = {
+  auto_advance: "auto-advance",
+  restore: "restore",
+  browse: "show detail",
+  library_favorites: "favorites",
+  deeplink: "deep link",
+  search_result: "search",
+};
+
+export function relativeAge(ts: number): string {
+  const ageMs = Date.now() - ts;
+  if (ageMs < 60_000) return `${Math.floor(ageMs / 1000)}s ago`;
+  if (ageMs < 3_600_000) return `${Math.floor(ageMs / 60_000)}m ago`;
+  if (ageMs < 86_400_000) return `${Math.floor(ageMs / 3_600_000)}h ago`;
+  return `${Math.floor(ageMs / 86_400_000)}d ago`;
+}
+
+export function formatShowDate(showId: string | null): string {
+  if (!showId) return "—";
+  const m = showId.match(/^(\d{4}-\d{2}-\d{2})/);
+  return m ? m[1] : showId.slice(0, 24);
+}
+
+/**
+ * Same bar shape as the Show Listening panel: each slot is one of the
+ * show's actual tracks (when total track count is known) so an unplayed
+ * track 8 of 12 reads as four trailing dim slots, not a missing tail.
+ * Falls back to length-of-events when track count is unavailable.
+ */
+export function TrackOutcomeBar({
+  tracks,
+  totalTracks,
+  compact = false,
+}: {
+  tracks: TrackPlay[];
+  totalTracks: number | undefined;
+  compact?: boolean;
+}) {
+  if (tracks.length === 0 && !totalTracks) return null;
+  const outcomeByPos = new Map<number, TrackOutcome>();
+  for (const t of tracks) {
+    const pos = t.index > 0 ? t.index - 1 : t.index;
+    const prior = outcomeByPos.get(pos);
+    if (!prior || SEVERITY[t.outcome] > SEVERITY[prior]) {
+      outcomeByPos.set(pos, t.outcome);
+    }
+  }
+  const heard = outcomeByPos.size;
+  const maxPos = heard > 0 ? Math.max(...outcomeByPos.keys()) + 1 : 0;
+  const total = totalTracks && totalTracks > 0 ? totalTracks : maxPos;
+  if (total === 0) return null;
+
+  const slotMax = compact ? 6 : 8;
+  const slotMin = 2;
+  const target = compact ? 96 : 120;
+
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      <div
+        className="flex gap-px min-w-0"
+        title={`${heard} of ${total} tracks`}
+      >
+        {Array.from({ length: total }, (_, i) => {
+          const outcome = outcomeByPos.get(i);
+          const cls = outcome ? OUTCOME_COLOR[outcome] : "bg-zinc-700";
+          const label = outcome
+            ? `track ${i + 1}: ${OUTCOME_LABEL[outcome]}`
+            : `track ${i + 1}: not played`;
+          return (
+            <div
+              key={i}
+              title={label}
+              className={`h-3 rounded-sm ${cls}`}
+              style={{
+                width: `${Math.max(Math.min(target / total, slotMax), slotMin)}px`,
+              }}
+            />
+          );
+        })}
+      </div>
+      <span className="text-xs text-zinc-500 whitespace-nowrap">
+        {heard}/{total}
+      </span>
+    </div>
+  );
+}
+
+export interface ListeningRowProps {
+  iid: string;
+  platform: string;
+  app_version: string;
+  ts: number;
+  show_id: string | null;
+  track_index: number | null;
+  source: string | null;
+  tracks: TrackPlay[];
+  totalTracks: number | undefined;
+  rowKey: string;
+  onClick?: () => void;
+}
+
+/**
+ * Shared row used by Listening Now and Recent Listening. Renders a
+ * desktop single-row layout (sm+) and a stacked two-line card on mobile.
+ */
+export function ListeningRow({
+  iid,
+  platform,
+  app_version,
+  ts,
+  show_id,
+  track_index,
+  source,
+  tracks,
+  totalTracks,
+  onClick,
+}: ListeningRowProps) {
+  const interactive = !!onClick;
+  const sourceLabel = source ? (SOURCE_LABELS[source] ?? source) : "—";
+  const age = relativeAge(ts);
+  const showDate = formatShowDate(show_id);
+  const trackLabel = track_index != null ? `track ${track_index}` : "—";
+
+  return (
+    <div
+      onClick={onClick}
+      className={`bg-deadly-surface rounded-lg text-sm ${
+        interactive ? "cursor-pointer hover:bg-zinc-800 transition-colors" : ""
+      }`}
+    >
+      {/* Mobile: stacked two-line card */}
+      <div className="sm:hidden px-3 py-2 flex flex-col gap-1.5">
+        <div className="flex items-center gap-2">
+          <span className="inline-flex items-center gap-1 shrink-0" title={iid}>
+            <span>{emojiForId(iid)}</span>
+            <span className="font-mono text-xs text-zinc-400">
+              {iid.slice(0, 8)}
+            </span>
+          </span>
+          <span className="text-zinc-300 ml-1">{showDate}</span>
+          <span className="font-mono text-xs text-zinc-500 ml-auto tabular-nums">
+            {age}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-xs text-zinc-500 truncate shrink-0">
+            {sourceLabel} · {trackLabel}
+          </span>
+          <div className="ml-auto min-w-0">
+            <TrackOutcomeBar tracks={tracks} totalTracks={totalTracks} compact />
+          </div>
+        </div>
+      </div>
+
+      {/* Desktop: single horizontal row */}
+      <div className="hidden sm:flex items-center gap-3 px-2 py-1.5">
+        <span
+          className="inline-flex items-center gap-1 shrink-0 w-24"
+          title={iid}
+        >
+          <span>{emojiForId(iid)}</span>
+          <span className="font-mono text-xs text-zinc-400">
+            {iid.slice(0, 8)}
+          </span>
+        </span>
+        <span className="font-mono text-xs text-zinc-500 w-20 shrink-0 tabular-nums">
+          {age}
+        </span>
+        <span className="text-zinc-300 w-24 shrink-0">{showDate}</span>
+        <span className="text-zinc-500 w-14 shrink-0">{trackLabel}</span>
+        <span className="text-zinc-500 w-24 shrink-0 truncate">
+          {sourceLabel}
+        </span>
+        <TrackOutcomeBar tracks={tracks} totalTracks={totalTracks} />
+        <span className="text-xs text-zinc-600 ml-auto truncate shrink-0">
+          {platform} {app_version}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/app/admin/analytics/components/listeningRow.tsx
+++ b/ui/src/app/admin/analytics/components/listeningRow.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { emojiForId } from "./emojiId";
+import { useWatchedInstalls } from "./WatchedInstallsContext";
 
 export type TrackOutcome = "complete" | "skipped" | "error" | "partial";
 
@@ -173,25 +174,59 @@ export function ListeningRow({
   const sourceLabel = source ? (SOURCE_LABELS[source] ?? source) : "—";
   const age = relativeAge(ts);
   const trackLabel = track_index != null ? `track ${track_index}` : "—";
+  const { isWatched, nameFor, setWatched, unwatch } = useWatchedInstalls();
+  const watched = isWatched(iid);
+  const friendlyName = nameFor(iid);
+
+  const toggleWatch = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (watched) unwatch(iid);
+    else setWatched(iid, null, null);
+  };
+
+  const StarButton = (
+    <button
+      onClick={toggleWatch}
+      title={watched ? "Stop watching" : "Watch this install"}
+      className={`shrink-0 w-4 text-center leading-none transition-colors ${
+        watched
+          ? "text-amber-400 hover:text-amber-300"
+          : "text-zinc-600 hover:text-amber-300"
+      }`}
+      aria-label={watched ? "Unwatch" : "Watch"}
+    >
+      {watched ? "★" : "☆"}
+    </button>
+  );
 
   return (
     <div
       onClick={onClick}
       className={`bg-deadly-surface rounded-lg text-sm ${
         interactive ? "cursor-pointer hover:bg-zinc-800 transition-colors" : ""
-      }`}
+      } ${watched ? "ring-1 ring-amber-500/40" : ""}`}
     >
       {/* Mobile: stacked two-line card */}
       <div className="sm:hidden px-3 py-2 flex flex-col gap-1.5">
-        <div className="flex items-center gap-2">
-          <span className="inline-flex items-center gap-1 shrink-0" title={iid}>
-            <span>{emojiForId(iid)}</span>
-            <span className="font-mono text-xs text-zinc-400">
-              {iid.slice(0, 8)}
-            </span>
+        <div className="flex items-center gap-2 min-w-0">
+          <span
+            className="inline-flex items-center gap-1 min-w-0 flex-1"
+            title={iid}
+          >
+            {StarButton}
+            <span className="shrink-0">{emojiForId(iid)}</span>
+            {friendlyName ? (
+              <span className="text-zinc-200 truncate min-w-0">
+                {friendlyName}
+              </span>
+            ) : (
+              <span className="font-mono text-xs text-zinc-400 shrink-0">
+                {iid.slice(0, 8)}
+              </span>
+            )}
           </span>
-          <ShowDateLink showId={show_id} className="text-zinc-300 ml-1" />
-          <span className="font-mono text-xs text-zinc-500 ml-auto tabular-nums">
+          <ShowDateLink showId={show_id} className="text-zinc-300 shrink-0" />
+          <span className="font-mono text-xs text-zinc-500 shrink-0 tabular-nums">
             {age}
           </span>
         </div>
@@ -208,13 +243,20 @@ export function ListeningRow({
       {/* Desktop: single horizontal row */}
       <div className="hidden sm:flex items-center gap-3 px-2 py-1.5">
         <span
-          className="inline-flex items-center gap-1 shrink-0 w-24"
+          className="inline-flex items-center gap-1 shrink-0 w-40"
           title={iid}
         >
-          <span>{emojiForId(iid)}</span>
-          <span className="font-mono text-xs text-zinc-400">
-            {iid.slice(0, 8)}
-          </span>
+          {StarButton}
+          <span className="shrink-0">{emojiForId(iid)}</span>
+          {friendlyName ? (
+            <span className="text-zinc-200 truncate min-w-0">
+              {friendlyName}
+            </span>
+          ) : (
+            <span className="font-mono text-xs text-zinc-400 shrink-0">
+              {iid.slice(0, 8)}
+            </span>
+          )}
         </span>
         <span className="font-mono text-xs text-zinc-500 w-20 shrink-0 tabular-nums">
           {age}


### PR DESCRIPTION
## Summary

Three major analytics admin improvements, plus mobile-friendliness work and several bug fixes.

### Recent Listening panel
- New collapsible panel below Listening Now showing finished listening sessions in the last 24h.
- Deduped by `(iid, show_id)` so a single user/show pair collapses across multiple app sessions; `session_count` exposed for visibility.
- Server query at `/api/analytics/recent-listening?hours=N&limit=N` and a `buildTrackBitmap` helper shared with Listening Now.
- Capped at 10 visible rows with a "Show more" expander.

### Detail views are now real pages
- `/admin/analytics?install=<iid>` and `?metric=<key>&filter=<value>` replace the bottom-sheet modals.
- No more `position: fixed` width / scroll-bleed / "panel too wide" issues; browser back works; URLs are deep-linkable.
- Dashboard scroll position is preserved on back-navigation by polling for content height before restoring `scrollY`.

### Per-install profile (new)
- Install detail page has Overview / Events tabs. Overview mirrors the main dashboard scoped to one iid: meta grid, Recent plays (same `ListeningRow` with bitmap, deduped by show), Top shows played (TopShowsList card style with image / venue / completion %), Plays by source, Recent searches, Features used (shared `FeatureAdoption` component bucketed by `props.category`), Recent errors.
- Everything aggregated client-side from `/api/analytics/install/<iid>` — no new endpoints.

### Watched installs (new)
- New `watched_installs(iid PK, name, notes, watched_at)` table + admin routes `GET/PUT/DELETE /api/analytics/watched[/:iid]`.
- React context (`WatchedInstallsProvider`) exposes `isWatched`, `nameFor`, `setWatched`, `unwatch` to every row.
- Clickable ★/☆ in every row (Listening Now, Recent Listening, Metric detail). Tap toggles watch state inline; friendly name (when set) replaces the short iid; alignment is preserved with a fixed-width star slot.
- Install detail page has a Watch toggle next to the heading; first-watch opens an inline name input.
- "Watched installs" panel at top of dashboard listing all flagged installs with name + unwatch.
- Page-wide "★ Watched" toggle in dashboard header collapses the page to iid-scoped panels filtered to watched installs and hides aggregate sections.

### Fixes
- **Listening Now dedup**: a user can only listen to one thing at a time, but the unmatched-`playback_start` filter would surface ghost starts from rapid show switches / force-quits / crashes. Now takes only the most recent unmatched start per iid.
- **Listening Now mobile rows**: stacked two-line card on `< sm`, original horizontal row on `sm+`; no more horizontal overflow.
- **Event timeline ordering**: events inside each session group are now ordered most-recent-first, matching outer session ordering.
- **Show links** across analytics panels: Listening Now / Recent Listening row dates, Top Shows entries, and Show Engagement entries now link to `/shows/<id>` in a new tab (click propagation stopped so the row's existing tap target is preserved).

## Test plan
- [ ] `/admin/analytics` renders with new Recent Listening panel below Listening Now
- [ ] Tap a row in Recent Listening — lands at `/admin/analytics?install=<iid>` with Overview tab
- [ ] Overview shows recent plays with bitmap, top shows with images, plays-by-source bars, search history, features
- [ ] Switch to Events tab — timeline shows by-session, with most-recent-first inside each group
- [ ] Tap ★ next to the heading — flag the install + name prompt appears
- [ ] Back to dashboard via "← Back" — scroll position preserved
- [ ] Tap ☆ in any row — install becomes watched, ★ lights up; alignment unchanged
- [ ] Toggle "★ Watched" in header — aggregate panels hide; Listening Now + Recent Listening filter to watched only
- [ ] Long show ids no longer cause horizontal overflow on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)