### PR TITLE
feat(android/auto): autoplay/resume via onPlaybackResumption (DEAD-336)

### DIFF
--- a/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/service/DeadlyMediaSessionService.kt
+++ b/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/service/DeadlyMediaSessionService.kt
@@ -581,6 +581,40 @@ class DeadlyMediaSessionService : MediaLibraryService() {
             return Futures.immediateFuture(LibraryResult.ofItemList(paged, params))
         }
 
+        // Called by Android Auto, system media resume cards (Android 12+),
+        // Wear OS, and Assistant when the user (or AA's auto-resume setting)
+        // wants to resume playback after the app has been killed. Returning
+        // the last queue + position lets these surfaces show a resumable
+        // session; whether playback starts automatically is controlled by
+        // the requesting surface (e.g. Android Auto's own auto-resume toggle),
+        // matching Spotify/YT Music behaviour.
+        override fun onPlaybackResumption(
+            mediaSession: MediaSession,
+            controller: MediaSession.ControllerInfo
+        ): ListenableFuture<MediaSession.MediaItemsWithStartPosition> = serviceScope.future {
+            Log.d(TAG, "[RESUME] onPlaybackResumption from ${controller.packageName}")
+            val prefs = getSharedPreferences("last_played_track", MODE_PRIVATE)
+            val showId = prefs.getString("show_id", null)
+            val recordingId = prefs.getString("recording_id", null)
+            val format = prefs.getString("selected_format", null)
+            if (showId == null || recordingId == null || format == null) {
+                Log.d(TAG, "[RESUME] No last-played session, declining resume")
+                throw UnsupportedOperationException("No resumable session")
+            }
+            val trackIndex = prefs.getInt("track_index", 0)
+            val positionMs = prefs.getLong("position_ms", 0L)
+            val tracks = browseTreeProvider.resolveRecordingToPlayableTracks(
+                showId, recordingId, format
+            )
+            if (tracks.isEmpty()) {
+                Log.w(TAG, "[RESUME] No tracks resolved for $showId/$recordingId")
+                throw UnsupportedOperationException("No tracks resolved")
+            }
+            val safeIndex = trackIndex.coerceIn(0, tracks.size - 1)
+            Log.d(TAG, "[RESUME] Returning ${tracks.size} tracks, idx=$safeIndex, pos=${positionMs}ms")
+            MediaSession.MediaItemsWithStartPosition(tracks, safeIndex, positionMs)
+        }
+
         override fun onSetMediaItems(
             mediaSession: MediaSession,
             controller: MediaSession.ControllerInfo,


### PR DESCRIPTION
## Summary
- Override `MediaLibrarySession.Callback.onPlaybackResumption` to return the last queue + position from `last_played_track` prefs.
- Enables Android Auto auto-resume on car connect (gated by AA's own setting), lock-screen media resume cards, Wear OS resume, and Assistant resume.
- No in-app toggle needed — each surface honors its own user setting, matching Spotify/YT Music.

Fixes DEAD-336.

## Why this shape
The Reddit-reported "autoplay doesn't work" bug was caused by us never exposing a resumable session to the system. `onPlaybackResumption` is the standard hook for AA / system media resume / Wear; returning `MediaItemsWithStartPosition` lets those surfaces decide whether to autoplay or show a tap-to-resume control. Phone-call resume is unaffected (separate AudioFocus codepath).

## Test plan
- [x] Play a show, kill the app, connect Android Auto with AA's "auto-resume media in car" **on** → last queue resumes and plays.
- [x] Same scenario with AA's setting **off** → car shows a tap-to-resume control, doesn't autoplay.
- [ ] After killing the app with a last-played track, Android 12+ lock screen shows a resumable media card for The Deadly.
- [ ] Phone call during playback → playback pauses and resumes as before (no regression in AudioFocus handling).
- [ ] First launch with no last-played track → AA / lock screen don't show a stale resume entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)