### PR TITLE
feat(mobile/home): trending shows + home polish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,13 @@ docker-redeploy: docker-destroy docker-up
 # Destroy + rebuild + start + tail logs
 docker-redeploy-logs: docker-redeploy docker-logs
 
-# Run API locally without Docker (for quick iteration)
+# Run API locally without Docker (for quick iteration).
+# Reads analytics/users from ./api-data so `make db-pull-analytics` and
+# `make db-restore` land where dev actually looks.
 api-dev:
-	cd api && npm run dev
+	cd api && ANALYTICS_DB_PATH=$(PWD)/api-data/analytics.db \
+		USERS_DB_PATH=$(PWD)/api-data/users.db \
+		npm run dev
 
 # Install API dependencies
 api-install:

--- a/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/HomeService.kt
+++ b/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/HomeService.kt
@@ -38,6 +38,10 @@ data class HomeContent(
     val recentShows: List<Show>,
     val todayInHistory: List<Show>,
     val featuredCollections: List<DeadCollection>,
+    /** Shows for the user's currently-selected trending window. */
+    val trendingShows: List<Show>,
+    /** Which window [trendingShows] came from — drives section subtitle / docs. */
+    val trendingWindow: TrendingWindow,
     val lastRefresh: Long
 ) {
     companion object {
@@ -45,6 +49,8 @@ data class HomeContent(
             recentShows = emptyList(),
             todayInHistory = emptyList(),
             featuredCollections = emptyList(),
+            trendingShows = emptyList(),
+            trendingWindow = TrendingWindow.NOW,
             lastRefresh = 0L
         )
     }

--- a/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/HomeService.kt
+++ b/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/HomeService.kt
@@ -27,6 +27,9 @@ interface HomeService {
      * @return Result indicating success or failure with error details
      */
     suspend fun refreshAll(): Result<Unit>
+
+    /** Advance the trending window preference one step (Day → Week → Month → All → Day). */
+    fun cycleTrendingWindow()
 }
 
 /**
@@ -42,6 +45,8 @@ data class HomeContent(
     val trendingShows: List<Show>,
     /** Which window [trendingShows] came from — drives section subtitle / docs. */
     val trendingWindow: TrendingWindow,
+    /** When true, Trending renders above Today in History; otherwise below. */
+    val trendingAboveToday: Boolean,
     val lastRefresh: Long
 ) {
     companion object {
@@ -51,6 +56,7 @@ data class HomeContent(
             featuredCollections = emptyList(),
             trendingShows = emptyList(),
             trendingWindow = TrendingWindow.NOW,
+            trendingAboveToday = true,
             lastRefresh = 0L
         )
     }

--- a/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/HomeService.kt
+++ b/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/HomeService.kt
@@ -49,6 +49,12 @@ data class HomeContent(
     val trendingAboveToday: Boolean,
     /** How many rows of Recently Played to render (1..4). Each row = 2 shows. */
     val recentRows: Int,
+    /** Card size for the Trending carousel: "small" or "large". */
+    val trendingCardSize: String,
+    /** Card size for the Today In History carousel: "small" or "large". */
+    val todayCardSize: String,
+    /** Card size for the Featured Collections carousel: "small" or "large". */
+    val collectionsCardSize: String,
     val lastRefresh: Long
 ) {
     companion object {
@@ -60,6 +66,9 @@ data class HomeContent(
             trendingWindow = TrendingWindow.NOW,
             trendingAboveToday = false,
             recentRows = 2,
+            trendingCardSize = "small",
+            todayCardSize = "large",
+            collectionsCardSize = "large",
             lastRefresh = 0L
         )
     }

--- a/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/HomeService.kt
+++ b/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/HomeService.kt
@@ -56,7 +56,7 @@ data class HomeContent(
             featuredCollections = emptyList(),
             trendingShows = emptyList(),
             trendingWindow = TrendingWindow.NOW,
-            trendingAboveToday = true,
+            trendingAboveToday = false,
             lastRefresh = 0L
         )
     }

--- a/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/HomeService.kt
+++ b/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/HomeService.kt
@@ -47,6 +47,8 @@ data class HomeContent(
     val trendingWindow: TrendingWindow,
     /** When true, Trending renders above Today in History; otherwise below. */
     val trendingAboveToday: Boolean,
+    /** How many rows of Recently Played to render (1..4). Each row = 2 shows. */
+    val recentRows: Int,
     val lastRefresh: Long
 ) {
     companion object {
@@ -57,6 +59,7 @@ data class HomeContent(
             trendingShows = emptyList(),
             trendingWindow = TrendingWindow.NOW,
             trendingAboveToday = false,
+            recentRows = 2,
             lastRefresh = 0L
         )
     }

--- a/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/TrendingService.kt
+++ b/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/TrendingService.kt
@@ -26,6 +26,14 @@ enum class TrendingWindow {
         ALL -> "All"
     }
 
+    /** Label suffix used in the dynamic home title "Trending <titleLabel>". */
+    val titleLabel: String get() = when (this) {
+        NOW -> "now"
+        WEEK -> "this week"
+        MONTH -> "this month"
+        ALL -> "all time"
+    }
+
     /** Persisted preference key. Stable across renames of shortLabel. */
     val key: String get() = when (this) {
         NOW -> "now"

--- a/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/TrendingService.kt
+++ b/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/TrendingService.kt
@@ -15,7 +15,42 @@ interface TrendingService {
     suspend fun refresh(): Result<Unit>
 }
 
-enum class TrendingWindow { NOW, WEEK, MONTH, ALL }
+enum class TrendingWindow {
+    NOW, WEEK, MONTH, ALL;
+
+    /** Short label rendered on the home chip. */
+    val shortLabel: String get() = when (this) {
+        NOW -> "Day"
+        WEEK -> "Week"
+        MONTH -> "Month"
+        ALL -> "All"
+    }
+
+    /** Persisted preference key. Stable across renames of shortLabel. */
+    val key: String get() = when (this) {
+        NOW -> "now"
+        WEEK -> "week"
+        MONTH -> "month"
+        ALL -> "all"
+    }
+
+    /** Next window in cycle order. ALL wraps back to NOW. */
+    fun next(): TrendingWindow = when (this) {
+        NOW -> WEEK
+        WEEK -> MONTH
+        MONTH -> ALL
+        ALL -> NOW
+    }
+
+    companion object {
+        fun fromKey(key: String): TrendingWindow = when (key) {
+            "week" -> WEEK
+            "month" -> MONTH
+            "all" -> ALL
+            else -> NOW
+        }
+    }
+}
 
 data class TrendingContent(
     val now: List<Show>,

--- a/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/TrendingService.kt
+++ b/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/TrendingService.kt
@@ -1,0 +1,43 @@
+package com.grateful.deadly.core.api.home
+
+import com.grateful.deadly.core.model.Show
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Trending shows for the home screen across four time windows.
+ *
+ * Backed by /api/trending which returns the most-played shows per window;
+ * the implementation hydrates those show IDs into full Show objects from
+ * the local catalog so callers only deal in domain models.
+ */
+interface TrendingService {
+    val trending: StateFlow<TrendingContent>
+    suspend fun refresh(): Result<Unit>
+}
+
+enum class TrendingWindow { NOW, WEEK, MONTH, ALL }
+
+data class TrendingContent(
+    val now: List<Show>,
+    val week: List<Show>,
+    val month: List<Show>,
+    val all: List<Show>,
+    val lastRefresh: Long,
+) {
+    fun forWindow(window: TrendingWindow): List<Show> = when (window) {
+        TrendingWindow.NOW -> now
+        TrendingWindow.WEEK -> week
+        TrendingWindow.MONTH -> month
+        TrendingWindow.ALL -> all
+    }
+
+    companion object {
+        fun initial() = TrendingContent(
+            now = emptyList(),
+            week = emptyList(),
+            month = emptyList(),
+            all = emptyList(),
+            lastRefresh = 0L,
+        )
+    }
+}

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
@@ -58,7 +58,7 @@ class AppPreferences @Inject constructor(
     }
 
     private val _homeTrendingAboveToday = MutableStateFlow(
-        prefs.getBoolean(KEY_HOME_TRENDING_ABOVE_TODAY, true)
+        prefs.getBoolean(KEY_HOME_TRENDING_ABOVE_TODAY, false)
     )
 
     /** When true, the Trending section renders above Today in History; otherwise below. */

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
@@ -54,6 +54,19 @@ class AppPreferences @Inject constructor(
         private const val KEY_DEVELOPER_MODE_UNLOCKED = "developer_mode_unlocked"
         private const val KEY_PLAYER_CONTROLS_STYLE = "player_controls_style"
         private const val KEY_HOME_TRENDING_WINDOW = "home_trending_window"
+        private const val KEY_HOME_TRENDING_ABOVE_TODAY = "home_trending_above_today"
+    }
+
+    private val _homeTrendingAboveToday = MutableStateFlow(
+        prefs.getBoolean(KEY_HOME_TRENDING_ABOVE_TODAY, true)
+    )
+
+    /** When true, the Trending section renders above Today in History; otherwise below. */
+    val homeTrendingAboveToday: StateFlow<Boolean> = _homeTrendingAboveToday.asStateFlow()
+
+    fun setHomeTrendingAboveToday(value: Boolean) {
+        prefs.edit().putBoolean(KEY_HOME_TRENDING_ABOVE_TODAY, value).apply()
+        _homeTrendingAboveToday.value = value
     }
 
     private val _homeTrendingWindow = MutableStateFlow(

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
@@ -55,6 +55,7 @@ class AppPreferences @Inject constructor(
         private const val KEY_PLAYER_CONTROLS_STYLE = "player_controls_style"
         private const val KEY_HOME_TRENDING_WINDOW = "home_trending_window"
         private const val KEY_HOME_TRENDING_ABOVE_TODAY = "home_trending_above_today"
+        private const val KEY_HOME_RECENT_ROWS = "home_recent_rows"
     }
 
     private val _homeTrendingAboveToday = MutableStateFlow(
@@ -67,6 +68,19 @@ class AppPreferences @Inject constructor(
     fun setHomeTrendingAboveToday(value: Boolean) {
         prefs.edit().putBoolean(KEY_HOME_TRENDING_ABOVE_TODAY, value).apply()
         _homeTrendingAboveToday.value = value
+    }
+
+    private val _homeRecentRows = MutableStateFlow(
+        prefs.getInt(KEY_HOME_RECENT_ROWS, 2).coerceIn(1, 4)
+    )
+
+    /** How many rows of Recently Played to render on the home screen (1..4). Each row holds 2 shows. */
+    val homeRecentRows: StateFlow<Int> = _homeRecentRows.asStateFlow()
+
+    fun setHomeRecentRows(value: Int) {
+        val clamped = value.coerceIn(1, 4)
+        prefs.edit().putInt(KEY_HOME_RECENT_ROWS, clamped).apply()
+        _homeRecentRows.value = clamped
     }
 
     private val _homeTrendingWindow = MutableStateFlow(

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
@@ -56,6 +56,46 @@ class AppPreferences @Inject constructor(
         private const val KEY_HOME_TRENDING_WINDOW = "home_trending_window"
         private const val KEY_HOME_TRENDING_ABOVE_TODAY = "home_trending_above_today"
         private const val KEY_HOME_RECENT_ROWS = "home_recent_rows"
+        private const val KEY_HOME_TRENDING_CARD_SIZE = "home_trending_card_size"
+        private const val KEY_HOME_TODAY_CARD_SIZE = "home_today_card_size"
+        private const val KEY_HOME_COLLECTIONS_CARD_SIZE = "home_collections_card_size"
+    }
+
+    private val _homeTrendingCardSize = MutableStateFlow(
+        prefs.getString(KEY_HOME_TRENDING_CARD_SIZE, null) ?: "small"
+    )
+    val homeTrendingCardSize: StateFlow<String> = _homeTrendingCardSize.asStateFlow()
+    fun setHomeTrendingCardSize(value: String) {
+        prefs.edit().putString(KEY_HOME_TRENDING_CARD_SIZE, value).apply()
+        _homeTrendingCardSize.value = value
+    }
+
+    private val _homeTodayCardSize = MutableStateFlow(
+        prefs.getString(KEY_HOME_TODAY_CARD_SIZE, null) ?: "large"
+    )
+    val homeTodayCardSize: StateFlow<String> = _homeTodayCardSize.asStateFlow()
+    fun setHomeTodayCardSize(value: String) {
+        prefs.edit().putString(KEY_HOME_TODAY_CARD_SIZE, value).apply()
+        _homeTodayCardSize.value = value
+    }
+
+    private val _homeCollectionsCardSize = MutableStateFlow(
+        prefs.getString(KEY_HOME_COLLECTIONS_CARD_SIZE, null) ?: "large"
+    )
+    val homeCollectionsCardSize: StateFlow<String> = _homeCollectionsCardSize.asStateFlow()
+    fun setHomeCollectionsCardSize(value: String) {
+        prefs.edit().putString(KEY_HOME_COLLECTIONS_CARD_SIZE, value).apply()
+        _homeCollectionsCardSize.value = value
+    }
+
+    /** Restore all Home Screen preferences to defaults. */
+    fun resetHomePreferences() {
+        setHomeTrendingWindow("now")
+        setHomeTrendingAboveToday(false)
+        setHomeRecentRows(2)
+        setHomeTrendingCardSize("small")
+        setHomeTodayCardSize("large")
+        setHomeCollectionsCardSize("large")
     }
 
     private val _homeTrendingAboveToday = MutableStateFlow(

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
@@ -53,6 +53,19 @@ class AppPreferences @Inject constructor(
         private const val KEY_HAS_ADDED_FAVORITE = "has_added_favorite"
         private const val KEY_DEVELOPER_MODE_UNLOCKED = "developer_mode_unlocked"
         private const val KEY_PLAYER_CONTROLS_STYLE = "player_controls_style"
+        private const val KEY_HOME_TRENDING_WINDOW = "home_trending_window"
+    }
+
+    private val _homeTrendingWindow = MutableStateFlow(
+        prefs.getString(KEY_HOME_TRENDING_WINDOW, null) ?: "now"
+    )
+
+    /** Which trending window the home screen shows. One of "now"/"week"/"month"/"all". */
+    val homeTrendingWindow: StateFlow<String> = _homeTrendingWindow.asStateFlow()
+
+    fun setHomeTrendingWindow(value: String) {
+        prefs.edit().putString(KEY_HOME_TRENDING_WINDOW, value).apply()
+        _homeTrendingWindow.value = value
     }
 
     private val _includeShowsWithoutRecordings = MutableStateFlow(

--- a/androidApp/core/home/build.gradle.kts
+++ b/androidApp/core/home/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     implementation(project(":core:api:recent"))
     implementation(project(":core:model"))
     implementation(project(":core:domain"))
+    implementation(project(":core:database"))
     
     // Hilt
     implementation("com.google.dagger:hilt-android:2.56.1")

--- a/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/HomeServiceImpl.kt
+++ b/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/HomeServiceImpl.kt
@@ -50,20 +50,29 @@ class HomeServiceImpl @Inject constructor(
     private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     
     // Reactive combination of all home content sources
+    // Pair the two preference flows so the main combine stays at 5 args
+    // (Flow.combine's typed overloads top out at 5).
+    private val trendingPrefs = combine(
+        appPreferences.homeTrendingWindow,
+        appPreferences.homeTrendingAboveToday,
+    ) { windowKey, aboveToday -> windowKey to aboveToday }
+
     override val homeContent: StateFlow<HomeContent> = combine(
         recentShowsService.recentShows,
         loadTodayInHistoryFlow(),
         collectionsService.featuredCollections,
         trendingService.trending,
-        appPreferences.homeTrendingWindow
-    ) { recentShows, todayInHistory, featuredCollections, trending, windowKey ->
-        val window = parseWindow(windowKey)
+        trendingPrefs
+    ) { recentShows, todayInHistory, featuredCollections, trending, prefs ->
+        val (windowKey, aboveToday) = prefs
+        val window = TrendingWindow.fromKey(windowKey)
         HomeContent(
             recentShows = recentShows,
             todayInHistory = todayInHistory,
             featuredCollections = featuredCollections,
             trendingShows = trending.forWindow(window),
             trendingWindow = window,
+            trendingAboveToday = aboveToday,
             lastRefresh = System.currentTimeMillis()
         )
     }.stateIn(
@@ -76,12 +85,6 @@ class HomeServiceImpl @Inject constructor(
         Log.d(TAG, "HomeServiceImpl initialized with reactive RecentShowsService integration")
     }
 
-    private fun parseWindow(key: String): TrendingWindow = when (key) {
-        "week" -> TrendingWindow.WEEK
-        "month" -> TrendingWindow.MONTH
-        "all" -> TrendingWindow.ALL
-        else -> TrendingWindow.NOW
-    }
     
     /**
      * Reactive flow for today in history shows
@@ -109,6 +112,11 @@ class HomeServiceImpl @Inject constructor(
         return showRepository.getShowsForDate(today.monthValue, today.dayOfMonth)
     }
     
+    override fun cycleTrendingWindow() {
+        val current = TrendingWindow.fromKey(appPreferences.homeTrendingWindow.value)
+        appPreferences.setHomeTrendingWindow(current.next().key)
+    }
+
     override suspend fun refreshAll(): Result<Unit> {
         Log.d(TAG, "refreshAll() called - reactive flows will auto-refresh")
         

--- a/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/HomeServiceImpl.kt
+++ b/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/HomeServiceImpl.kt
@@ -52,12 +52,31 @@ class HomeServiceImpl @Inject constructor(
     // Reactive combination of all home content sources
     // Bundle the preference flows so the main combine stays at 5 args
     // (Flow.combine's typed overloads top out at 5).
-    private data class HomePrefs(val windowKey: String, val aboveToday: Boolean, val recentRows: Int)
+    private data class HomePrefs(
+        val windowKey: String,
+        val aboveToday: Boolean,
+        val recentRows: Int,
+        val trendingCardSize: String,
+        val todayCardSize: String,
+        val collectionsCardSize: String,
+    )
     private val homePrefs = combine(
         appPreferences.homeTrendingWindow,
         appPreferences.homeTrendingAboveToday,
         appPreferences.homeRecentRows,
-    ) { windowKey, aboveToday, recentRows -> HomePrefs(windowKey, aboveToday, recentRows) }
+        appPreferences.homeTrendingCardSize,
+        appPreferences.homeTodayCardSize,
+        appPreferences.homeCollectionsCardSize,
+    ) { values ->
+        HomePrefs(
+            windowKey = values[0] as String,
+            aboveToday = values[1] as Boolean,
+            recentRows = values[2] as Int,
+            trendingCardSize = values[3] as String,
+            todayCardSize = values[4] as String,
+            collectionsCardSize = values[5] as String,
+        )
+    }
 
     override val homeContent: StateFlow<HomeContent> = combine(
         recentShowsService.recentShows,
@@ -75,6 +94,9 @@ class HomeServiceImpl @Inject constructor(
             trendingWindow = window,
             trendingAboveToday = prefs.aboveToday,
             recentRows = prefs.recentRows,
+            trendingCardSize = prefs.trendingCardSize,
+            todayCardSize = prefs.todayCardSize,
+            collectionsCardSize = prefs.collectionsCardSize,
             lastRefresh = System.currentTimeMillis()
         )
     }.stateIn(

--- a/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/HomeServiceImpl.kt
+++ b/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/HomeServiceImpl.kt
@@ -3,8 +3,11 @@ package com.grateful.deadly.core.home
 import android.util.Log
 import com.grateful.deadly.core.api.home.HomeService
 import com.grateful.deadly.core.api.home.HomeContent
+import com.grateful.deadly.core.api.home.TrendingService
+import com.grateful.deadly.core.api.home.TrendingWindow
 import com.grateful.deadly.core.api.recent.RecentShowsService
 import com.grateful.deadly.core.api.collections.DeadCollectionsService
+import com.grateful.deadly.core.database.AppPreferences
 import com.grateful.deadly.core.domain.repository.ShowRepository
 import com.grateful.deadly.core.model.*
 import kotlinx.coroutines.CoroutineScope
@@ -35,7 +38,9 @@ import javax.inject.Singleton
 class HomeServiceImpl @Inject constructor(
     private val showRepository: ShowRepository,
     private val recentShowsService: RecentShowsService,
-    private val collectionsService: DeadCollectionsService
+    private val collectionsService: DeadCollectionsService,
+    private val trendingService: TrendingService,
+    private val appPreferences: AppPreferences
 ) : HomeService {
     
     companion object {
@@ -48,12 +53,17 @@ class HomeServiceImpl @Inject constructor(
     override val homeContent: StateFlow<HomeContent> = combine(
         recentShowsService.recentShows,
         loadTodayInHistoryFlow(),
-        collectionsService.featuredCollections
-    ) { recentShows, todayInHistory, featuredCollections ->
+        collectionsService.featuredCollections,
+        trendingService.trending,
+        appPreferences.homeTrendingWindow
+    ) { recentShows, todayInHistory, featuredCollections, trending, windowKey ->
+        val window = parseWindow(windowKey)
         HomeContent(
             recentShows = recentShows,
             todayInHistory = todayInHistory,
             featuredCollections = featuredCollections,
+            trendingShows = trending.forWindow(window),
+            trendingWindow = window,
             lastRefresh = System.currentTimeMillis()
         )
     }.stateIn(
@@ -64,6 +74,13 @@ class HomeServiceImpl @Inject constructor(
     
     init {
         Log.d(TAG, "HomeServiceImpl initialized with reactive RecentShowsService integration")
+    }
+
+    private fun parseWindow(key: String): TrendingWindow = when (key) {
+        "week" -> TrendingWindow.WEEK
+        "month" -> TrendingWindow.MONTH
+        "all" -> TrendingWindow.ALL
+        else -> TrendingWindow.NOW
     }
     
     /**

--- a/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/HomeServiceImpl.kt
+++ b/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/HomeServiceImpl.kt
@@ -50,29 +50,31 @@ class HomeServiceImpl @Inject constructor(
     private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     
     // Reactive combination of all home content sources
-    // Pair the two preference flows so the main combine stays at 5 args
+    // Bundle the preference flows so the main combine stays at 5 args
     // (Flow.combine's typed overloads top out at 5).
-    private val trendingPrefs = combine(
+    private data class HomePrefs(val windowKey: String, val aboveToday: Boolean, val recentRows: Int)
+    private val homePrefs = combine(
         appPreferences.homeTrendingWindow,
         appPreferences.homeTrendingAboveToday,
-    ) { windowKey, aboveToday -> windowKey to aboveToday }
+        appPreferences.homeRecentRows,
+    ) { windowKey, aboveToday, recentRows -> HomePrefs(windowKey, aboveToday, recentRows) }
 
     override val homeContent: StateFlow<HomeContent> = combine(
         recentShowsService.recentShows,
         loadTodayInHistoryFlow(),
         collectionsService.featuredCollections,
         trendingService.trending,
-        trendingPrefs
+        homePrefs
     ) { recentShows, todayInHistory, featuredCollections, trending, prefs ->
-        val (windowKey, aboveToday) = prefs
-        val window = TrendingWindow.fromKey(windowKey)
+        val window = TrendingWindow.fromKey(prefs.windowKey)
         HomeContent(
             recentShows = recentShows,
             todayInHistory = todayInHistory,
             featuredCollections = featuredCollections,
             trendingShows = trending.forWindow(window),
             trendingWindow = window,
-            trendingAboveToday = aboveToday,
+            trendingAboveToday = prefs.aboveToday,
+            recentRows = prefs.recentRows,
             lastRefresh = System.currentTimeMillis()
         )
     }.stateIn(

--- a/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/TrendingServiceImpl.kt
+++ b/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/TrendingServiceImpl.kt
@@ -1,0 +1,101 @@
+package com.grateful.deadly.core.home
+
+import android.util.Log
+import com.grateful.deadly.core.api.home.TrendingContent
+import com.grateful.deadly.core.api.home.TrendingService
+import com.grateful.deadly.core.database.AppPreferences
+import com.grateful.deadly.core.domain.repository.ShowRepository
+import com.grateful.deadly.core.model.Show
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Fetches trending shows from /api/trending and resolves the returned IDs
+ * into Show domain models via the local catalog. Refreshes on init and
+ * periodically; failures keep the previous content rather than blanking.
+ */
+@Singleton
+class TrendingServiceImpl @Inject constructor(
+    private val appPreferences: AppPreferences,
+    private val showRepository: ShowRepository,
+) : TrendingService {
+
+    companion object {
+        private const val TAG = "TrendingServiceImpl"
+        private const val REFRESH_INTERVAL_MS = 10 * 60 * 1000L
+    }
+
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val _trending = MutableStateFlow(TrendingContent.initial())
+    override val trending: StateFlow<TrendingContent> = _trending.asStateFlow()
+
+    init {
+        scope.launch {
+            while (isActive) {
+                refresh()
+                delay(REFRESH_INTERVAL_MS)
+            }
+        }
+    }
+
+    override suspend fun refresh(): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            val raw = fetchTrendingJson()
+            val windows = raw.getJSONObject("windows")
+            val nowIds = parseIds(windows, "now")
+            val weekIds = parseIds(windows, "week")
+            val monthIds = parseIds(windows, "month")
+            val allIds = parseIds(windows, "all")
+
+            // Single batch lookup, then partition. Preserves the server's
+            // ranking order — getShowsByIds() does not guarantee order, so
+            // we reorder each window list ourselves.
+            val unique = (nowIds + weekIds + monthIds + allIds).toSet().toList()
+            val shows = showRepository.getShowsByIds(unique).associateBy { it.id }
+
+            _trending.value = TrendingContent(
+                now = nowIds.mapNotNull { shows[it] },
+                week = weekIds.mapNotNull { shows[it] },
+                month = monthIds.mapNotNull { shows[it] },
+                all = allIds.mapNotNull { shows[it] },
+                lastRefresh = System.currentTimeMillis(),
+            )
+        }.onFailure {
+            Log.w(TAG, "Trending refresh failed: ${it.message}")
+        }
+    }
+
+    private fun fetchTrendingJson(): JSONObject {
+        val url = URL("${appPreferences.apiBaseUrl}/api/trending")
+        val conn = url.openConnection() as HttpURLConnection
+        try {
+            conn.requestMethod = "GET"
+            conn.connectTimeout = 10_000
+            conn.readTimeout = 10_000
+            val code = conn.responseCode
+            if (code !in 200..299) error("HTTP $code")
+            val body = conn.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+            return JSONObject(body)
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    private fun parseIds(windows: JSONObject, key: String): List<String> {
+        val arr = windows.optJSONArray(key) ?: return emptyList()
+        return List(arr.length()) { i -> arr.getJSONObject(i).getString("show_id") }
+    }
+}

--- a/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/di/HomeModule.kt
+++ b/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/di/HomeModule.kt
@@ -1,7 +1,9 @@
 package com.grateful.deadly.core.home.di
 
 import com.grateful.deadly.core.api.home.HomeService
+import com.grateful.deadly.core.api.home.TrendingService
 import com.grateful.deadly.core.home.HomeServiceImpl
+import com.grateful.deadly.core.home.TrendingServiceImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -26,4 +28,10 @@ abstract class HomeModule {
     abstract fun bindHomeService(
         impl: HomeServiceImpl
     ): HomeService
+
+    @Binds
+    @Singleton
+    abstract fun bindTrendingService(
+        impl: TrendingServiceImpl
+    ): TrendingService
 }

--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeScreen.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeScreen.kt
@@ -57,6 +57,7 @@ fun HomeScreen(
             item {
                 RecentShowsGrid(
                     shows = uiState.homeContent.recentShows,
+                    rows = uiState.homeContent.recentRows,
                     onShowClick = onNavigateToShow,
                     onShowLongPress = { show ->
                         detailShow = show

--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeScreen.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeScreen.kt
@@ -65,17 +65,17 @@ fun HomeScreen(
             }
         }
 
-        // Trending Section — above Today In History per ADR-0004
-        item {
+        // Trending + Today In History — order toggled by the
+        // "Show trending above Today" preference.
+        val trendingItem: @Composable () -> Unit = {
             TrendingNowSection(
                 shows = uiState.homeContent.trendingShows,
                 window = uiState.homeContent.trendingWindow,
                 onShowClick = { show -> onNavigateToShow(show.id) },
+                onCycleWindow = { viewModel.cycleTrendingWindow() },
             )
         }
-
-        // Today In Grateful Dead History Section
-        item {
+        val todayItem: @Composable () -> Unit = {
             val todayItems = uiState.homeContent.todayInHistory.map { show ->
                 HorizontalCollectionItem(
                     id = show.id,
@@ -90,11 +90,17 @@ fun HomeScreen(
                 title = "Today In Grateful Dead History",
                 items = todayItems,
                 onItemClick = { item ->
-                    // Find the show and navigate
                     val show = uiState.homeContent.todayInHistory.find { it.id == item.id }
                     show?.let { onNavigateToShow(it.id) }
                 }
             )
+        }
+        if (uiState.homeContent.trendingAboveToday) {
+            item { trendingItem() }
+            item { todayItem() }
+        } else {
+            item { todayItem() }
+            item { trendingItem() }
         }
 
         // Featured Collections Section

--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeScreen.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.grateful.deadly.core.design.component.ShowDetailBottomSheet
@@ -68,11 +69,17 @@ fun HomeScreen(
 
         // Trending + Today In History — order toggled by the
         // "Show trending above Today" preference.
+        val todayCardWidth = cardWidthFor(uiState.homeContent.todayCardSize)
+        val collectionsCardWidth = cardWidthFor(uiState.homeContent.collectionsCardSize)
+        val isTodayCompact = uiState.homeContent.todayCardSize == "small"
+
         val trendingItem: @Composable () -> Unit = {
             TrendingNowSection(
                 shows = uiState.homeContent.trendingShows,
                 window = uiState.homeContent.trendingWindow,
+                cardSize = uiState.homeContent.trendingCardSize,
                 onShowClick = { show -> onNavigateToShow(show.id) },
+                onShowLongPress = { show -> detailShow = show },
                 onCycleWindow = { viewModel.cycleTrendingWindow() },
             )
         }
@@ -80,7 +87,8 @@ fun HomeScreen(
             val todayItems = uiState.homeContent.todayInHistory.map { show ->
                 HorizontalCollectionItem(
                     id = show.id,
-                    displayText = "${show.date}\n${show.venue.name}\n${show.location.displayText}",
+                    displayText = if (isTodayCompact) show.date
+                        else "${show.date}\n${show.venue.name}\n${show.location.displayText}",
                     type = CollectionItemType.SHOW,
                     recordingId = show.bestRecordingId,
                     imageUrl = show.coverImageUrl
@@ -90,9 +98,14 @@ fun HomeScreen(
             HorizontalCollection(
                 title = "Today In Grateful Dead History",
                 items = todayItems,
+                cardWidth = todayCardWidth,
                 onItemClick = { item ->
                     val show = uiState.homeContent.todayInHistory.find { it.id == item.id }
                     show?.let { onNavigateToShow(it.id) }
+                },
+                onItemLongPress = { item ->
+                    uiState.homeContent.todayInHistory.find { it.id == item.id }
+                        ?.let { detailShow = it }
                 }
             )
         }
@@ -117,6 +130,7 @@ fun HomeScreen(
             HorizontalCollection(
                 title = "Featured Collections",
                 items = collectionItems,
+                cardWidth = collectionsCardWidth,
                 onItemClick = { item ->
                     onNavigateToCollection(item.id)
                 }
@@ -124,3 +138,5 @@ fun HomeScreen(
         }
     }
 }
+
+private fun cardWidthFor(size: String): Dp = if (size == "small") 100.dp else 160.dp

--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeScreen.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeScreen.kt
@@ -13,6 +13,7 @@ import com.grateful.deadly.feature.home.screens.main.components.HorizontalCollec
 import com.grateful.deadly.feature.home.screens.main.components.HorizontalCollectionItem
 import com.grateful.deadly.feature.home.screens.main.components.CollectionItemType
 import com.grateful.deadly.feature.home.screens.main.components.RecentShowsGrid
+import com.grateful.deadly.feature.home.screens.main.components.TrendingNowSection
 
 /**
  * HomeScreen - Rich home interface with content discovery
@@ -62,6 +63,15 @@ fun HomeScreen(
                     }
                 )
             }
+        }
+
+        // Trending Section — above Today In History per ADR-0004
+        item {
+            TrendingNowSection(
+                shows = uiState.homeContent.trendingShows,
+                window = uiState.homeContent.trendingWindow,
+                onShowClick = { show -> onNavigateToShow(show.id) },
+            )
         }
 
         // Today In Grateful Dead History Section

--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeViewModel.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeViewModel.kt
@@ -81,6 +81,11 @@ class HomeViewModel @Inject constructor(
         }
     }
     
+    /** Cycle the trending window forward (Day → Week → Month → All → Day). */
+    fun cycleTrendingWindow() {
+        homeService.cycleTrendingWindow()
+    }
+
     /**
      * Clear error state
      */

--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/components/HomeCollectionComponents.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/components/HomeCollectionComponents.kt
@@ -1,19 +1,19 @@
 package com.grateful.deadly.feature.home.screens.main.components
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.grateful.deadly.core.design.component.ShowArtwork
 
@@ -25,7 +25,9 @@ fun HorizontalCollection(
     title: String,
     items: List<HorizontalCollectionItem>,
     onItemClick: (HorizontalCollectionItem) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    cardWidth: Dp = 160.dp,
+    onItemLongPress: ((HorizontalCollectionItem) -> Unit)? = null,
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
@@ -37,7 +39,7 @@ fun HorizontalCollection(
             style = MaterialTheme.typography.headlineSmall,
             fontWeight = FontWeight.Bold
         )
-        
+
         // Horizontal scrolling row
         LazyRow(
             horizontalArrangement = Arrangement.spacedBy(16.dp)
@@ -45,7 +47,9 @@ fun HorizontalCollection(
             items(items) { item ->
                 CollectionItemCard(
                     item = item,
-                    onItemClick = { onItemClick(item) }
+                    cardWidth = cardWidth,
+                    onItemClick = { onItemClick(item) },
+                    onItemLongPress = onItemLongPress?.let { handler -> { handler(item) } }
                 )
             }
         }
@@ -55,28 +59,34 @@ fun HorizontalCollection(
 /**
  * Individual item in horizontal collection
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun CollectionItemCard(
     item: HorizontalCollectionItem,
     onItemClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    cardWidth: Dp = 160.dp,
+    onItemLongPress: (() -> Unit)? = null,
 ) {
     Column(
         modifier = modifier
-            .width(160.dp)
-            .clickable { onItemClick() },
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+            .width(cardWidth)
+            .combinedClickable(
+                onClick = onItemClick,
+                onLongClick = onItemLongPress
+            ),
+        verticalArrangement = Arrangement.spacedBy(if (cardWidth < 140.dp) 6.dp else 12.dp)
     ) {
         // Large square image
         ShowArtwork(
             recordingId = item.recordingId,
             contentDescription = null,
             modifier = Modifier
-                .size(160.dp)
+                .size(cardWidth)
                 .clip(RoundedCornerShape(12.dp)),
             imageUrl = item.imageUrl
         )
-        
+
         // Descriptive text - parse lines and display each with truncation
         Column(
             verticalArrangement = Arrangement.spacedBy(2.dp)

--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/components/HomeShowComponents.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/components/HomeShowComponents.kt
@@ -25,24 +25,23 @@ import com.grateful.deadly.core.design.component.ShowArtwork
 import com.grateful.deadly.core.model.Show
 
 /**
- * Recent Shows Grid - 2-column layout showing recently played shows.
- * Defaults to 4 (2x2) to keep the home screen short; a "Show more" /
- * "Show less" footer reveals up to 8.
+ * Recent Shows Grid - 2-column layout. The number of rows is a user
+ * preference (1..4); each row holds 2 shows. Set in Settings.
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun RecentShowsGrid(
     shows: List<Show>,
+    rows: Int,
     onShowClick: (String) -> Unit,
     onShowLongPress: (Show) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    var expanded by rememberSaveable { mutableStateOf(false) }
-    val limit = if (expanded) 8 else 4
-    val displayShows = shows.take(limit)
+    val clampedRows = rows.coerceIn(1, 4)
+    val displayShows = shows.take(clampedRows * 2)
     val rowCount = (displayShows.size + 1) / 2
+    if (rowCount == 0) return
     val gridHeight = (rowCount * 80 + (rowCount - 1) * 4).dp
-    val canExpand = shows.size > 4
 
     Column(modifier = modifier.fillMaxWidth()) {
         Text(
@@ -67,17 +66,6 @@ fun RecentShowsGrid(
                     onShowClick = { onShowClick(show.id) },
                     onShowLongPress = { onShowLongPress(show) }
                 )
-            }
-        }
-
-        if (canExpand) {
-            TextButton(
-                onClick = { expanded = !expanded },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 4.dp),
-            ) {
-                Text(if (expanded) "Show less" else "Show more")
             }
         }
     }

--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/components/HomeShowComponents.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/components/HomeShowComponents.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -24,8 +25,9 @@ import com.grateful.deadly.core.design.component.ShowArtwork
 import com.grateful.deadly.core.model.Show
 
 /**
- * Recent Shows Grid - Dynamic 2-column layout showing recently played shows
- * Automatically adjusts height based on number of shows (1-8 shows, 1-4 rows)
+ * Recent Shows Grid - 2-column layout showing recently played shows.
+ * Defaults to 4 (2x2) to keep the home screen short; a "Show more" /
+ * "Show less" footer reveals up to 8.
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -35,9 +37,12 @@ fun RecentShowsGrid(
     onShowLongPress: (Show) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val displayShows = shows.take(8) // Maximum 8 shows for 2x4 grid
-    val rowCount = (displayShows.size + 1) / 2 // Calculate rows needed (ceiling division)
-    val gridHeight = (rowCount * 80 + (rowCount - 1) * 4).dp // rows × card height + spacing
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    val limit = if (expanded) 8 else 4
+    val displayShows = shows.take(limit)
+    val rowCount = (displayShows.size + 1) / 2
+    val gridHeight = (rowCount * 80 + (rowCount - 1) * 4).dp
+    val canExpand = shows.size > 4
 
     Column(modifier = modifier.fillMaxWidth()) {
         Text(
@@ -50,11 +55,11 @@ fun RecentShowsGrid(
         LazyVerticalGrid(
             columns = GridCells.Fixed(2),
             modifier = Modifier
-                .height(gridHeight) // Fixed height required — nested in LazyColumn
+                .height(gridHeight)
                 .fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalArrangement = Arrangement.spacedBy(4.dp),
-            userScrollEnabled = false // Disable scrolling to hold its size
+            userScrollEnabled = false
         ) {
             items(displayShows) { show ->
                 RecentShowCard(
@@ -62,6 +67,17 @@ fun RecentShowsGrid(
                     onShowClick = { onShowClick(show.id) },
                     onShowLongPress = { onShowLongPress(show) }
                 )
+            }
+        }
+
+        if (canExpand) {
+            TextButton(
+                onClick = { expanded = !expanded },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 4.dp),
+            ) {
+                Text(if (expanded) "Show less" else "Show more")
             }
         }
     }

--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/components/TrendingNowSection.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/components/TrendingNowSection.kt
@@ -1,9 +1,11 @@
 package com.grateful.deadly.feature.home.screens.main.components
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -14,20 +16,24 @@ import com.grateful.deadly.core.api.home.TrendingWindow
 import com.grateful.deadly.core.model.Show
 
 /**
- * "Trending on The Deadly" home section. Renders one time window's shows
- * with a chip on the right that cycles Day → Week → Month → All on tap.
- * The chosen window persists via [onCycleWindow] which writes to
- * AppPreferences, keeping in sync with the Settings selector.
+ * "Trending <window>" home section. The title itself is tappable and cycles
+ * Day → Week → Month → All on tap; the chosen window persists via
+ * [onCycleWindow] which writes to AppPreferences, keeping in sync with the
+ * Settings selector.
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun TrendingNowSection(
     shows: List<Show>,
     window: TrendingWindow,
+    cardSize: String,
     onShowClick: (Show) -> Unit,
+    onShowLongPress: (Show) -> Unit,
     onCycleWindow: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     if (shows.isEmpty()) return
+    val isCompact = cardSize == "small"
 
     Column(
         modifier = modifier.fillMaxWidth(),
@@ -39,40 +45,43 @@ fun TrendingNowSection(
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text(
-                text = "Trending on The Deadly",
+                text = "Trending ${window.titleLabel}",
                 style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.Bold,
-                modifier = Modifier.weight(1f),
+                maxLines = 1,
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable(onClick = onCycleWindow),
             )
-            WindowChip(window = window, onClick = onCycleWindow)
+            Text(
+                text = "Show ${window.next().titleLabel}",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                modifier = Modifier.clickable(onClick = onCycleWindow),
+            )
         }
         LazyRow(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
             items(shows, key = { it.id }) { show ->
+                val display = if (isCompact) {
+                    show.date
+                } else {
+                    "${show.date}\n${show.venue.name}\n${show.location.displayText}"
+                }
                 CollectionItemCard(
                     item = HorizontalCollectionItem(
                         id = show.id,
-                        displayText = "${show.date}\n${show.venue.name}\n${show.location.displayText}",
+                        displayText = display,
                         type = CollectionItemType.SHOW,
                         recordingId = show.bestRecordingId,
                         imageUrl = show.coverImageUrl,
                     ),
+                    cardWidth = if (isCompact) 100.dp else 160.dp,
                     onItemClick = { onShowClick(show) },
+                    onItemLongPress = { onShowLongPress(show) },
                 )
             }
         }
     }
-}
-
-@Composable
-private fun WindowChip(window: TrendingWindow, onClick: () -> Unit) {
-    AssistChip(
-        onClick = onClick,
-        label = {
-            Text(
-                text = window.shortLabel,
-                style = MaterialTheme.typography.titleMedium,
-            )
-        },
-        shape = RoundedCornerShape(20.dp),
-    )
 }

--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/components/TrendingNowSection.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/components/TrendingNowSection.kt
@@ -3,8 +3,10 @@ package com.grateful.deadly.feature.home.screens.main.components
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -12,15 +14,17 @@ import com.grateful.deadly.core.api.home.TrendingWindow
 import com.grateful.deadly.core.model.Show
 
 /**
- * "Trending on The Deadly" home section. Renders a single time window's
- * worth of shows; the choice of window is a user preference set in
- * Settings (defaults to NOW = rolling 24h).
+ * "Trending on The Deadly" home section. Renders one time window's shows
+ * with a chip on the right that cycles Day → Week → Month → All on tap.
+ * The chosen window persists via [onCycleWindow] which writes to
+ * AppPreferences, keeping in sync with the Settings selector.
  */
 @Composable
 fun TrendingNowSection(
     shows: List<Show>,
     window: TrendingWindow,
     onShowClick: (Show) -> Unit,
+    onCycleWindow: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     if (shows.isEmpty()) return
@@ -29,16 +33,19 @@ fun TrendingNowSection(
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Text(
-            text = "Trending on The Deadly",
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold,
-        )
-        Text(
-            text = window.subtitle,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = "Trending on The Deadly",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(1f),
+            )
+            WindowChip(window = window, onClick = onCycleWindow)
+        }
         LazyRow(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
             items(shows, key = { it.id }) { show ->
                 CollectionItemCard(
@@ -56,10 +63,16 @@ fun TrendingNowSection(
     }
 }
 
-private val TrendingWindow.subtitle: String
-    get() = when (this) {
-        TrendingWindow.NOW -> "Last 24 hours"
-        TrendingWindow.WEEK -> "Last 7 days"
-        TrendingWindow.MONTH -> "Last 30 days"
-        TrendingWindow.ALL -> "All time"
-    }
+@Composable
+private fun WindowChip(window: TrendingWindow, onClick: () -> Unit) {
+    AssistChip(
+        onClick = onClick,
+        label = {
+            Text(
+                text = window.shortLabel,
+                style = MaterialTheme.typography.titleMedium,
+            )
+        },
+        shape = RoundedCornerShape(20.dp),
+    )
+}

--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/components/TrendingNowSection.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/components/TrendingNowSection.kt
@@ -1,0 +1,65 @@
+package com.grateful.deadly.feature.home.screens.main.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.grateful.deadly.core.api.home.TrendingWindow
+import com.grateful.deadly.core.model.Show
+
+/**
+ * "Trending on The Deadly" home section. Renders a single time window's
+ * worth of shows; the choice of window is a user preference set in
+ * Settings (defaults to NOW = rolling 24h).
+ */
+@Composable
+fun TrendingNowSection(
+    shows: List<Show>,
+    window: TrendingWindow,
+    onShowClick: (Show) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (shows.isEmpty()) return
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = "Trending on The Deadly",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            text = window.subtitle,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        LazyRow(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            items(shows, key = { it.id }) { show ->
+                CollectionItemCard(
+                    item = HorizontalCollectionItem(
+                        id = show.id,
+                        displayText = "${show.date}\n${show.venue.name}\n${show.location.displayText}",
+                        type = CollectionItemType.SHOW,
+                        recordingId = show.bestRecordingId,
+                        imageUrl = show.coverImageUrl,
+                    ),
+                    onItemClick = { onShowClick(show) },
+                )
+            }
+        }
+    }
+}
+
+private val TrendingWindow.subtitle: String
+    get() = when (this) {
+        TrendingWindow.NOW -> "Last 24 hours"
+        TrendingWindow.WEEK -> "Last 7 days"
+        TrendingWindow.MONTH -> "Last 30 days"
+        TrendingWindow.ALL -> "All time"
+    }

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
@@ -37,6 +37,7 @@ fun SettingsScreen(
     val sourceBadgeStyle by viewModel.sourceBadgeStyle.collectAsState()
     val playerControlsStyle by viewModel.playerControlsStyle.collectAsState()
     val homeTrendingWindow by viewModel.homeTrendingWindow.collectAsState()
+    val homeTrendingAboveToday by viewModel.homeTrendingAboveToday.collectAsState()
     val authState by viewModel.authState.collectAsState()
     val serverEnvironment by viewModel.serverEnvironment.collectAsState()
     val developerModeUnlocked by viewModel.developerModeUnlocked.collectAsState()
@@ -146,6 +147,15 @@ fun SettingsScreen(
             HomeTrendingWindowRow(
                 currentKey = homeTrendingWindow,
                 onSelected = { viewModel.setHomeTrendingWindow(it) }
+            )
+        }
+
+        item {
+            PreferenceToggleRow(
+                title = "Show Trending above Today",
+                subtitle = "Move the Trending section below \"Today In Grateful Dead History\" by turning this off.",
+                checked = homeTrendingAboveToday,
+                onCheckedChange = { viewModel.toggleHomeTrendingAboveToday() }
             )
         }
 
@@ -540,10 +550,10 @@ private fun HomeTrendingWindowRow(
     onSelected: (String) -> Unit
 ) {
     val options = listOf(
-        "now" to "24h",
+        "now" to "Day",
         "week" to "Week",
         "month" to "Month",
-        "all" to "All-Time",
+        "all" to "All",
     )
     Column(
         modifier = Modifier

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
@@ -39,6 +39,9 @@ fun SettingsScreen(
     val homeTrendingWindow by viewModel.homeTrendingWindow.collectAsState()
     val homeTrendingAboveToday by viewModel.homeTrendingAboveToday.collectAsState()
     val homeRecentRows by viewModel.homeRecentRows.collectAsState()
+    val homeTrendingCardSize by viewModel.homeTrendingCardSize.collectAsState()
+    val homeTodayCardSize by viewModel.homeTodayCardSize.collectAsState()
+    val homeCollectionsCardSize by viewModel.homeCollectionsCardSize.collectAsState()
     val authState by viewModel.authState.collectAsState()
     val serverEnvironment by viewModel.serverEnvironment.collectAsState()
     val developerModeUnlocked by viewModel.developerModeUnlocked.collectAsState()
@@ -144,6 +147,11 @@ fun SettingsScreen(
             )
         }
 
+        item { HorizontalDivider() }
+
+        // ── HOME SCREEN ──────────────────────────────────────────────
+        item { SectionHeader("Home Screen") }
+
         item {
             HomeTrendingWindowRow(
                 currentKey = homeTrendingWindow,
@@ -165,6 +173,37 @@ fun SettingsScreen(
                 currentRows = homeRecentRows,
                 onSelected = { viewModel.setHomeRecentRows(it) }
             )
+        }
+
+        item {
+            HomeCardSizeRow(
+                title = "Trending card size",
+                subtitle = "Size of cards in the Trending carousel.",
+                current = homeTrendingCardSize,
+                onSelected = { viewModel.setHomeTrendingCardSize(it) }
+            )
+        }
+
+        item {
+            HomeCardSizeRow(
+                title = "Today In History card size",
+                subtitle = "Size of cards in the Today In Grateful Dead History carousel.",
+                current = homeTodayCardSize,
+                onSelected = { viewModel.setHomeTodayCardSize(it) }
+            )
+        }
+
+        item {
+            HomeCardSizeRow(
+                title = "Featured Collections card size",
+                subtitle = "Size of cards in the Featured Collections carousel.",
+                current = homeCollectionsCardSize,
+                onSelected = { viewModel.setHomeCollectionsCardSize(it) }
+            )
+        }
+
+        item {
+            HomeResetRow(onReset = { viewModel.resetHomePreferences() })
         }
 
         item { HorizontalDivider() }
@@ -581,6 +620,59 @@ private fun HomeRecentRowsRow(
                     )
                 ) {
                     Text(rows.toString())
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HomeResetRow(onReset: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        TextButton(onClick = onReset) {
+            Text(
+                text = "Reset Home Screen to Defaults",
+                color = MaterialTheme.colorScheme.error
+            )
+        }
+    }
+}
+
+@Composable
+private fun HomeCardSizeRow(
+    title: String,
+    subtitle: String,
+    current: String,
+    onSelected: (String) -> Unit,
+) {
+    val options = listOf("small" to "Small", "large" to "Large")
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        Text(text = title, style = MaterialTheme.typography.bodyLarge)
+        Text(
+            text = subtitle,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+            options.forEachIndexed { index, (key, label) ->
+                SegmentedButton(
+                    selected = current == key,
+                    onClick = { onSelected(key) },
+                    shape = SegmentedButtonDefaults.itemShape(
+                        index = index,
+                        count = options.size
+                    )
+                ) {
+                    Text(label)
                 }
             }
         }

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
@@ -36,6 +36,7 @@ fun SettingsScreen(
     val includeShowsWithoutRecordings by viewModel.includeShowsWithoutRecordings.collectAsState()
     val sourceBadgeStyle by viewModel.sourceBadgeStyle.collectAsState()
     val playerControlsStyle by viewModel.playerControlsStyle.collectAsState()
+    val homeTrendingWindow by viewModel.homeTrendingWindow.collectAsState()
     val authState by viewModel.authState.collectAsState()
     val serverEnvironment by viewModel.serverEnvironment.collectAsState()
     val developerModeUnlocked by viewModel.developerModeUnlocked.collectAsState()
@@ -138,6 +139,13 @@ fun SettingsScreen(
             PlayerControlsStyleRow(
                 currentStyle = PlayerControlsStyle.fromString(playerControlsStyle),
                 onStyleSelected = { viewModel.setPlayerControlsStyle(it.name) }
+            )
+        }
+
+        item {
+            HomeTrendingWindowRow(
+                currentKey = homeTrendingWindow,
+                onSelected = { viewModel.setHomeTrendingWindow(it) }
             )
         }
 
@@ -525,6 +533,46 @@ private fun PlayerControlsStyleRow(
 }
 
 // ── Source badge style selector ──────────────────────────────────────────────
+
+@Composable
+private fun HomeTrendingWindowRow(
+    currentKey: String,
+    onSelected: (String) -> Unit
+) {
+    val options = listOf(
+        "now" to "24h",
+        "week" to "Week",
+        "month" to "Month",
+        "all" to "All-Time",
+    )
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        Text(text = "Trending window on home", style = MaterialTheme.typography.bodyLarge)
+        Text(
+            text = "Which time range \"Trending on The Deadly\" shows",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+            options.forEachIndexed { index, (key, label) ->
+                SegmentedButton(
+                    selected = currentKey == key,
+                    onClick = { onSelected(key) },
+                    shape = SegmentedButtonDefaults.itemShape(
+                        index = index,
+                        count = options.size
+                    )
+                ) {
+                    Text(label)
+                }
+            }
+        }
+    }
+}
 
 @Composable
 private fun SourceBadgeStyleRow(

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
@@ -38,6 +38,7 @@ fun SettingsScreen(
     val playerControlsStyle by viewModel.playerControlsStyle.collectAsState()
     val homeTrendingWindow by viewModel.homeTrendingWindow.collectAsState()
     val homeTrendingAboveToday by viewModel.homeTrendingAboveToday.collectAsState()
+    val homeRecentRows by viewModel.homeRecentRows.collectAsState()
     val authState by viewModel.authState.collectAsState()
     val serverEnvironment by viewModel.serverEnvironment.collectAsState()
     val developerModeUnlocked by viewModel.developerModeUnlocked.collectAsState()
@@ -156,6 +157,13 @@ fun SettingsScreen(
                 subtitle = "Move the Trending section below \"Today In Grateful Dead History\" by turning this off.",
                 checked = homeTrendingAboveToday,
                 onCheckedChange = { viewModel.toggleHomeTrendingAboveToday() }
+            )
+        }
+
+        item {
+            HomeRecentRowsRow(
+                currentRows = homeRecentRows,
+                onSelected = { viewModel.setHomeRecentRows(it) }
             )
         }
 
@@ -543,6 +551,41 @@ private fun PlayerControlsStyleRow(
 }
 
 // ── Source badge style selector ──────────────────────────────────────────────
+
+@Composable
+private fun HomeRecentRowsRow(
+    currentRows: Int,
+    onSelected: (Int) -> Unit
+) {
+    val options = listOf(1, 2, 3, 4)
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        Text(text = "Recently Played rows", style = MaterialTheme.typography.bodyLarge)
+        Text(
+            text = "How many rows of recent shows on the home screen (2 shows per row)",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+            options.forEachIndexed { index, rows ->
+                SegmentedButton(
+                    selected = currentRows == rows,
+                    onClick = { onSelected(rows) },
+                    shape = SegmentedButtonDefaults.itemShape(
+                        index = index,
+                        count = options.size
+                    )
+                ) {
+                    Text(rows.toString())
+                }
+            }
+        }
+    }
+}
 
 @Composable
 private fun HomeTrendingWindowRow(

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
@@ -99,6 +99,17 @@ class SettingsViewModel @Inject constructor(
         ))
     }
 
+    val homeTrendingWindow: StateFlow<String> = appPreferences.homeTrendingWindow
+
+    fun setHomeTrendingWindow(value: String) {
+        appPreferences.setHomeTrendingWindow(value)
+        analyticsService.track("feature_use", mapOf(
+            "feature" to "set_home_trending_window",
+            "category" to "preference",
+            "value" to value,
+        ))
+    }
+
     val authState: StateFlow<AuthState> = authService.authState
 
     val useBetaMode: StateFlow<Boolean> = appPreferences.useBetaModeFlow

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
@@ -133,6 +133,45 @@ class SettingsViewModel @Inject constructor(
         ))
     }
 
+    val homeTrendingCardSize: StateFlow<String> = appPreferences.homeTrendingCardSize
+    val homeTodayCardSize: StateFlow<String> = appPreferences.homeTodayCardSize
+    val homeCollectionsCardSize: StateFlow<String> = appPreferences.homeCollectionsCardSize
+
+    fun setHomeTrendingCardSize(value: String) {
+        appPreferences.setHomeTrendingCardSize(value)
+        analyticsService.track("feature_use", mapOf(
+            "feature" to "set_home_trending_card_size",
+            "category" to "preference",
+            "value" to value,
+        ))
+    }
+
+    fun setHomeTodayCardSize(value: String) {
+        appPreferences.setHomeTodayCardSize(value)
+        analyticsService.track("feature_use", mapOf(
+            "feature" to "set_home_today_card_size",
+            "category" to "preference",
+            "value" to value,
+        ))
+    }
+
+    fun setHomeCollectionsCardSize(value: String) {
+        appPreferences.setHomeCollectionsCardSize(value)
+        analyticsService.track("feature_use", mapOf(
+            "feature" to "set_home_collections_card_size",
+            "category" to "preference",
+            "value" to value,
+        ))
+    }
+
+    fun resetHomePreferences() {
+        appPreferences.resetHomePreferences()
+        analyticsService.track("feature_use", mapOf(
+            "feature" to "reset_home_preferences",
+            "category" to "preference",
+        ))
+    }
+
     val authState: StateFlow<AuthState> = authService.authState
 
     val useBetaMode: StateFlow<Boolean> = appPreferences.useBetaModeFlow

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
@@ -110,6 +110,18 @@ class SettingsViewModel @Inject constructor(
         ))
     }
 
+    val homeTrendingAboveToday: StateFlow<Boolean> = appPreferences.homeTrendingAboveToday
+
+    fun toggleHomeTrendingAboveToday() {
+        val newValue = !appPreferences.homeTrendingAboveToday.value
+        appPreferences.setHomeTrendingAboveToday(newValue)
+        analyticsService.track("feature_use", mapOf(
+            "feature" to "set_home_trending_above_today",
+            "category" to "preference",
+            "value" to newValue.toString(),
+        ))
+    }
+
     val authState: StateFlow<AuthState> = authService.authState
 
     val useBetaMode: StateFlow<Boolean> = appPreferences.useBetaModeFlow

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
@@ -122,6 +122,17 @@ class SettingsViewModel @Inject constructor(
         ))
     }
 
+    val homeRecentRows: StateFlow<Int> = appPreferences.homeRecentRows
+
+    fun setHomeRecentRows(value: Int) {
+        appPreferences.setHomeRecentRows(value)
+        analyticsService.track("feature_use", mapOf(
+            "feature" to "set_home_recent_rows",
+            "category" to "preference",
+            "value" to value.toString(),
+        ))
+    }
+
     val authState: StateFlow<AuthState> = authService.authState
 
     val useBetaMode: StateFlow<Boolean> = appPreferences.useBetaModeFlow

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -12,6 +12,7 @@ import { userRoutes } from "./routes/user.js";
 import { authMiddleware } from "./auth/middleware.js";
 import { connectRoutes } from "./connect/routes.js";
 import { analyticsRoutes } from "./routes/analytics.js";
+import { trendingRoutes } from "./routes/trending.js";
 import { betaRoutes } from "./routes/beta.js";
 import { devTokenRoutes } from "./auth/dev-token.js";
 import { isDev } from "./env.js";
@@ -63,6 +64,7 @@ export function buildApp() {
   app.register(userRoutes);
   app.register(connectRoutes);
   app.register(analyticsRoutes);
+  app.register(trendingRoutes);
   app.register(betaRoutes);
 
   if (isDev) {

--- a/api/src/db/__tests__/trending.test.ts
+++ b/api/src/db/__tests__/trending.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+
+// Point the analytics module at a temp DB before importing it so its
+// module-level singleton opens our test file, not data/analytics.db.
+const TMP_DB = path.join(
+  os.tmpdir(),
+  `trending-test-${process.pid}-${Date.now()}.db`,
+);
+process.env.ANALYTICS_DB_PATH = TMP_DB;
+
+const {
+  getAnalyticsDb,
+  insertEvents,
+  rollupShowPlaysDay,
+  backfillShowPlaysIfEmpty,
+  getTrending,
+  closeAnalyticsDb,
+} = await import("../analytics.js");
+
+function todayUtc(daysOffset = 0): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + daysOffset);
+  return d.toISOString().slice(0, 10);
+}
+
+function tsForDay(daysAgo: number, hour = 12): number {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - daysAgo);
+  d.setUTCHours(hour, 0, 0, 0);
+  return d.getTime();
+}
+
+function play(
+  iid: string,
+  sid: string,
+  showId: string,
+  ts: number,
+  trackIndex = 0,
+) {
+  return {
+    event: "playback_start",
+    ts,
+    iid,
+    sid,
+    platform: "ios",
+    app_version: "2.30.0",
+    props: { show_id: showId, track_index: trackIndex },
+  };
+}
+
+beforeEach(() => {
+  // Truncate between tests so each starts clean. Cheaper than reopening
+  // the DB.
+  const db = getAnalyticsDb();
+  db.exec(`DELETE FROM analytics_events; DELETE FROM show_plays_daily;`);
+});
+
+afterAll(() => {
+  closeAnalyticsDb();
+  if (fs.existsSync(TMP_DB)) fs.unlinkSync(TMP_DB);
+});
+
+describe("rollupShowPlaysDay", () => {
+  it("groups plays by show and counts sessions and plays", () => {
+    const day = todayUtc();
+    const ts = tsForDay(0);
+    insertEvents([
+      // Alice, one session, 3 tracks of show A
+      play("alice", "s1", "show-A", ts, 0),
+      play("alice", "s1", "show-A", ts + 1, 1),
+      play("alice", "s1", "show-A", ts + 2, 2),
+      // Bob, one session, 1 track of show A
+      play("bob", "s2", "show-A", ts + 3, 0),
+      // Alice, second session, 1 track of show B
+      play("alice", "s3", "show-B", ts + 4, 0),
+    ]);
+
+    rollupShowPlaysDay(day);
+
+    const rows = getAnalyticsDb()
+      .prepare(
+        `SELECT show_id, sessions, plays FROM show_plays_daily
+         WHERE day = ? ORDER BY show_id`,
+      )
+      .all(day);
+
+    expect(rows).toEqual([
+      { show_id: "show-A", sessions: 2, plays: 4 },
+      { show_id: "show-B", sessions: 1, plays: 1 },
+    ]);
+  });
+
+  it("re-running replaces the day's rows (idempotent)", () => {
+    const day = todayUtc();
+    const ts = tsForDay(0);
+    insertEvents([play("alice", "s1", "show-A", ts, 0)]);
+    rollupShowPlaysDay(day);
+    rollupShowPlaysDay(day);
+
+    const count = (
+      getAnalyticsDb()
+        .prepare(`SELECT COUNT(*) AS c FROM show_plays_daily WHERE day = ?`)
+        .get(day) as { c: number }
+    ).c;
+    expect(count).toBe(1);
+  });
+
+  it("ignores events without a show_id", () => {
+    const day = todayUtc();
+    const ts = tsForDay(0);
+    getAnalyticsDb()
+      .prepare(
+        `INSERT INTO analytics_events (event, ts, iid, sid, platform, app_version, props)
+         VALUES ('playback_start', ?, 'a', 's', 'ios', '2.30.0', NULL)`,
+      )
+      .run(ts);
+
+    rollupShowPlaysDay(day);
+
+    const rows = getAnalyticsDb()
+      .prepare(`SELECT * FROM show_plays_daily WHERE day = ?`)
+      .all(day);
+    expect(rows).toEqual([]);
+  });
+});
+
+describe("getTrending", () => {
+  it("returns four windows with correct ordering", () => {
+    // Build a corpus that differentiates the windows.
+    const events = [
+      // show-A: heavy today, dominates `now`
+      play("u1", "s1", "show-A", tsForDay(0, 10)),
+      play("u2", "s2", "show-A", tsForDay(0, 11)),
+      play("u3", "s3", "show-A", tsForDay(0, 12)),
+      // show-B: spread across the week, dominates `week`
+      play("u1", "wk1", "show-B", tsForDay(1)),
+      play("u2", "wk2", "show-B", tsForDay(2)),
+      play("u3", "wk3", "show-B", tsForDay(3)),
+      play("u4", "wk4", "show-B", tsForDay(4)),
+      // show-C: only month-old, dominates `month` but not week
+      play("u1", "mo1", "show-C", tsForDay(15)),
+      play("u2", "mo2", "show-C", tsForDay(20)),
+      // show-D: old (out of month), only shows in `all`
+      play("u1", "old1", "show-D", tsForDay(60)),
+    ];
+    insertEvents(events);
+
+    // Roll up every day that has events. The endpoint's rollup job does
+    // this for today + yesterday in real life; here we just do all of
+    // them so we can assert on every window.
+    for (let i = 0; i <= 60; i++) {
+      rollupShowPlaysDay(todayUtc(-i));
+    }
+
+    const result = getTrending(10);
+
+    expect(result.windows.now[0]?.show_id).toBe("show-A");
+    expect(result.windows.now[0]?.sessions).toBe(3);
+
+    const weekIds = result.windows.week.map((r) => r.show_id);
+    expect(weekIds[0]).toBe("show-B");
+    expect(weekIds).toContain("show-A");
+    expect(weekIds).not.toContain("show-D");
+
+    const monthIds = result.windows.month.map((r) => r.show_id);
+    expect(monthIds).toContain("show-C");
+    expect(monthIds).not.toContain("show-D");
+
+    const allIds = result.windows.all.map((r) => r.show_id);
+    expect(allIds).toContain("show-D");
+  });
+
+  it("respects the limit parameter", () => {
+    const ts = tsForDay(0);
+    const events = Array.from({ length: 15 }, (_, i) =>
+      play(`u${i}`, `s${i}`, `show-${i}`, ts + i),
+    );
+    insertEvents(events);
+    rollupShowPlaysDay(todayUtc());
+
+    const result = getTrending(5);
+    expect(result.windows.now).toHaveLength(5);
+    expect(result.windows.all).toHaveLength(5);
+  });
+
+  it("orders by sessions desc, then plays desc as tiebreaker", () => {
+    const ts = tsForDay(0);
+    insertEvents([
+      // show-X: 1 session, 5 plays
+      play("u1", "s1", "show-X", ts, 0),
+      play("u1", "s1", "show-X", ts + 1, 1),
+      play("u1", "s1", "show-X", ts + 2, 2),
+      play("u1", "s1", "show-X", ts + 3, 3),
+      play("u1", "s1", "show-X", ts + 4, 4),
+      // show-Y: 2 sessions, 2 plays — should beat X on sessions
+      play("u2", "s2", "show-Y", ts, 0),
+      play("u3", "s3", "show-Y", ts + 1, 0),
+    ]);
+    rollupShowPlaysDay(todayUtc());
+
+    const result = getTrending(10);
+    expect(result.windows.now[0]?.show_id).toBe("show-Y");
+    expect(result.windows.now[1]?.show_id).toBe("show-X");
+  });
+
+  it("backfillShowPlaysIfEmpty populates every day with events on first run", () => {
+    insertEvents([
+      play("u1", "s1", "show-A", tsForDay(0)),
+      play("u1", "s2", "show-A", tsForDay(5)),
+      play("u2", "s3", "show-B", tsForDay(10)),
+    ]);
+
+    const filled = backfillShowPlaysIfEmpty();
+    expect(filled).toBe(3); // 3 distinct days
+
+    // Second call should be a no-op.
+    expect(backfillShowPlaysIfEmpty()).toBe(0);
+
+    const all = getTrending(10).windows.all.map((r) => r.show_id);
+    expect(all).toContain("show-A");
+    expect(all).toContain("show-B");
+  });
+
+  it("returns empty arrays when there are no events", () => {
+    const result = getTrending(10);
+    expect(result.windows.now).toEqual([]);
+    expect(result.windows.week).toEqual([]);
+    expect(result.windows.month).toEqual([]);
+    expect(result.windows.all).toEqual([]);
+    expect(typeof result.generated_at).toBe("string");
+  });
+});

--- a/api/src/db/analytics.ts
+++ b/api/src/db/analytics.ts
@@ -78,6 +78,15 @@ function initSchema(db: Database.Database): void {
       PRIMARY KEY (day, event, platform, app_version)
     );
 
+    CREATE TABLE IF NOT EXISTS show_plays_daily (
+      day TEXT NOT NULL,
+      show_id TEXT NOT NULL,
+      sessions INTEGER NOT NULL,
+      plays INTEGER NOT NULL,
+      PRIMARY KEY (day, show_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_show_plays_day ON show_plays_daily(day);
+
     CREATE TABLE IF NOT EXISTS watched_installs (
       iid TEXT PRIMARY KEY,
       name TEXT,
@@ -1717,6 +1726,153 @@ export function getInstallEvents(iid: string): InstallSummary | null {
   `).all(iid) as InstallEvent[];
 
   return { ...summary, events };
+}
+
+// ── Trending shows ──────────────────────────────────────────────────
+
+export interface TrendingShow {
+  show_id: string;
+  sessions: number;
+  plays: number;
+}
+
+export interface TrendingResponse {
+  generated_at: string;
+  windows: {
+    now: TrendingShow[];
+    week: TrendingShow[];
+    month: TrendingShow[];
+    all: TrendingShow[];
+  };
+}
+
+/**
+ * Upserts a day's row in `show_plays_daily` from raw events. Called hourly for
+ * today, once at startup for yesterday. "Day" is UTC-aligned to match the
+ * `date(ts/1000, 'unixepoch')` expression used everywhere else in this file.
+ *
+ * `sessions` counts distinct (iid, sid) tuples for the day — one app session
+ * sitting down to play a show counts once, regardless of how many tracks they
+ * played through. `plays` is the raw track-start count.
+ */
+export function rollupShowPlaysDay(day: string): void {
+  const db = getAnalyticsDb();
+  db.prepare(`
+    DELETE FROM show_plays_daily WHERE day = ?
+  `).run(day);
+  db.prepare(`
+    INSERT INTO show_plays_daily (day, show_id, sessions, plays)
+    SELECT
+      date(ts / 1000, 'unixepoch') AS day,
+      json_extract(props, '$.show_id') AS show_id,
+      COUNT(DISTINCT iid || '|' || sid) AS sessions,
+      COUNT(*) AS plays
+    FROM analytics_events
+    WHERE event = 'playback_start'
+      AND date(ts / 1000, 'unixepoch') = ?
+      AND json_extract(props, '$.show_id') IS NOT NULL
+    GROUP BY day, show_id
+  `).run(day);
+}
+
+/**
+ * Trending shows across four time windows. Used by the home screen.
+ *
+ * The "now" window is rolling 24h queried directly from analytics_events,
+ * so it stays current between hourly rollups. The other windows aggregate
+ * from `show_plays_daily`, summing per show. Summing sessions across days
+ * slightly overcounts because a single human spanning multiple days is
+ * counted per day — that's an engagement-weighted signal we prefer for
+ * ranking, per ADR-0004.
+ */
+export function getTrending(limit = 10): TrendingResponse {
+  const db = getAnalyticsDb();
+  const now = Date.now();
+  const dayAgo = now - 24 * 3600 * 1000;
+  const weekStart = todayUtcMinusDays(6); // inclusive of today = 7 days
+  const monthStart = todayUtcMinusDays(29);
+
+  const nowRows = db
+    .prepare(
+      `SELECT
+         json_extract(props, '$.show_id') AS show_id,
+         COUNT(DISTINCT iid || '|' || sid) AS sessions,
+         COUNT(*) AS plays
+       FROM analytics_events
+       WHERE event = 'playback_start'
+         AND ts > ?
+         AND json_extract(props, '$.show_id') IS NOT NULL
+       GROUP BY show_id
+       ORDER BY sessions DESC, plays DESC
+       LIMIT ?`,
+    )
+    .all(dayAgo, limit) as TrendingShow[];
+
+  const weekRows = trendingFromRollup(weekStart, limit);
+  const monthRows = trendingFromRollup(monthStart, limit);
+  const allRows = trendingFromRollup(null, limit);
+
+  return {
+    generated_at: new Date(now).toISOString(),
+    windows: {
+      now: nowRows,
+      week: weekRows,
+      month: monthRows,
+      all: allRows,
+    },
+  };
+}
+
+/**
+ * One-shot backfill: rolls up every distinct day present in
+ * analytics_events. No-op if show_plays_daily already has rows. Returns
+ * the number of days rolled (0 means already populated). Intended to
+ * run once at startup so /api/trending isn't blank against a freshly
+ * pulled prod DB.
+ */
+export function backfillShowPlaysIfEmpty(): number {
+  const db = getAnalyticsDb();
+  const existing = db
+    .prepare(`SELECT COUNT(*) AS c FROM show_plays_daily`)
+    .get() as { c: number };
+  if (existing.c > 0) return 0;
+
+  const days = db
+    .prepare(
+      `SELECT DISTINCT date(ts / 1000, 'unixepoch') AS day
+       FROM analytics_events
+       WHERE event = 'playback_start'
+         AND json_extract(props, '$.show_id') IS NOT NULL
+       ORDER BY day`,
+    )
+    .all() as Array<{ day: string }>;
+
+  for (const { day } of days) rollupShowPlaysDay(day);
+  return days.length;
+}
+
+function trendingFromRollup(sinceDay: string | null, limit: number): TrendingShow[] {
+  const db = getAnalyticsDb();
+  const where = sinceDay ? "WHERE day >= ?" : "";
+  const params: (string | number)[] = sinceDay ? [sinceDay, limit] : [limit];
+  return db
+    .prepare(
+      `SELECT show_id,
+              SUM(sessions) AS sessions,
+              SUM(plays) AS plays
+       FROM show_plays_daily
+       ${where}
+       GROUP BY show_id
+       ORDER BY sessions DESC, plays DESC
+       LIMIT ?`,
+    )
+    .all(...params) as TrendingShow[];
+}
+
+function todayUtcMinusDays(daysBack: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - daysBack);
+  return d.toISOString().slice(0, 10);
 }
 
 // ── Cleanup ──────────────────────────────────────────────────────────

--- a/api/src/db/analytics.ts
+++ b/api/src/db/analytics.ts
@@ -1824,31 +1824,32 @@ export function getTrending(limit = 10): TrendingResponse {
 }
 
 /**
- * One-shot backfill: rolls up every distinct day present in
- * analytics_events. No-op if show_plays_daily already has rows. Returns
- * the number of days rolled (0 means already populated). Intended to
- * run once at startup so /api/trending isn't blank against a freshly
- * pulled prod DB.
+ * Backfill any day present in analytics_events that has no rows in
+ * show_plays_daily yet. Runs every startup — cheap when there's nothing
+ * to do, self-heals after `make db-pull-analytics` or any other event
+ * that introduces historical days the rollup never saw.
+ *
+ * Returns the number of days rolled up (0 = nothing to backfill).
  */
 export function backfillShowPlaysIfEmpty(): number {
   const db = getAnalyticsDb();
-  const existing = db
-    .prepare(`SELECT COUNT(*) AS c FROM show_plays_daily`)
-    .get() as { c: number };
-  if (existing.c > 0) return 0;
 
-  const days = db
+  const missingDays = db
     .prepare(
-      `SELECT DISTINCT date(ts / 1000, 'unixepoch') AS day
-       FROM analytics_events
-       WHERE event = 'playback_start'
-         AND json_extract(props, '$.show_id') IS NOT NULL
+      `SELECT DISTINCT date(e.ts / 1000, 'unixepoch') AS day
+       FROM analytics_events e
+       WHERE e.event = 'playback_start'
+         AND json_extract(e.props, '$.show_id') IS NOT NULL
+         AND NOT EXISTS (
+           SELECT 1 FROM show_plays_daily r
+           WHERE r.day = date(e.ts / 1000, 'unixepoch')
+         )
        ORDER BY day`,
     )
     .all() as Array<{ day: string }>;
 
-  for (const { day } of days) rollupShowPlaysDay(day);
-  return days.length;
+  for (const { day } of missingDays) rollupShowPlaysDay(day);
+  return missingDays.length;
 }
 
 function trendingFromRollup(sinceDay: string | null, limit: number): TrendingShow[] {

--- a/api/src/routes/trending.ts
+++ b/api/src/routes/trending.ts
@@ -1,0 +1,119 @@
+import type { FastifyInstance } from "fastify";
+import {
+  backfillShowPlaysIfEmpty,
+  getTrending,
+  rollupShowPlaysDay,
+} from "../db/analytics.js";
+import { getPublisher } from "../db/redis.js";
+
+const CACHE_KEY = "trending:v1";
+const CACHE_TTL_SECONDS = 600; // 10 minutes
+const TRENDING_LIMIT = 10;
+
+const trendingShowSchema = {
+  type: "object",
+  properties: {
+    show_id: { type: "string" },
+    sessions: { type: "number" },
+    plays: { type: "number" },
+  },
+} as const;
+
+export async function trendingRoutes(app: FastifyInstance): Promise<void> {
+  app.get(
+    "/api/trending",
+    {
+      schema: {
+        tags: ["analytics"],
+        summary: "Trending shows for the home screen",
+        description:
+          "Returns four time windows (now=24h, week, month, all-time) of " +
+          "the most-played shows. Cached for 10 minutes in Redis.",
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              generated_at: { type: "string" },
+              windows: {
+                type: "object",
+                properties: {
+                  now: { type: "array", items: trendingShowSchema },
+                  week: { type: "array", items: trendingShowSchema },
+                  month: { type: "array", items: trendingShowSchema },
+                  all: { type: "array", items: trendingShowSchema },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    async (_request, reply) => {
+      // Try Redis first. Failure (no Redis available, network blip) falls
+      // through to a direct query — better to be uncached than to 500.
+      try {
+        const cached = await getPublisher().get(CACHE_KEY);
+        if (cached) {
+          reply.header("X-Trending-Cache", "hit");
+          return reply.type("application/json").send(cached);
+        }
+      } catch {
+        // Fall through to direct query.
+      }
+
+      const fresh = getTrending(TRENDING_LIMIT);
+      const payload = JSON.stringify(fresh);
+
+      try {
+        await getPublisher().set(CACHE_KEY, payload, "EX", CACHE_TTL_SECONDS);
+      } catch {
+        // Cache write best-effort.
+      }
+
+      reply.header("X-Trending-Cache", "miss");
+      return reply.type("application/json").send(payload);
+    },
+  );
+}
+
+// ── Scheduled tasks (call from server.ts) ────────────────────────────
+
+/**
+ * Rolls up today + yesterday on startup, then once per hour. Yesterday is
+ * re-rolled to catch any late-arriving events that landed after midnight UTC.
+ * Today's row is the one that actually drives the week/month/all windows
+ * being fresh on the home screen.
+ */
+export function startTrendingSchedules(): void {
+  const runRollup = (): void => {
+    try {
+      const today = new Date().toISOString().slice(0, 10);
+      const yesterday = new Date(Date.now() - 24 * 3600 * 1000)
+        .toISOString()
+        .slice(0, 10);
+      rollupShowPlaysDay(yesterday);
+      rollupShowPlaysDay(today);
+      // Bust cache so the next request reflects the fresh rollup.
+      getPublisher()
+        .del(CACHE_KEY)
+        .catch(() => {});
+    } catch (err) {
+      console.error("Trending rollup error:", err);
+    }
+  };
+
+  // First-run backfill: if show_plays_daily is empty, populate it from
+  // every day present in analytics_events. Self-healing — drop the table
+  // and restart to re-roll history.
+  try {
+    const filled = backfillShowPlaysIfEmpty();
+    if (filled > 0) {
+      console.log(`[trending] backfilled ${filled} day(s) of show plays`);
+    }
+  } catch (err) {
+    console.error("Trending backfill error:", err);
+  }
+
+  runRollup();
+  setInterval(runRollup, 3600_000).unref();
+}

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -3,6 +3,7 @@ import { closeUsersDb } from "./db/users.js";
 import { closeAnalyticsDb } from "./db/analytics.js";
 import { closeRedis } from "./db/redis.js";
 import { startAnalyticsSchedules } from "./routes/analytics.js";
+import { startTrendingSchedules } from "./routes/trending.js";
 import { startBetaSyncSchedule } from "./routes/beta.js";
 
 const HOST = process.env.HOST ?? "0.0.0.0";
@@ -14,6 +15,7 @@ async function start() {
   try {
     await app.listen({ host: HOST, port: PORT });
     startAnalyticsSchedules();
+    startTrendingSchedules();
     startBetaSyncSchedule();
   } catch (err) {
     app.log.error(err);

--- a/docs/adr/0004-trending-shows.md
+++ b/docs/adr/0004-trending-shows.md
@@ -325,6 +325,91 @@ as a longer-term cleanup.
   Personalized trending ("shows similar to what you've been playing")
   is a different feature and a different conversation.
 
+## Post-implementation updates (2026-05-25)
+
+The endpoint and mobile carousels shipped on iOS and Android. A few
+things changed or got learned during build-out.
+
+### Rollup backfill bug
+
+The hourly rollup was originally written to upsert rows only for the
+*current* UTC day, on the assumption that historical days never change.
+That assumption held until we noticed `week` and `month` windows
+under-counting after the job missed a tick (deploy, restart, etc.) —
+the missed day stayed empty forever because nothing re-visited it.
+
+Fix: the rollup now backfills **any day in the analytics window that
+has no row in `show_plays_daily`**, not just empty days. Cheap because
+the lookup is a left join against the day-keyed index. See commit
+`6cb5edc4`.
+
+This shifts the operational model from "every hour is incremental" to
+"every hour is self-healing." Worth keeping in mind if we ever add a
+second show-keyed rollup — same property should apply.
+
+### UI iteration on the window selector
+
+The ADR specified "Four tabs: Now / Week / Month / All-Time." We tried
+that, an `AssistChip` pill that cycled, and a few other variants before
+landing on the current design:
+
+- **Title is the selector.** The carousel header itself reads
+  "Trending now" / "Trending this week" / "Trending this month" /
+  "Trending all time" and is tappable. A secondary "Show <next>" label
+  on the right of the row hints at the cycle and is also tappable.
+- **Why:** A four-tab strip burned vertical space and made the section
+  feel heavier than its neighbors (Recently Played, Today in History).
+  Inline cycling collapses the control into the heading itself.
+- **Risk we accepted:** without explicit tab affordances, users may
+  not immediately discover that the window is configurable. Mitigation:
+  the "Show <next>" text on the right reads as an action; the same
+  preference is also exposed as a segmented control in Settings →
+  Home Screen.
+
+### Carousel position is a user preference, not hardcoded
+
+The ADR said "v1 hard-codes the position above TIH." We implemented a
+`homeTrendingAboveToday` boolean instead, because once we had it
+running it was obvious that someone who prefers date-context-first
+(Today in History) over discovery-first (Trending) shouldn't have to
+wait for a "reorderable home modules" feature to flip it.
+
+Default flipped to **Trending below Today** mid-build, based on
+preference for the date-centric Today section anchoring the screen.
+
+### Per-section card sizing
+
+The Trending carousel surfaces 10 items, vs Today (typically 1-3) and
+Collections (a handful). At the default 160pt card width, Trending
+visually dominated the screen — every other section was "scroll past
+this." Solution: each carousel has its own card-size preference
+(`small` / `large`). Trending defaults to small (100pt, date-only
+caption); Today and Collections stay at 160pt. All three are
+user-overridable in Settings → Home Screen.
+
+This is a UI-only knob, not a data concern. Worth recording because
+it surfaces a pattern: the right "compactness" of a carousel is a
+function of how many things are in it and how unique each one is.
+Recently-played-by-this-user (always-relevant) and trending-shows
+(many, mostly-unknown-to-this-user) shouldn't get the same real
+estate per item.
+
+### Long-press preview parity
+
+Recently Played had a long-press detail popover from day one. Today
+and Trending did not. Added bottom-sheet (Android) and contextMenu
+preview (iOS) handlers for parity — users who long-press one show
+card now get the same detail surface on all three sections. Cheap
+to do and the inconsistency was confusing.
+
+### Settings grouping + reset
+
+All six home preferences (window, above-Today, recent rows, three card
+sizes) now live under a dedicated "Home Screen" section in Settings,
+with a "Reset Home Screen to Defaults" action at the bottom. The
+density of home knobs reached a tipping point during this round; one
+big "Preferences" section was getting hard to scan.
+
 ## References
 
 - `api-data/analytics.db` — production analytics database (pulled via

--- a/docs/adr/0004-trending-shows.md
+++ b/docs/adr/0004-trending-shows.md
@@ -1,0 +1,334 @@
+# ADR-0004: Trending shows on the home screen
+
+## Status
+
+Proposed (2026-05-24)
+
+## Context
+
+We collect playback analytics on every track start (`playback_start`
+events with `show_id` and `recording_id` in the props). At time of
+writing the prod `analytics.db` holds ~6,800 such events across 51
+days, growing — last week averaged ~280 plays/day. This data is rich
+enough to answer "what are people listening to right now?" but is
+currently invisible to users.
+
+There is product appetite for a **Trending Now** surface on the home
+screen. The motivation is **discovery**: today the home screen surfaces
+Today-in-History (date-relevant shows from prior years) and a few
+hand-curated entry points. There is no signal that exposes "what other
+listeners are actually playing this week." The catalog is enormous
+(thousands of shows) and most of it never surfaces in front of any
+given user. Trending is meant to widen the funnel.
+
+A naive design — "show the top N most-played shows in window X" —
+runs into several issues that surfaced during data analysis:
+
+1. **`playback_start` fires per track**, not per show. A user who
+   plays one track and a user who plays a full 22-track second set
+   look like 1 vs 22 plays of the same show. Raw play counts
+   conflate engagement breadth with engagement depth.
+
+2. **Without de-duplication, a single user can dominate.** Example
+   from prod: show `1981-03-21-rainbow-theatre-london-england` shows
+   33 plays in the last 7 days — from **one** install. A show with 9
+   listeners averaging 3 plays each is more meaningfully "trending."
+
+3. **Today-in-History drives a daily content cycle.** Different shows
+   surface naturally on different dates because TIH is one of the main
+   things driving people into the player. This is a feature, not a
+   problem — it means raw counts in short windows already differ
+   meaningfully from all-time counts without any special "velocity"
+   math.
+
+4. **Short windows have low absolute volume.** A 24-hour window
+   currently sees ~280 plays total, spread across dozens of shows.
+   The top show in a day might have only 2-6 distinct listeners.
+   Any minimum-listener filter would empty the list.
+
+5. **Velocity-style rankings ("trending vs baseline") add complexity
+   without obvious payoff** at current scale. With TIH naturally
+   rotating the catalog, raw counts already differentiate windows.
+
+The product goal is **catalog exposure**, not consensus ranking. The
+user has explicitly stated a preference for filling a 10-slot list
+with low-confidence picks over showing 2-3 high-confidence picks. A
+show with one listener is still "trending" in the sense that
+matters — someone is listening to it and we have nothing more
+authoritative to surface.
+
+## Decision
+
+### Endpoint
+
+A single `GET /api/trending` endpoint returns four time windows in
+one response so client tab switches are instant:
+
+```json
+{
+  "generated_at": "2026-05-24T18:00:00Z",
+  "windows": {
+    "now":   [ { "show_id": "...", "sessions": 6, "plays": 14 }, ... 10 ],
+    "week":  [ ... 10 ],
+    "month": [ ... 10 ],
+    "all":   [ ... 10 ]
+  }
+}
+```
+
+Payload is small (~5KB). Cached in Redis under `trending:v1` with a
+10-minute TTL.
+
+### Window semantics
+
+- **`now`** — rolling last 24 hours (not calendar day). Smoother
+  than midnight-bounded windows; matches the "Now" label.
+- **`week`** — rolling last 7 days.
+- **`month`** — rolling last 30 days.
+- **`all`** — all-time, since the analytics table's first row.
+
+### Ranking primitive: show-sessions
+
+The unit ranked is a **show-session**: one distinct
+`(install_id, session_id, show_id)` tuple. One person sitting down
+to play a show = 1 session, regardless of whether they played 1
+track or 22. This dedupes the per-track inflation cleanly.
+
+```sql
+sessions  = COUNT(DISTINCT iid || '|' || sid)  -- primary ranking signal
+plays     = COUNT(*)                            -- raw track plays (exposed for transparency)
+```
+
+We deliberately **do not** expose distinct-listeners in the rolled-up
+windows. See *Distinct-listener counting* below.
+
+Within each window:
+```
+ORDER BY sessions DESC, plays DESC
+LIMIT 10
+```
+
+No minimum-listener filter, no minimum-session filter. A show with one
+session still gets a slot if there are not 10 better candidates.
+
+### Overlap across windows: allow it
+
+Cornell 5/8/77 can legitimately appear in `now`, `week`, `month`,
+**and** `all` simultaneously. We do not exclude shows from shorter
+windows that appear in longer ones. Rationale: the user wants
+**"what people are actually playing"** to be the source of truth, not
+a curated "spread the love" filter. If Cornell really is trending
+today, it belongs on the Today tab. If users want fresh discovery,
+that's exactly what the Week / Month / All-Time tabs give them when
+Cornell falls off the short windows.
+
+### Storage: per-show daily rollup
+
+A new table aggregates show plays per calendar day:
+
+```sql
+CREATE TABLE show_plays_daily (
+  day TEXT NOT NULL,           -- 'YYYY-MM-DD' UTC
+  show_id TEXT NOT NULL,
+  sessions INTEGER NOT NULL,   -- COUNT(DISTINCT iid || '|' || sid) within day
+  plays INTEGER NOT NULL,      -- COUNT(*) within day
+  PRIMARY KEY (day, show_id)
+);
+CREATE INDEX idx_show_plays_day ON show_plays_daily(day);
+```
+
+The week / month / all windows are computed by summing across this
+rollup — cheap (~thousands of rows at most).
+
+The **`now` (24h)** window does **not** use the rollup. It queries
+`analytics_events` directly with a `ts > now() - 24h` predicate. This
+gives true rolling-24h semantics, sidesteps the day-boundary
+mismatch with the rollup, and is cheap at current volume (uses
+`idx_analytics_event_ts`). At ~6,800 events total it's effectively
+free; the design is fine until volume grows ~100×.
+
+### Rollup cadence: hourly
+
+The rollup job runs **hourly**, not nightly. Two reasons:
+- Keeps the week / month / all windows fresh enough that the home
+  screen feels live, not 24-hour-stale.
+- Cheap to do — incremental upsert of today's row only.
+
+The existing `analytics_daily_rollup` job remains nightly; the new
+per-show rollup is independent.
+
+### Distinct-listener counting
+
+The natural question — "how many distinct *people* listened to this
+show this week?" — cannot be answered by summing daily rollup rows.
+If Alice listens Mon, Tue, Wed she gets counted three times in
+`SUM(daily.listeners)`. True distinct counts would require either
+querying `analytics_events` directly for each window (heavier) or a
+materialized per-iid roll.
+
+We chose to **not expose distinct-listener counts in the response at
+all**, for v1:
+
+- The user has explicitly stated they care more about "times played"
+  than "who listened." A single very engaged user is a legitimate
+  trending signal, not noise to filter out.
+- Show-sessions already gives us the right ranking signal without
+  needing distinct-listener counts.
+- Avoiding the field entirely is honest. We don't return a number
+  that could be misread as "humans" when it's really "listener-days."
+
+If a future product need requires true distinct listener counts (e.g.,
+a "X people are listening to this" badge), we'll query
+`analytics_events` directly for that specific use case, or add a
+second rollup keyed by `(week, show_id, iid)`.
+
+### Client integration
+
+- The home screen gains a **"Trending Now"** carousel section.
+- Four tabs: **Now / Week / Month / All-Time**, defaulting to **Now**
+  (the tab that changes most, and the one with the highest discovery
+  value).
+- Each tab is a horizontal scroll of 10 show cards, matching the
+  existing home carousel pattern.
+- Refreshes on app open and on pull-to-refresh.
+
+Carousel position on the home screen defaults to **above
+Today-in-History**, but is built as a reorderable home module so
+the user can move it (or hide it) from Settings. If the existing
+home doesn't already have a module-ordering system, that work is
+out of scope for the trending feature itself and v1 hard-codes the
+position above TIH.
+
+## Consequences
+
+### Positive
+
+- **Catalog exposure.** Up to 40 distinct shows surface across the
+  four tabs (with full overlap allowed, fewer in practice). Today the
+  home surfaces ~5-10. Massive widening of the funnel.
+- **Listener data finally drives product.** Two months of analytics
+  data has been informing nothing user-facing. This is the first
+  surface that uses it.
+- **No "favorites cabal" lock-in.** Even if Cornell dominates every
+  tab, the Week and Month tabs will still expose date-rotating TIH
+  picks, '82 Greek runs, Spring '90, etc., because those genuinely
+  appear in the data alongside the perennial favorites.
+- **Cheap to run.** One Redis-cached endpoint, one hourly rollup job,
+  one small table. The `now` window scans `analytics_events` directly
+  but that table is small and indexed.
+- **Self-improving signal as user base grows.** Today the `now`
+  window has limited signal (~2-6 listeners per top show). At 10×
+  volume the same query gives noticeably stronger rankings without
+  any code change.
+
+### Negative
+
+- **`now` tab can be lumpy at current scale.** With ~280 plays/day
+  spread across many shows, the top show on `now` might have only a
+  handful of sessions. This is by design (we'd rather show 10 lightly
+  trending shows than 2 strongly trending ones), but a user looking
+  at the data analytically will notice the small numbers. We don't
+  expose session counts in the UI for v1, so this is invisible to
+  most users.
+- **A single power user can move the `now` rankings.** With low
+  absolute volume, one person playing through a full show can put it
+  near the top of the Today tab. We accept this — the product owner
+  has explicitly opted into this tradeoff, and it tends to surface
+  *more* catalog, not less.
+- **`week`/`month` aggregation drifts slightly from "true."**
+  Computing those windows by summing daily rollup rows means we lose
+  any sub-day distinctness. In practice this only matters for the
+  distinct-listener count, which we deliberately don't expose. The
+  session count is correct because a session ID is scoped to a single
+  app lifetime, which is almost always within one day.
+- **No velocity / momentum signal in v1.** A show that suddenly spikes
+  from 0 plays to 5 plays today won't rank above an evergreen show
+  with 50 plays/day. Velocity would surface novelty better. Deferred
+  until we see whether it's actually missed in practice.
+- **Hourly rollup adds a recurring job to the infra.** Small in
+  absolute cost but it's another thing that can fail silently and
+  cause the home screen to look stale. Mitigation: rollup job emits
+  its own analytics event on success; an absence is detectable.
+
+## Alternatives considered
+
+**Rank by raw play count.** Simplest possible. Rejected because
+`playback_start` fires per track, so a 22-track listen-through
+dominates 22 single-track samples. The signal is engagement-weighted
+in a way that doesn't match user intuition for "trending."
+
+**Rank by distinct listeners only.** Filters out the "one obsessive
+listener" case cleanly. Rejected because the product owner explicitly
+prefers exposing more catalog — a show with one engaged listener is
+still a legitimate trending signal in a discovery context. Also
+inflates the rollup-double-counting problem.
+
+**Velocity (window count vs baseline).** Rank by `plays_in_window /
+expected_plays_from_baseline` so newly-spiking shows rise above
+perennials. Considered seriously. Rejected for v1 because (a) TIH
+already provides natural rotation that differentiates short windows
+from long ones, (b) low-volume windows blow up the math (1 / 0
+problem) and need Bayesian smoothing to be sane, and (c) the user
+goal is exposure breadth, not novelty detection. Reconsider if
+windows start looking too similar in practice.
+
+**Anti-overlap across windows.** Exclude from shorter windows any
+show that appears in a longer window's top-N. Considered seriously
+and proposed in conversation. Rejected because the user wants the
+trending list to reflect actual listening, not a curated "spread the
+content" filter. Cornell genuinely trending today should appear on
+Today.
+
+**Minimum-listener filter (e.g., ≥3 distinct listeners).** Would
+cleanly remove the "one person played it" entries from the `now`
+tab. Rejected because it would empty the Today tab at current
+volume — the product owner prefers a full list of weak signals over
+an empty list of strong ones.
+
+**Per-window endpoint (`GET /api/trending?window=now`).** RESTful
+and feels right. Rejected in favor of returning all four windows in
+one response so tab switches don't require network round-trips. The
+payload is ~5KB; the latency savings are worth it.
+
+**Compute on every request (no rollup).** At current volume this
+would work. Rejected because the design needs to survive a 10-100×
+volume increase without rework. The hourly rollup is cheap to add
+now and prevents a future migration.
+
+**Reuse `analytics_daily_rollup`.** The existing table aggregates by
+`(day, event, platform, app_version)` — no `show_id` dimension. We'd
+have to extend it or join into props JSON on every query. A separate
+per-show rollup table is cleaner and keeps the existing rollup's
+schema stable.
+
+**Track a dedicated `show_open` or `show_play_started` event distinct
+from per-track `playback_start`.** Would give us a cleaner "show
+session" primitive without the dedup step. Considered. Rejected for
+v1 because (a) `playback_start` + iid/sid dedup already approximates
+this, (b) adding a new client event means waiting for app version
+adoption before the signal is reliable, and (c) the data we have
+goes back 51 days and we want trending working immediately, not in
+60 days when a new app version reaches saturation. Worth revisiting
+as a longer-term cleanup.
+
+## Open questions
+
+- **UI session-count visibility.** Do we show "X people listening
+  this week" next to each show? Probably not for v1 — keeps the
+  surface clean and avoids the listener-day-vs-people distinction
+  leaking to users. Revisit after launch.
+- **Pagination beyond 10.** v1 returns 10 per window. If users
+  reach the end and want more, we'd extend to a paginated
+  `/api/trending/{window}` endpoint. Decision deferred until we see
+  engagement.
+- **Personalization.** Global-only for v1, by explicit decision.
+  Personalized trending ("shows similar to what you've been playing")
+  is a different feature and a different conversation.
+
+## References
+
+- `api-data/analytics.db` — production analytics database (pulled via
+  `make db-pull-analytics`).
+- `Makefile` — `db-pull-analytics` target for fetching prod data.
+- Existing schema: `analytics_events`, `analytics_daily_rollup`.
+- Event: `playback_start` with props `{ show_id, recording_id, track_index }`.

--- a/iosApp/deadly/App/AppContainer.swift
+++ b/iosApp/deadly/App/AppContainer.swift
@@ -17,6 +17,7 @@ final class AppContainer {
     let showRepository: any ShowRepository
     let searchService: SearchServiceImpl
     let homeService: HomeServiceImpl
+    let trendingService: TrendingServiceImpl
     let favoritesService: FavoritesServiceImpl
     let collectionsService: CollectionsServiceImpl
     let streamPlayer: StreamPlayer
@@ -156,6 +157,15 @@ final class AppContainer {
                 collectionsDAO: CollectionsDAO(database: db),
                 recentShowsService: recentService
             )
+
+            // Trending pulls from /api/trending and resolves IDs against
+            // the local show catalog. @MainActor; safe to init inline.
+            trendingService = MainActor.assumeIsolated {
+                TrendingServiceImpl(
+                    appPreferences: prefs,
+                    showRepository: showRepo
+                )
+            }
 
             let archive = URLSessionArchiveMetadataClient()
             archiveClient = archive

--- a/iosApp/deadly/Core/Design/DeadlyTheme.swift
+++ b/iosApp/deadly/Core/Design/DeadlyTheme.swift
@@ -42,9 +42,26 @@ enum DeadlySpacing {
 
 enum DeadlySize {
     static let carouselCard: CGFloat = 160
+    static let carouselCardSmall: CGFloat = 100
     static let recentCardHeight: CGFloat = 64
     static let recentArtwork: CGFloat = 56
     static let artworkCornerRadius: CGFloat = 6
     static let cardCornerRadius: CGFloat = 8
     static let carouselCornerRadius: CGFloat = 12
+}
+
+/// Per-section carousel sizing on Home. Persisted as raw strings.
+enum CarouselCardSize: String, CaseIterable, Identifiable {
+    case small, large
+    var id: String { rawValue }
+    var label: String { self == .small ? "Small" : "Large" }
+    var width: CGFloat {
+        switch self {
+        case .small: return DeadlySize.carouselCardSmall
+        case .large: return DeadlySize.carouselCard
+        }
+    }
+    init(preferenceKey: String) {
+        self = CarouselCardSize(rawValue: preferenceKey) ?? .large
+    }
 }

--- a/iosApp/deadly/Core/Service/AppPreferences.swift
+++ b/iosApp/deadly/Core/Service/AppPreferences.swift
@@ -131,7 +131,7 @@ final class AppPreferences {
             Self.sourceBadgeStyleKey: "LONG",
             Self.playerControlsStyleKey: "skipTrack",
             Self.homeTrendingWindowKey: "now",
-            Self.homeTrendingAboveTodayKey: true,
+            Self.homeTrendingAboveTodayKey: false,
         ])
         includeShowsWithoutRecordings = UserDefaults.standard.bool(forKey: Self.includeShowsWithoutRecordingsKey)
         customServerUrl = UserDefaults.standard.string(forKey: Self.customServerUrlKey) ?? ""

--- a/iosApp/deadly/Core/Service/AppPreferences.swift
+++ b/iosApp/deadly/Core/Service/AppPreferences.swift
@@ -22,6 +22,9 @@ final class AppPreferences {
     private static let homeTrendingWindowKey = "home_trending_window"
     private static let homeTrendingAboveTodayKey = "home_trending_above_today"
     private static let homeRecentRowsKey = "home_recent_rows"
+    private static let homeTrendingCardSizeKey = "home_trending_card_size"
+    private static let homeTodayCardSizeKey = "home_today_card_size"
+    private static let homeCollectionsCardSizeKey = "home_collections_card_size"
 
     /// Server environment: "prod", "beta", or "custom".
     var serverEnvironment: String {
@@ -119,6 +122,31 @@ final class AppPreferences {
         }
     }
 
+    /// Card size for the Trending carousel: "small" or "large".
+    var homeTrendingCardSize: String {
+        didSet { UserDefaults.standard.set(homeTrendingCardSize, forKey: Self.homeTrendingCardSizeKey) }
+    }
+
+    /// Card size for the Today in History carousel: "small" or "large".
+    var homeTodayCardSize: String {
+        didSet { UserDefaults.standard.set(homeTodayCardSize, forKey: Self.homeTodayCardSizeKey) }
+    }
+
+    /// Card size for the Featured Collections carousel: "small" or "large".
+    var homeCollectionsCardSize: String {
+        didSet { UserDefaults.standard.set(homeCollectionsCardSize, forKey: Self.homeCollectionsCardSizeKey) }
+    }
+
+    /// Restore all Home Screen preferences to defaults.
+    func resetHomePreferences() {
+        homeTrendingWindow = "now"
+        homeTrendingAboveToday = false
+        homeRecentRows = 2
+        homeTrendingCardSize = "small"
+        homeTodayCardSize = "large"
+        homeCollectionsCardSize = "large"
+    }
+
     /// Persistent install ID (UUID). Generated once on first access, survives opt-out/opt-in cycles.
     let installId: String
 
@@ -143,6 +171,9 @@ final class AppPreferences {
             Self.homeTrendingWindowKey: "now",
             Self.homeTrendingAboveTodayKey: false,
             Self.homeRecentRowsKey: 2,
+            Self.homeTrendingCardSizeKey: "small",
+            Self.homeTodayCardSizeKey: "large",
+            Self.homeCollectionsCardSizeKey: "large",
         ])
         includeShowsWithoutRecordings = UserDefaults.standard.bool(forKey: Self.includeShowsWithoutRecordingsKey)
         customServerUrl = UserDefaults.standard.string(forKey: Self.customServerUrlKey) ?? ""
@@ -166,6 +197,9 @@ final class AppPreferences {
         homeTrendingWindow = UserDefaults.standard.string(forKey: Self.homeTrendingWindowKey) ?? "now"
         homeTrendingAboveToday = UserDefaults.standard.bool(forKey: Self.homeTrendingAboveTodayKey)
         homeRecentRows = max(1, min(4, UserDefaults.standard.integer(forKey: Self.homeRecentRowsKey)))
+        homeTrendingCardSize = UserDefaults.standard.string(forKey: Self.homeTrendingCardSizeKey) ?? "small"
+        homeTodayCardSize = UserDefaults.standard.string(forKey: Self.homeTodayCardSizeKey) ?? "large"
+        homeCollectionsCardSize = UserDefaults.standard.string(forKey: Self.homeCollectionsCardSizeKey) ?? "large"
         analyticsEnabled = UserDefaults.standard.object(forKey: Self.analyticsEnabledKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: Self.analyticsEnabledKey)

--- a/iosApp/deadly/Core/Service/AppPreferences.swift
+++ b/iosApp/deadly/Core/Service/AppPreferences.swift
@@ -21,6 +21,7 @@ final class AppPreferences {
     private static let playerControlsStyleKey = "player_controls_style"
     private static let homeTrendingWindowKey = "home_trending_window"
     private static let homeTrendingAboveTodayKey = "home_trending_above_today"
+    private static let homeRecentRowsKey = "home_recent_rows"
 
     /// Server environment: "prod", "beta", or "custom".
     var serverEnvironment: String {
@@ -109,6 +110,15 @@ final class AppPreferences {
         didSet { UserDefaults.standard.set(homeTrendingAboveToday, forKey: Self.homeTrendingAboveTodayKey) }
     }
 
+    /// Rows of Recently Played to render on home (1..4). Each row = 2 shows.
+    var homeRecentRows: Int {
+        didSet {
+            let clamped = max(1, min(4, homeRecentRows))
+            if clamped != homeRecentRows { homeRecentRows = clamped; return }
+            UserDefaults.standard.set(homeRecentRows, forKey: Self.homeRecentRowsKey)
+        }
+    }
+
     /// Persistent install ID (UUID). Generated once on first access, survives opt-out/opt-in cycles.
     let installId: String
 
@@ -132,6 +142,7 @@ final class AppPreferences {
             Self.playerControlsStyleKey: "skipTrack",
             Self.homeTrendingWindowKey: "now",
             Self.homeTrendingAboveTodayKey: false,
+            Self.homeRecentRowsKey: 2,
         ])
         includeShowsWithoutRecordings = UserDefaults.standard.bool(forKey: Self.includeShowsWithoutRecordingsKey)
         customServerUrl = UserDefaults.standard.string(forKey: Self.customServerUrlKey) ?? ""
@@ -154,6 +165,7 @@ final class AppPreferences {
         playerControlsStyle = UserDefaults.standard.string(forKey: Self.playerControlsStyleKey) ?? "skipTrack"
         homeTrendingWindow = UserDefaults.standard.string(forKey: Self.homeTrendingWindowKey) ?? "now"
         homeTrendingAboveToday = UserDefaults.standard.bool(forKey: Self.homeTrendingAboveTodayKey)
+        homeRecentRows = max(1, min(4, UserDefaults.standard.integer(forKey: Self.homeRecentRowsKey)))
         analyticsEnabled = UserDefaults.standard.object(forKey: Self.analyticsEnabledKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: Self.analyticsEnabledKey)

--- a/iosApp/deadly/Core/Service/AppPreferences.swift
+++ b/iosApp/deadly/Core/Service/AppPreferences.swift
@@ -19,6 +19,7 @@ final class AppPreferences {
     private static let analyticsEnabledKey = "analytics_enabled"
     private static let installIdKey = "install_id"
     private static let playerControlsStyleKey = "player_controls_style"
+    private static let homeTrendingWindowKey = "home_trending_window"
 
     /// Server environment: "prod", "beta", or "custom".
     var serverEnvironment: String {
@@ -97,6 +98,11 @@ final class AppPreferences {
         didSet { UserDefaults.standard.set(playerControlsStyle, forKey: Self.playerControlsStyleKey) }
     }
 
+    /// Which trending window the home screen shows: "now"/"week"/"month"/"all".
+    var homeTrendingWindow: String {
+        didSet { UserDefaults.standard.set(homeTrendingWindow, forKey: Self.homeTrendingWindowKey) }
+    }
+
     /// Persistent install ID (UUID). Generated once on first access, survives opt-out/opt-in cycles.
     let installId: String
 
@@ -118,6 +124,7 @@ final class AppPreferences {
             Self.shareAttachImageKey: false,
             Self.sourceBadgeStyleKey: "LONG",
             Self.playerControlsStyleKey: "skipTrack",
+            Self.homeTrendingWindowKey: "now",
         ])
         includeShowsWithoutRecordings = UserDefaults.standard.bool(forKey: Self.includeShowsWithoutRecordingsKey)
         customServerUrl = UserDefaults.standard.string(forKey: Self.customServerUrlKey) ?? ""
@@ -138,6 +145,7 @@ final class AppPreferences {
         shareAttachImage = UserDefaults.standard.bool(forKey: Self.shareAttachImageKey)
         sourceBadgeStyle = UserDefaults.standard.string(forKey: Self.sourceBadgeStyleKey) ?? "LONG"
         playerControlsStyle = UserDefaults.standard.string(forKey: Self.playerControlsStyleKey) ?? "skipTrack"
+        homeTrendingWindow = UserDefaults.standard.string(forKey: Self.homeTrendingWindowKey) ?? "now"
         analyticsEnabled = UserDefaults.standard.object(forKey: Self.analyticsEnabledKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: Self.analyticsEnabledKey)

--- a/iosApp/deadly/Core/Service/AppPreferences.swift
+++ b/iosApp/deadly/Core/Service/AppPreferences.swift
@@ -20,6 +20,7 @@ final class AppPreferences {
     private static let installIdKey = "install_id"
     private static let playerControlsStyleKey = "player_controls_style"
     private static let homeTrendingWindowKey = "home_trending_window"
+    private static let homeTrendingAboveTodayKey = "home_trending_above_today"
 
     /// Server environment: "prod", "beta", or "custom".
     var serverEnvironment: String {
@@ -103,6 +104,11 @@ final class AppPreferences {
         didSet { UserDefaults.standard.set(homeTrendingWindow, forKey: Self.homeTrendingWindowKey) }
     }
 
+    /// When true, Trending renders above Today in History; otherwise below.
+    var homeTrendingAboveToday: Bool {
+        didSet { UserDefaults.standard.set(homeTrendingAboveToday, forKey: Self.homeTrendingAboveTodayKey) }
+    }
+
     /// Persistent install ID (UUID). Generated once on first access, survives opt-out/opt-in cycles.
     let installId: String
 
@@ -125,6 +131,7 @@ final class AppPreferences {
             Self.sourceBadgeStyleKey: "LONG",
             Self.playerControlsStyleKey: "skipTrack",
             Self.homeTrendingWindowKey: "now",
+            Self.homeTrendingAboveTodayKey: true,
         ])
         includeShowsWithoutRecordings = UserDefaults.standard.bool(forKey: Self.includeShowsWithoutRecordingsKey)
         customServerUrl = UserDefaults.standard.string(forKey: Self.customServerUrlKey) ?? ""
@@ -146,6 +153,7 @@ final class AppPreferences {
         sourceBadgeStyle = UserDefaults.standard.string(forKey: Self.sourceBadgeStyleKey) ?? "LONG"
         playerControlsStyle = UserDefaults.standard.string(forKey: Self.playerControlsStyleKey) ?? "skipTrack"
         homeTrendingWindow = UserDefaults.standard.string(forKey: Self.homeTrendingWindowKey) ?? "now"
+        homeTrendingAboveToday = UserDefaults.standard.bool(forKey: Self.homeTrendingAboveTodayKey)
         analyticsEnabled = UserDefaults.standard.object(forKey: Self.analyticsEnabledKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: Self.analyticsEnabledKey)

--- a/iosApp/deadly/Core/Service/TrendingService.swift
+++ b/iosApp/deadly/Core/Service/TrendingService.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+enum TrendingWindow: String, CaseIterable, Identifiable {
+    case now, week, month, all
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .now: return "24h"
+        case .week: return "Week"
+        case .month: return "Month"
+        case .all: return "All-Time"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .now: return "Last 24 hours"
+        case .week: return "Last 7 days"
+        case .month: return "Last 30 days"
+        case .all: return "All time"
+        }
+    }
+
+    /// Tolerant of unknown strings — defaults to .now.
+    init(preferenceKey: String) {
+        self = TrendingWindow(rawValue: preferenceKey) ?? .now
+    }
+}
+
+struct TrendingContent: Sendable {
+    var now: [Show] = []
+    var week: [Show] = []
+    var month: [Show] = []
+    var all: [Show] = []
+
+    func shows(for window: TrendingWindow) -> [Show] {
+        switch window {
+        case .now: return now
+        case .week: return week
+        case .month: return month
+        case .all: return all
+        }
+    }
+}
+
+@MainActor
+protocol TrendingService {
+    var content: TrendingContent { get }
+    func refresh() async
+}

--- a/iosApp/deadly/Core/Service/TrendingService.swift
+++ b/iosApp/deadly/Core/Service/TrendingService.swift
@@ -6,10 +6,10 @@ enum TrendingWindow: String, CaseIterable, Identifiable {
 
     var label: String {
         switch self {
-        case .now: return "Day"
-        case .week: return "Week"
-        case .month: return "Month"
-        case .all: return "All"
+        case .now: return "now"
+        case .week: return "this week"
+        case .month: return "this month"
+        case .all: return "all time"
         }
     }
 

--- a/iosApp/deadly/Core/Service/TrendingService.swift
+++ b/iosApp/deadly/Core/Service/TrendingService.swift
@@ -6,19 +6,20 @@ enum TrendingWindow: String, CaseIterable, Identifiable {
 
     var label: String {
         switch self {
-        case .now: return "24h"
+        case .now: return "Day"
         case .week: return "Week"
         case .month: return "Month"
-        case .all: return "All-Time"
+        case .all: return "All"
         }
     }
 
-    var subtitle: String {
+    /// Next window in cycle order. `.all` wraps back to `.now`.
+    var next: TrendingWindow {
         switch self {
-        case .now: return "Last 24 hours"
-        case .week: return "Last 7 days"
-        case .month: return "Last 30 days"
-        case .all: return "All time"
+        case .now: return .week
+        case .week: return .month
+        case .month: return .all
+        case .all: return .now
         }
     }
 

--- a/iosApp/deadly/Core/Service/TrendingServiceImpl.swift
+++ b/iosApp/deadly/Core/Service/TrendingServiceImpl.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Fetches /api/trending and resolves the returned show IDs into Show
+/// domain models from the local catalog. Server returns four windows
+/// (now=24h, week, month, all-time) — we hydrate each independently and
+/// preserve server ranking order.
+@Observable
+@MainActor
+final class TrendingServiceImpl: TrendingService {
+    private let appPreferences: AppPreferences
+    private let showRepository: any ShowRepository
+    private let session: URLSession
+
+    private(set) var content = TrendingContent()
+
+    init(
+        appPreferences: AppPreferences,
+        showRepository: any ShowRepository,
+        session: URLSession = .shared
+    ) {
+        self.appPreferences = appPreferences
+        self.showRepository = showRepository
+        self.session = session
+    }
+
+    func refresh() async {
+        do {
+            let payload = try await fetchPayload()
+            let nowIds = payload.windows.now.map(\.show_id)
+            let weekIds = payload.windows.week.map(\.show_id)
+            let monthIds = payload.windows.month.map(\.show_id)
+            let allIds = payload.windows.all.map(\.show_id)
+
+            // Single batch lookup, then reorder per window to preserve
+            // server ranking.
+            let unique = Array(Set(nowIds + weekIds + monthIds + allIds))
+            let byId: [String: Show] = Dictionary(
+                uniqueKeysWithValues: try showRepository.getShowsByIds(unique).map { ($0.id, $0) }
+            )
+
+            content = TrendingContent(
+                now: nowIds.compactMap { byId[$0] },
+                week: weekIds.compactMap { byId[$0] },
+                month: monthIds.compactMap { byId[$0] },
+                all: allIds.compactMap { byId[$0] }
+            )
+        } catch {
+            // Leave previous content in place on failure.
+        }
+    }
+
+    private func fetchPayload() async throws -> TrendingPayload {
+        let url = URL(string: "\(appPreferences.apiBaseUrl)/api/trending")!
+        let (data, response) = try await session.data(from: url)
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            throw URLError(.badServerResponse)
+        }
+        return try JSONDecoder().decode(TrendingPayload.self, from: data)
+    }
+
+    // MARK: - Wire format
+
+    private struct TrendingPayload: Decodable {
+        let windows: Windows
+        struct Windows: Decodable {
+            let now: [Entry]
+            let week: [Entry]
+            let month: [Entry]
+            let all: [Entry]
+        }
+        struct Entry: Decodable {
+            let show_id: String
+        }
+    }
+}

--- a/iosApp/deadly/Feature/Home/HomeScreen.swift
+++ b/iosApp/deadly/Feature/Home/HomeScreen.swift
@@ -13,6 +13,15 @@ struct HomeScreen: View {
     private var trendingShows: [Show] {
         trendingService.content.shows(for: trendingWindow)
     }
+    private var trendingCardSize: CarouselCardSize {
+        CarouselCardSize(preferenceKey: appPreferences.homeTrendingCardSize)
+    }
+    private var todayCardSize: CarouselCardSize {
+        CarouselCardSize(preferenceKey: appPreferences.homeTodayCardSize)
+    }
+    private var collectionsCardSize: CarouselCardSize {
+        CarouselCardSize(preferenceKey: appPreferences.homeCollectionsCardSize)
+    }
 
     var body: some View {
         ScrollView {
@@ -26,11 +35,11 @@ struct HomeScreen: View {
                 if appPreferences.homeTrendingAboveToday {
                     if !trendingShows.isEmpty { trendingSection }
                     if !content.todayInHistory.isEmpty {
-                        carouselSection("Today in Grateful Dead History", shows: content.todayInHistory)
+                        carouselSection("Today in Grateful Dead History", shows: content.todayInHistory, size: todayCardSize.width)
                     }
                 } else {
                     if !content.todayInHistory.isEmpty {
-                        carouselSection("Today in Grateful Dead History", shows: content.todayInHistory)
+                        carouselSection("Today in Grateful Dead History", shows: content.todayInHistory, size: todayCardSize.width)
                     }
                     if !trendingShows.isEmpty { trendingSection }
                 }
@@ -56,28 +65,38 @@ struct HomeScreen: View {
 
     private var trendingSection: some View {
         VStack(alignment: .leading, spacing: DeadlySpacing.itemSpacing) {
+            let cycle = {
+                let next = trendingWindow.next
+                appPreferences.homeTrendingWindow = next.rawValue
+                container.analyticsService.track("feature_use", props: [
+                    "feature": "set_home_trending_window",
+                    "category": "preference",
+                    "value": next.rawValue,
+                ])
+            }
             HStack(spacing: 12) {
-                Text("Trending on The Deadly")
-                    .font(.title2)
-                    .fontWeight(.bold)
-                Spacer(minLength: 8)
-                Button {
-                    let next = trendingWindow.next
-                    appPreferences.homeTrendingWindow = next.rawValue
-                    container.analyticsService.track("feature_use", props: [
-                        "feature": "set_home_trending_window",
-                        "category": "preference",
-                        "value": next.rawValue,
-                    ])
-                } label: {
-                    Text(trendingWindow.label)
-                        .font(.headline)
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 6)
-                        .background(.thinMaterial, in: Capsule())
+                Button(action: cycle) {
+                    Text("Trending \(trendingWindow.label)")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Trending window: \(trendingWindow.label). Tap to change.")
+                .accessibilityLabel("Trending \(trendingWindow.label). Tap to change window.")
+
+                Spacer(minLength: 8)
+
+                Button(action: cycle) {
+                    Text("Show \(trendingWindow.next.label)")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
+                .accessibilityHidden(true)
             }
 
             ScrollView(.horizontal, showsIndicators: false) {
@@ -87,11 +106,24 @@ struct HomeScreen: View {
                             ShowCarouselCard(
                                 imageRecordingId: show.bestRecordingId,
                                 imageUrl: show.coverImageUrl,
-                                lines: [show.date, show.venue.name, show.location.displayText],
-                                recordingCount: show.recordingCount
+                                lines: [show.date],
+                                recordingCount: show.recordingCount,
+                                size: trendingCardSize.width
                             )
                         }
                         .buttonStyle(.plain)
+                        .contextMenu {
+                            NavigationLink(value: show.id) {
+                                Label("View Show", systemImage: "eye")
+                            }
+                        } preview: {
+                            ShowDetailPopover(
+                                date: show.date,
+                                venue: show.venue.name,
+                                location: show.location.displayText,
+                                rating: show.hasRating ? show.displayRating : nil
+                            )
+                        }
                     }
                 }
             }
@@ -139,7 +171,7 @@ struct HomeScreen: View {
         }
     }
 
-    private func carouselSection(_ title: String, shows: [Show]) -> some View {
+    private func carouselSection(_ title: String, shows: [Show], size: CGFloat) -> some View {
         VStack(alignment: .leading, spacing: DeadlySpacing.itemSpacing) {
             Text(title)
                 .font(.title2)
@@ -153,7 +185,8 @@ struct HomeScreen: View {
                                 imageRecordingId: show.bestRecordingId,
                                 imageUrl: show.coverImageUrl,
                                 lines: [show.date, show.venue.name, show.location.displayText],
-                                recordingCount: show.recordingCount
+                                recordingCount: show.recordingCount,
+                                size: size
                             )
                         }
                         .buttonStyle(.plain)
@@ -188,7 +221,8 @@ struct HomeScreen: View {
                             ShowCarouselCard(
                                 imageRecordingId: nil,
                                 imageUrl: nil,
-                                lines: [collection.formattedName, collection.showCountText]
+                                lines: [collection.formattedName, collection.showCountText],
+                                size: collectionsCardSize.width
                             )
                         }
                         .buttonStyle(.plain)

--- a/iosApp/deadly/Feature/Home/HomeScreen.swift
+++ b/iosApp/deadly/Feature/Home/HomeScreen.swift
@@ -21,12 +21,18 @@ struct HomeScreen: View {
                     recentShowsSection
                 }
 
-                if !trendingShows.isEmpty {
-                    trendingSection
-                }
-
-                if !content.todayInHistory.isEmpty {
-                    carouselSection("Today in Grateful Dead History", shows: content.todayInHistory)
+                // Trending + Today in History — order honors the
+                // "Show trending above Today" preference.
+                if appPreferences.homeTrendingAboveToday {
+                    if !trendingShows.isEmpty { trendingSection }
+                    if !content.todayInHistory.isEmpty {
+                        carouselSection("Today in Grateful Dead History", shows: content.todayInHistory)
+                    }
+                } else {
+                    if !content.todayInHistory.isEmpty {
+                        carouselSection("Today in Grateful Dead History", shows: content.todayInHistory)
+                    }
+                    if !trendingShows.isEmpty { trendingSection }
                 }
 
                 if !content.featuredCollections.isEmpty {
@@ -50,13 +56,29 @@ struct HomeScreen: View {
 
     private var trendingSection: some View {
         VStack(alignment: .leading, spacing: DeadlySpacing.itemSpacing) {
-            Text("Trending on The Deadly")
-                .font(.title2)
-                .fontWeight(.bold)
-
-            Text(trendingWindow.subtitle)
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            HStack(spacing: 12) {
+                Text("Trending on The Deadly")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                Spacer(minLength: 8)
+                Button {
+                    let next = trendingWindow.next
+                    appPreferences.homeTrendingWindow = next.rawValue
+                    container.analyticsService.track("feature_use", props: [
+                        "feature": "set_home_trending_window",
+                        "category": "preference",
+                        "value": next.rawValue,
+                    ])
+                } label: {
+                    Text(trendingWindow.label)
+                        .font(.headline)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 6)
+                        .background(.thinMaterial, in: Capsule())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Trending window: \(trendingWindow.label). Tap to change.")
+            }
 
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHStack(spacing: DeadlySpacing.itemSpacing) {

--- a/iosApp/deadly/Feature/Home/HomeScreen.swift
+++ b/iosApp/deadly/Feature/Home/HomeScreen.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct HomeScreen: View {
     @Environment(\.appContainer) private var container
+    @State private var recentExpanded = false
 
     private var homeService: HomeServiceImpl { container.homeService }
     private var trendingService: TrendingServiceImpl { container.trendingService }
@@ -101,7 +102,14 @@ struct HomeScreen: View {
     // MARK: - Sections
 
     private var recentShowsSection: some View {
-        VStack(alignment: .leading, spacing: DeadlySpacing.itemSpacing) {
+        // Default to 4 (2×2) to save vertical real estate; reveal up to 8
+        // when the user expands. Local UI state — doesn't persist across
+        // launches by design.
+        let limit = recentExpanded ? 8 : 4
+        let shows = Array(content.recentShows.prefix(limit))
+        let canExpand = content.recentShows.count > 4
+
+        return VStack(alignment: .leading, spacing: DeadlySpacing.itemSpacing) {
             Text("Recently Played")
                 .font(.title2)
                 .fontWeight(.bold)
@@ -113,7 +121,7 @@ struct HomeScreen: View {
                 ],
                 spacing: DeadlySpacing.gridVerticalSpacing
             ) {
-                ForEach(content.recentShows) { show in
+                ForEach(shows) { show in
                     NavigationLink(value: show.id) {
                         RecentShowCard(show: show)
                     }
@@ -131,6 +139,18 @@ struct HomeScreen: View {
                         )
                     }
                 }
+            }
+
+            if canExpand {
+                Button {
+                    withAnimation { recentExpanded.toggle() }
+                } label: {
+                    Text(recentExpanded ? "Show less" : "Show more")
+                        .font(.body)
+                        .frame(maxWidth: .infinity, minHeight: 36)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.tint)
             }
         }
     }

--- a/iosApp/deadly/Feature/Home/HomeScreen.swift
+++ b/iosApp/deadly/Feature/Home/HomeScreen.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct HomeScreen: View {
     @Environment(\.appContainer) private var container
-    @State private var recentExpanded = false
 
     private var homeService: HomeServiceImpl { container.homeService }
     private var trendingService: TrendingServiceImpl { container.trendingService }
@@ -102,12 +101,9 @@ struct HomeScreen: View {
     // MARK: - Sections
 
     private var recentShowsSection: some View {
-        // Default to 4 (2×2) to save vertical real estate; reveal up to 8
-        // when the user expands. Local UI state — doesn't persist across
-        // launches by design.
-        let limit = recentExpanded ? 8 : 4
+        // Row count is a persisted preference (1..4). Each row = 2 shows.
+        let limit = max(1, min(4, appPreferences.homeRecentRows)) * 2
         let shows = Array(content.recentShows.prefix(limit))
-        let canExpand = content.recentShows.count > 4
 
         return VStack(alignment: .leading, spacing: DeadlySpacing.itemSpacing) {
             Text("Recently Played")
@@ -139,18 +135,6 @@ struct HomeScreen: View {
                         )
                     }
                 }
-            }
-
-            if canExpand {
-                Button {
-                    withAnimation { recentExpanded.toggle() }
-                } label: {
-                    Text(recentExpanded ? "Show less" : "Show more")
-                        .font(.body)
-                        .frame(maxWidth: .infinity, minHeight: 36)
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(.tint)
             }
         }
     }

--- a/iosApp/deadly/Feature/Home/HomeScreen.swift
+++ b/iosApp/deadly/Feature/Home/HomeScreen.swift
@@ -4,13 +4,25 @@ struct HomeScreen: View {
     @Environment(\.appContainer) private var container
 
     private var homeService: HomeServiceImpl { container.homeService }
+    private var trendingService: TrendingServiceImpl { container.trendingService }
+    private var appPreferences: AppPreferences { container.appPreferences }
     private var content: HomeContent { homeService.content }
+    private var trendingWindow: TrendingWindow {
+        TrendingWindow(preferenceKey: appPreferences.homeTrendingWindow)
+    }
+    private var trendingShows: [Show] {
+        trendingService.content.shows(for: trendingWindow)
+    }
 
     var body: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: DeadlySpacing.sectionSpacing) {
                 if !content.recentShows.isEmpty {
                     recentShowsSection
+                }
+
+                if !trendingShows.isEmpty {
+                    trendingSection
                 }
 
                 if !content.todayInHistory.isEmpty {
@@ -28,7 +40,40 @@ struct HomeScreen: View {
             .padding(DeadlySpacing.screenPadding)
         }
         .navigationBarTitleDisplayMode(.inline)
-        .task { await homeService.refresh() }
+        .task {
+            await homeService.refresh()
+            await trendingService.refresh()
+        }
+    }
+
+    // MARK: - Trending
+
+    private var trendingSection: some View {
+        VStack(alignment: .leading, spacing: DeadlySpacing.itemSpacing) {
+            Text("Trending on The Deadly")
+                .font(.title2)
+                .fontWeight(.bold)
+
+            Text(trendingWindow.subtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: DeadlySpacing.itemSpacing) {
+                    ForEach(trendingShows) { show in
+                        NavigationLink(value: show.id) {
+                            ShowCarouselCard(
+                                imageRecordingId: show.bestRecordingId,
+                                imageUrl: show.coverImageUrl,
+                                lines: [show.date, show.venue.name, show.location.displayText],
+                                recordingCount: show.recordingCount
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
     }
 
     // MARK: - Sections

--- a/iosApp/deadly/Feature/Home/ShowCarouselCard.swift
+++ b/iosApp/deadly/Feature/Home/ShowCarouselCard.swift
@@ -5,13 +5,16 @@ struct ShowCarouselCard: View {
     let imageUrl: String?
     let lines: [String]
     var recordingCount: Int? = nil
+    var size: CGFloat = DeadlySize.carouselCard
+
+    private var isCompact: Bool { size <= DeadlySize.carouselCardSmall }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: isCompact ? 6 : 12) {
             ShowArtwork(
                 recordingId: imageRecordingId,
                 imageUrl: imageUrl,
-                size: DeadlySize.carouselCard,
+                size: size,
                 cornerRadius: DeadlySize.carouselCornerRadius
             )
             VStack(alignment: .leading, spacing: 2) {
@@ -28,7 +31,7 @@ struct ShowCarouselCard: View {
                 }
             }
         }
-        .frame(width: DeadlySize.carouselCard)
+        .frame(width: size)
         .opacity(recordingCount == 0 ? 0.5 : 1.0)
         .accessibilityElement(children: .combine)
     }

--- a/iosApp/deadly/Feature/Settings/SettingsScreen.swift
+++ b/iosApp/deadly/Feature/Settings/SettingsScreen.swift
@@ -181,6 +181,29 @@ struct SettingsScreen: View {
                         .font(.callout)
                         .foregroundStyle(.secondary)
                 }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Trending window on home")
+                    Picker("Trending window on home", selection: Binding(
+                        get: { TrendingWindow(preferenceKey: container.appPreferences.homeTrendingWindow) },
+                        set: { newWindow in
+                            container.appPreferences.homeTrendingWindow = newWindow.rawValue
+                            container.analyticsService.track("feature_use", props: [
+                                "feature": "set_home_trending_window",
+                                "category": "preference",
+                                "value": newWindow.rawValue,
+                            ])
+                        }
+                    )) {
+                        ForEach(TrendingWindow.allCases) { window in
+                            Text(window.label).tag(window)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    Text("Which time range \"Trending on The Deadly\" shows.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             // MARK: - Audio

--- a/iosApp/deadly/Feature/Settings/SettingsScreen.swift
+++ b/iosApp/deadly/Feature/Settings/SettingsScreen.swift
@@ -223,6 +223,29 @@ struct SettingsScreen: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Recently Played rows")
+                    Picker("Recently Played rows", selection: Binding(
+                        get: { container.appPreferences.homeRecentRows },
+                        set: { newRows in
+                            container.appPreferences.homeRecentRows = newRows
+                            container.analyticsService.track("feature_use", props: [
+                                "feature": "set_home_recent_rows",
+                                "category": "preference",
+                                "value": String(newRows),
+                            ])
+                        }
+                    )) {
+                        ForEach(1...4, id: \.self) { rows in
+                            Text("\(rows)").tag(rows)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    Text("How many rows of recent shows on the home screen (2 shows per row).")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             // MARK: - Audio

--- a/iosApp/deadly/Feature/Settings/SettingsScreen.swift
+++ b/iosApp/deadly/Feature/Settings/SettingsScreen.swift
@@ -204,6 +204,25 @@ struct SettingsScreen: View {
                         .font(.callout)
                         .foregroundStyle(.secondary)
                 }
+
+                Toggle(isOn: Binding(
+                    get: { container.appPreferences.homeTrendingAboveToday },
+                    set: { newValue in
+                        container.appPreferences.homeTrendingAboveToday = newValue
+                        container.analyticsService.track("feature_use", props: [
+                            "feature": "set_home_trending_above_today",
+                            "category": "preference",
+                            "value": String(newValue),
+                        ])
+                    }
+                )) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Show Trending above Today")
+                        Text("Move the Trending section below \"Today in Grateful Dead History\" by turning this off.")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    }
+                }
             }
 
             // MARK: - Audio

--- a/iosApp/deadly/Feature/Settings/SettingsScreen.swift
+++ b/iosApp/deadly/Feature/Settings/SettingsScreen.swift
@@ -18,6 +18,37 @@ struct SettingsScreen: View {
     @State private var showingImportAlert = false
     @State private var authError: String?
     @State private var showingAuthError = false
+    private func cardSizePicker(
+        title: String,
+        helper: String,
+        feature: String,
+        get: @escaping () -> String,
+        set: @escaping (String) -> Void
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+            Picker(title, selection: Binding(
+                get: { CarouselCardSize(preferenceKey: get()) },
+                set: { newSize in
+                    set(newSize.rawValue)
+                    container.analyticsService.track("feature_use", props: [
+                        "feature": feature,
+                        "category": "preference",
+                        "value": newSize.rawValue,
+                    ])
+                }
+            )) {
+                ForEach(CarouselCardSize.allCases) { size in
+                    Text(size.label).tag(size)
+                }
+            }
+            .pickerStyle(.segmented)
+            Text(helper)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+    }
+
     private func settingsRow(_ title: String, systemImage: String) -> some View {
         HStack {
             Image(systemName: systemImage)
@@ -182,6 +213,10 @@ struct SettingsScreen: View {
                         .foregroundStyle(.secondary)
                 }
 
+            }
+
+            // MARK: - Home Screen
+            Section("Home Screen") {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Trending window on home")
                     Picker("Trending window on home", selection: Binding(
@@ -245,6 +280,40 @@ struct SettingsScreen: View {
                     Text("How many rows of recent shows on the home screen (2 shows per row).")
                         .font(.callout)
                         .foregroundStyle(.secondary)
+                }
+
+                cardSizePicker(
+                    title: "Trending card size",
+                    helper: "Size of cards in the Trending carousel.",
+                    feature: "set_home_trending_card_size",
+                    get: { container.appPreferences.homeTrendingCardSize },
+                    set: { container.appPreferences.homeTrendingCardSize = $0 }
+                )
+
+                cardSizePicker(
+                    title: "Today in History card size",
+                    helper: "Size of cards in the Today in Grateful Dead History carousel.",
+                    feature: "set_home_today_card_size",
+                    get: { container.appPreferences.homeTodayCardSize },
+                    set: { container.appPreferences.homeTodayCardSize = $0 }
+                )
+
+                cardSizePicker(
+                    title: "Featured Collections card size",
+                    helper: "Size of cards in the Featured Collections carousel.",
+                    feature: "set_home_collections_card_size",
+                    get: { container.appPreferences.homeCollectionsCardSize },
+                    set: { container.appPreferences.homeCollectionsCardSize = $0 }
+                )
+
+                Button(role: .destructive) {
+                    container.appPreferences.resetHomePreferences()
+                    container.analyticsService.track("feature_use", props: [
+                        "feature": "reset_home_preferences",
+                        "category": "preference",
+                    ])
+                } label: {
+                    Text("Reset Home Screen to Defaults")
                 }
             }
 


### PR DESCRIPTION
## Summary

End-to-end build of **"Trending on The Deadly"** — a new home-screen carousel surfacing what other listeners are actually playing — plus a polish pass that turned into a broader rework of the home screen and a new "Home Screen" settings section.

### What ships

**Backend** (`85b815cd`, `6cb5edc4`)
- New `GET /api/trending` endpoint returning four windows (now / week / month / all) in one ~5KB payload, Redis-cached 10 min.
- Per-show daily rollup table (`show_plays_daily`) with hourly job; ranked by show-sessions (deduped per `iid|sid`) not raw track plays.
- Rollup is self-healing: backfills any missing day, not just the current one.

**Mobile — iOS + Android parity** (`a2376038`, `7b522254`, `f256da4e`, `7b6fb9f4`, `4e74297e`)
- **Trending carousel** on home, with the time-window selector inlined into the section header: "Trending now / this week / this month / all time" — title is tappable to cycle forward, with a "Show <next>" hint on the right.
- **Per-section card sizing**: each carousel (Trending, Today, Collections) has its own small/large preference. Trending defaults to small (100pt, date-only caption); Today and Collections stay at 160pt.
- **Long-press detail** wired to Trending and Today on both platforms, matching what Recently Played already had — bottom sheet on Android, contextMenu preview on iOS.
- **Recently Played** is now configurable 1-4 rows (default 2), down from a fixed full grid.
- **Trending position** (above vs below Today) is a user preference.
- All six home prefs now live under a dedicated **"Home Screen"** section in Settings, with a **Reset to Defaults** action.

**Docs** (`669ff0f7`, `815c3a39`)
- ADR-0004 proposes the trending design.
- ADR-0004 post-implementation update captures what changed during build (rollup backfill bug, why we ditched the four-tab strip for inline cycling, why position became a preference, why per-section sizing emerged).

## Test plan

- [ ] iOS: Trending section renders with current window in title, "Show <next>" on the right; tapping either cycles forward through now → week → month → all → now.
- [ ] Android: same.
- [ ] iOS: long-press a Trending card → ShowDetailPopover preview. Same on Today.
- [ ] Android: long-press a Trending card → ShowDetailBottomSheet. Same on Today.
- [ ] iOS + Android: Settings → Home Screen — flip each card-size toggle, Recently Played rows, Trending window, above-Today; verify each takes effect immediately on the home screen.
- [ ] iOS + Android: hit "Reset Home Screen to Defaults" → trending=small, today=large, collections=large, recent rows=2, window=now, above-Today=off.
- [ ] API: hit `/api/trending`, confirm four windows return; restart rollup job and verify missing days backfill on next run.
- [ ] Confirm "Trending all time" + "Show now" fits without wrapping on a narrow device (iPhone SE / small Android).

🤖 Generated with [Claude Code](https://claude.com/claude-code)