### PR TITLE
fix(android/auto): seed controller state on connect to restore MiniPlayer (DEAD-360)

### DIFF
--- a/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/repository/MediaControllerRepository.kt
+++ b/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/repository/MediaControllerRepository.kt
@@ -635,7 +635,32 @@ class MediaControllerRepository @Inject constructor(
                     })
                     
                     Log.d(TAG, "MediaController connected successfully")
-                    
+
+                    // Seed state flows from the controller's existing state.
+                    // Player.Listener callbacks do not replay current state on
+                    // attach, so when we connect to a session that already has
+                    // a queue loaded (e.g. AA started playback via
+                    // onPlaybackResumption while the phone was asleep, or the
+                    // service survived an app re-launch), nothing fires and
+                    // _currentRecordingId stays null — which keeps the MiniPlayer
+                    // hidden even though playback is live (DEAD-360).
+                    val initialItem = controller.currentMediaItem
+                    if (initialItem != null) {
+                        _currentMediaItem.value = initialItem
+                        _currentTrack.value = controller.mediaMetadata
+                        _currentShowId.value = extractShowIdFromMediaItem(initialItem)
+                        _currentRecordingId.value = extractRecordingIdFromMediaItem(initialItem)
+                        _currentTrackIndex.value = controller.currentMediaItemIndex
+                        _mediaItemCount.value = controller.mediaItemCount
+                        _isPlaying.value = controller.isPlaying
+                        currentIsPlaying = controller.isPlaying
+                        currentExoPlayerState = controller.playbackState
+                        _duration.value = controller.duration.coerceAtLeast(0L)
+                        _currentPosition.value = controller.currentPosition.coerceAtLeast(0L)
+                        updatePlaybackState()
+                        Log.d(TAG, "Seeded state from existing controller: show=${_currentShowId.value}, rec=${_currentRecordingId.value}, idx=${_currentTrackIndex.value}, count=${_mediaItemCount.value}, isPlaying=${controller.isPlaying}")
+                    }
+
                     // Start position updater for MiniPlayer
                     startPositionUpdater()
                     


### PR DESCRIPTION
## Summary
- When AA starts playback via `onPlaybackResumption` while the phone is asleep (or the service survives an app re-launch), opening the app left the MiniPlayer hidden even though the notification and playback were live.
- Root cause: `MediaControllerRepository.connectToService()` only attaches a `Player.Listener` after binding. Media3 listeners do **not** replay current state on attach, so `_currentRecordingId` / `_currentTrack` stayed null and `CurrentTrackInfo` was null. The DEAD-229 short-circuit in `LastPlayedTrackService` (correctly) skips the `playTrack` call that previously seeded those flows via a transition.
- Fix: after connect, if `controller.currentMediaItem != null`, seed the state flows from the controller's current state. No `setMediaItems` / `prepare`, so the DEAD-229 live-queue protection is preserved.

## Test plan
- [x] Verified end-to-end on Pixel 6: AA starts playback while phone asleep → open phone app → MiniPlayer appears. Log confirms `Active session already has a queue — skipping restore` fires and state seeds from controller.
- [ ] In-app play → background → tap notification → MiniPlayer shows live track (DEAD-229 regression).
- [ ] Cold-launch with saved last-played track but no AA → MiniPlayer shows saved track.
- [ ] Fresh install, no playback → no MiniPlayer.
- [ ] Skip tracks in AA, then open app → MiniPlayer reflects current track (listener transitions still wired post-seed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)