### PR TITLE
fix(android/auto): don't clobber live session on app re-launch (DEAD-229)

### DIFF
--- a/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/repository/MediaControllerRepository.kt
+++ b/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/repository/MediaControllerRepository.kt
@@ -25,10 +25,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import android.net.Uri
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -967,6 +969,23 @@ class MediaControllerRepository @Inject constructor(
         }
     }
     
+    /**
+     * Wait briefly for connection, then report whether the session already has
+     * a queue loaded (e.g. the service survived from a prior Android Auto
+     * session). Used by app-launch restore paths to avoid clobbering live
+     * playback with a stale snapshot from SharedPreferences.
+     */
+    suspend fun hasActiveQueue(timeoutMs: Long = 3000L): Boolean {
+        withTimeoutOrNull(timeoutMs) {
+            connectionState.first {
+                it == ConnectionState.Connected || it == ConnectionState.Failed
+            }
+        }
+        return withContext(Dispatchers.Main) {
+            (mediaController?.mediaItemCount ?: 0) > 0
+        }
+    }
+
     /**
      * Get current MediaItems from the queue for hydration
      * Must be called from the main thread (MediaController requirement)

--- a/androidApp/core/miniplayer/src/main/java/com/grateful/deadly/core/miniplayer/LastPlayedTrackService.kt
+++ b/androidApp/core/miniplayer/src/main/java/com/grateful/deadly/core/miniplayer/LastPlayedTrackService.kt
@@ -138,12 +138,23 @@ class LastPlayedTrackService @Inject constructor(
      */
     suspend fun restoreLastPlayedTrack() {
         try {
+            // If the MediaSession service survived from a prior session (e.g.
+            // user was on Android Auto, exited the car without pausing, then
+            // tapped the phone notification), a queue is already loaded. Calling
+            // playTrack here would clobber it via setMediaItems+prepare, jumping
+            // to the slightly-stale SharedPreferences snapshot and replacing the
+            // live artwork with the ArtworkProvider fallback (DEAD-229).
+            if (mediaControllerRepository.hasActiveQueue()) {
+                Log.d(TAG, "Active session already has a queue — skipping restore")
+                return
+            }
+
             val lastTrack = getLastPlayedTrack()
             if (lastTrack == null) {
                 Log.d(TAG, "No last played track to restore")
                 return
             }
-            
+
             Log.d(TAG, "Restoring last played track: ${lastTrack.trackTitle}")
             
             // Load track into MediaController with exact position (without auto-playing)


### PR DESCRIPTION
## Summary
- Fixes DEAD-229: tapping the phone notification after exiting the car (without pausing) jumped playback back to a prior track and showed wrong album art.
- Root cause: `AppViewModel.init` unconditionally called `LastPlayedTrackService.restoreLastPlayedTrack()`, which invoked `playTrack` → `setMediaItems` + `prepare` on the live MediaController. That clobbered the in-flight queue with the last SharedPreferences snapshot (stale by up to a few seconds) and replaced live artwork with the `ArtworkProvider` fallback (since `coverImageUrl` isn't stored in the saved state).
- Fix: add `MediaControllerRepository.hasActiveQueue()` and short-circuit `restoreLastPlayedTrack()` when the controller already has items loaded.

## Test plan
- [x] `./gradlew assembleDebug` builds clean.
- [x] Verified on Pixel 6 in real Android Auto session: notification tap now keeps the live track + correct art instead of skipping back.
- [ ] In-car regression check on a longer drive (multi-track playback, exit + re-enter cycles).

Note: local DHU repro was blocked by the [known Android 16 Android Auto regression](https://9to5google.com/2025/11/04/some-android-auto-users-report-issues-after-updating-to-android-16/) — DHU TCP accept then immediate disconnect on the phone side. Verification was done in-car instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)