### PR TITLE
fix(api/trending): logical-listen ranking

### DIFF
--- a/api/src/db/__tests__/trending.test.ts
+++ b/api/src/db/__tests__/trending.test.ts
@@ -14,24 +14,13 @@ process.env.ANALYTICS_DB_PATH = TMP_DB;
 const {
   getAnalyticsDb,
   insertEvents,
-  rollupShowPlaysDay,
-  backfillShowPlaysIfEmpty,
+  rebuildShowListensRollup,
   getTrending,
   closeAnalyticsDb,
 } = await import("../analytics.js");
 
-function todayUtc(daysOffset = 0): string {
-  const d = new Date();
-  d.setUTCDate(d.getUTCDate() + daysOffset);
-  return d.toISOString().slice(0, 10);
-}
-
-function tsForDay(daysAgo: number, hour = 12): number {
-  const d = new Date();
-  d.setUTCDate(d.getUTCDate() - daysAgo);
-  d.setUTCHours(hour, 0, 0, 0);
-  return d.getTime();
-}
+const HOUR_MS = 3600 * 1000;
+const DAY_MS = 24 * HOUR_MS;
 
 function play(
   iid: string,
@@ -52,10 +41,8 @@ function play(
 }
 
 beforeEach(() => {
-  // Truncate between tests so each starts clean. Cheaper than reopening
-  // the DB.
   const db = getAnalyticsDb();
-  db.exec(`DELETE FROM analytics_events; DELETE FROM show_plays_daily;`);
+  db.exec(`DELETE FROM analytics_events; DELETE FROM show_listens_rollup;`);
 });
 
 afterAll(() => {
@@ -63,173 +50,190 @@ afterAll(() => {
   if (fs.existsSync(TMP_DB)) fs.unlinkSync(TMP_DB);
 });
 
-describe("rollupShowPlaysDay", () => {
-  it("groups plays by show and counts sessions and plays", () => {
-    const day = todayUtc();
-    const ts = tsForDay(0);
+describe("logical-listen aggregation", () => {
+  it("5 restarts of the same show within 6h = 1 listen", () => {
+    // The bug ADR-0004 was rewritten to fix: same listener restarting the
+    // same show across app sessions used to count as N listens.
+    const t = Date.now() - HOUR_MS;
     insertEvents([
-      // Alice, one session, 3 tracks of show A
-      play("alice", "s1", "show-A", ts, 0),
-      play("alice", "s1", "show-A", ts + 1, 1),
-      play("alice", "s1", "show-A", ts + 2, 2),
-      // Bob, one session, 1 track of show A
-      play("bob", "s2", "show-A", ts + 3, 0),
-      // Alice, second session, 1 track of show B
-      play("alice", "s3", "show-B", ts + 4, 0),
+      play("alice", "s1", "show-A", t),
+      play("alice", "s2", "show-A", t + 5 * 60_000), // 5 min later, new sid
+      play("alice", "s3", "show-A", t + 10 * 60_000),
+      play("alice", "s4", "show-A", t + 20 * 60_000),
+      play("alice", "s5", "show-A", t + 30 * 60_000),
     ]);
+    rebuildShowListensRollup();
 
-    rollupShowPlaysDay(day);
-
-    const rows = getAnalyticsDb()
-      .prepare(
-        `SELECT show_id, sessions, plays FROM show_plays_daily
-         WHERE day = ? ORDER BY show_id`,
-      )
-      .all(day);
-
-    expect(rows).toEqual([
-      { show_id: "show-A", sessions: 2, plays: 4 },
-      { show_id: "show-B", sessions: 1, plays: 1 },
-    ]);
+    const result = getTrending(10);
+    const row = result.windows.now.find((r) => r.show_id === "show-A");
+    expect(row).toBeDefined();
+    expect(row!.listens).toBe(1);
+    expect(row!.plays).toBe(5);
+    expect(row!.installs).toBe(1);
   });
 
-  it("re-running replaces the day's rows (idempotent)", () => {
-    const day = todayUtc();
-    const ts = tsForDay(0);
-    insertEvents([play("alice", "s1", "show-A", ts, 0)]);
-    rollupShowPlaysDay(day);
-    rollupShowPlaysDay(day);
+  it("plays on the same show separated by > 6h = separate listens", () => {
+    const t = Date.now() - 12 * HOUR_MS;
+    insertEvents([
+      play("alice", "s1", "show-A", t),
+      play("alice", "s2", "show-A", t + 7 * HOUR_MS), // 7h later
+    ]);
+    rebuildShowListensRollup();
 
-    const count = (
-      getAnalyticsDb()
-        .prepare(`SELECT COUNT(*) AS c FROM show_plays_daily WHERE day = ?`)
-        .get(day) as { c: number }
-    ).c;
-    expect(count).toBe(1);
+    const row = getTrending(10).windows.now.find((r) => r.show_id === "show-A");
+    expect(row!.listens).toBe(2);
+    expect(row!.plays).toBe(2);
+    expect(row!.installs).toBe(1);
   });
 
-  it("ignores events without a show_id", () => {
-    const day = todayUtc();
-    const ts = tsForDay(0);
-    getAnalyticsDb()
-      .prepare(
-        `INSERT INTO analytics_events (event, ts, iid, sid, platform, app_version, props)
-         VALUES ('playback_start', ?, 'a', 's', 'ios', '2.30.0', NULL)`,
-      )
-      .run(ts);
+  it("interleaved A → B → A breaks the A listen", () => {
+    const t = Date.now() - HOUR_MS;
+    insertEvents([
+      play("alice", "s1", "show-A", t),
+      play("alice", "s1", "show-B", t + 60_000),
+      play("alice", "s1", "show-A", t + 120_000),
+    ]);
+    rebuildShowListensRollup();
 
-    rollupShowPlaysDay(day);
+    const a = getTrending(10).windows.now.find((r) => r.show_id === "show-A")!;
+    const b = getTrending(10).windows.now.find((r) => r.show_id === "show-B")!;
+    expect(a.listens).toBe(2); // started, interrupted by B, resumed = new listen
+    expect(a.plays).toBe(2);
+    expect(b.listens).toBe(1);
+  });
 
-    const rows = getAnalyticsDb()
-      .prepare(`SELECT * FROM show_plays_daily WHERE day = ?`)
-      .all(day);
-    expect(rows).toEqual([]);
+  it("distinct installs each get their own first-listen credit", () => {
+    const t = Date.now() - HOUR_MS;
+    insertEvents([
+      play("alice", "s1", "show-A", t),
+      play("bob", "s2", "show-A", t + 60_000),
+      play("carol", "s3", "show-A", t + 120_000),
+    ]);
+    rebuildShowListensRollup();
+
+    const row = getTrending(10).windows.now.find((r) => r.show_id === "show-A")!;
+    expect(row.listens).toBe(3);
+    expect(row.plays).toBe(3);
+    expect(row.installs).toBe(3);
+  });
+
+  it("deep listen (many tracks, one sitting) counts as 1 listen", () => {
+    // The other half of the bias problem: a 22-track listen-through
+    // shouldn't outweigh 3 different people each playing one track.
+    const t = Date.now() - HOUR_MS;
+    const deepListen = Array.from({ length: 22 }, (_, i) =>
+      play("alice", "s1", "show-A", t + i * 60_000, i),
+    );
+    const threeLightListens = [
+      play("bob", "s2", "show-B", t),
+      play("carol", "s3", "show-B", t + 60_000),
+      play("dave", "s4", "show-B", t + 120_000),
+    ];
+    insertEvents([...deepListen, ...threeLightListens]);
+    rebuildShowListensRollup();
+
+    const a = getTrending(10).windows.now.find((r) => r.show_id === "show-A")!;
+    const b = getTrending(10).windows.now.find((r) => r.show_id === "show-B")!;
+    expect(a.listens).toBe(1);
+    expect(b.listens).toBe(3);
+    // B beats A on the primary signal even though A has way more plays.
+    const order = getTrending(10).windows.now.map((r) => r.show_id);
+    expect(order.indexOf("show-B")).toBeLessThan(order.indexOf("show-A"));
   });
 });
 
-describe("getTrending", () => {
-  it("returns four windows with correct ordering", () => {
-    // Build a corpus that differentiates the windows.
-    const events = [
-      // show-A: heavy today, dominates `now`
-      play("u1", "s1", "show-A", tsForDay(0, 10)),
-      play("u2", "s2", "show-A", tsForDay(0, 11)),
-      play("u3", "s3", "show-A", tsForDay(0, 12)),
-      // show-B: spread across the week, dominates `week`
-      play("u1", "wk1", "show-B", tsForDay(1)),
-      play("u2", "wk2", "show-B", tsForDay(2)),
-      play("u3", "wk3", "show-B", tsForDay(3)),
-      play("u4", "wk4", "show-B", tsForDay(4)),
-      // show-C: only month-old, dominates `month` but not week
-      play("u1", "mo1", "show-C", tsForDay(15)),
-      play("u2", "mo2", "show-C", tsForDay(20)),
-      // show-D: old (out of month), only shows in `all`
-      play("u1", "old1", "show-D", tsForDay(60)),
-    ];
-    insertEvents(events);
+describe("getTrending window correctness", () => {
+  it("populates all four windows; out-of-window shows are absent", () => {
+    const now = Date.now();
+    insertEvents([
+      play("u1", "s1", "show-now", now - HOUR_MS),
+      play("u1", "s2", "show-week", now - 3 * DAY_MS),
+      play("u1", "s3", "show-month", now - 20 * DAY_MS),
+      play("u1", "s4", "show-old", now - 60 * DAY_MS),
+    ]);
+    rebuildShowListensRollup();
 
-    // Roll up every day that has events. The endpoint's rollup job does
-    // this for today + yesterday in real life; here we just do all of
-    // them so we can assert on every window.
-    for (let i = 0; i <= 60; i++) {
-      rollupShowPlaysDay(todayUtc(-i));
-    }
+    const r = getTrending(10);
+    const ids = (rows: { show_id: string }[]) => rows.map((x) => x.show_id);
 
-    const result = getTrending(10);
+    expect(ids(r.windows.now)).toEqual(["show-now"]);
+    expect(ids(r.windows.week).sort()).toEqual(["show-now", "show-week"]);
+    expect(ids(r.windows.month).sort()).toEqual([
+      "show-month",
+      "show-now",
+      "show-week",
+    ]);
+    expect(ids(r.windows.all).sort()).toEqual([
+      "show-month",
+      "show-now",
+      "show-old",
+      "show-week",
+    ]);
+  });
 
-    expect(result.windows.now[0]?.show_id).toBe("show-A");
-    expect(result.windows.now[0]?.sessions).toBe(3);
+  it("orders by listens DESC, plays DESC tiebreaker", () => {
+    const t = Date.now() - HOUR_MS;
+    insertEvents([
+      // show-X: 1 listen with many plays
+      ...Array.from({ length: 5 }, (_, i) =>
+        play("u1", "s1", "show-X", t + i * 60_000, i),
+      ),
+      // show-Y: 2 listens (2 different installs)
+      play("u2", "s2", "show-Y", t),
+      play("u3", "s3", "show-Y", t + 60_000),
+    ]);
+    rebuildShowListensRollup();
 
-    const weekIds = result.windows.week.map((r) => r.show_id);
-    expect(weekIds[0]).toBe("show-B");
-    expect(weekIds).toContain("show-A");
-    expect(weekIds).not.toContain("show-D");
-
-    const monthIds = result.windows.month.map((r) => r.show_id);
-    expect(monthIds).toContain("show-C");
-    expect(monthIds).not.toContain("show-D");
-
-    const allIds = result.windows.all.map((r) => r.show_id);
-    expect(allIds).toContain("show-D");
+    const order = getTrending(10).windows.now.map((r) => r.show_id);
+    expect(order[0]).toBe("show-Y"); // 2 listens > 1 listen
+    expect(order[1]).toBe("show-X");
   });
 
   it("respects the limit parameter", () => {
-    const ts = tsForDay(0);
+    const t = Date.now() - HOUR_MS;
     const events = Array.from({ length: 15 }, (_, i) =>
-      play(`u${i}`, `s${i}`, `show-${i}`, ts + i),
+      play(`u${i}`, `s${i}`, `show-${i}`, t + i),
     );
     insertEvents(events);
-    rollupShowPlaysDay(todayUtc());
+    rebuildShowListensRollup();
 
     const result = getTrending(5);
     expect(result.windows.now).toHaveLength(5);
     expect(result.windows.all).toHaveLength(5);
   });
 
-  it("orders by sessions desc, then plays desc as tiebreaker", () => {
-    const ts = tsForDay(0);
-    insertEvents([
-      // show-X: 1 session, 5 plays
-      play("u1", "s1", "show-X", ts, 0),
-      play("u1", "s1", "show-X", ts + 1, 1),
-      play("u1", "s1", "show-X", ts + 2, 2),
-      play("u1", "s1", "show-X", ts + 3, 3),
-      play("u1", "s1", "show-X", ts + 4, 4),
-      // show-Y: 2 sessions, 2 plays — should beat X on sessions
-      play("u2", "s2", "show-Y", ts, 0),
-      play("u3", "s3", "show-Y", ts + 1, 0),
-    ]);
-    rollupShowPlaysDay(todayUtc());
-
-    const result = getTrending(10);
-    expect(result.windows.now[0]?.show_id).toBe("show-Y");
-    expect(result.windows.now[1]?.show_id).toBe("show-X");
-  });
-
-  it("backfillShowPlaysIfEmpty populates every day with events on first run", () => {
-    insertEvents([
-      play("u1", "s1", "show-A", tsForDay(0)),
-      play("u1", "s2", "show-A", tsForDay(5)),
-      play("u2", "s3", "show-B", tsForDay(10)),
-    ]);
-
-    const filled = backfillShowPlaysIfEmpty();
-    expect(filled).toBe(3); // 3 distinct days
-
-    // Second call should be a no-op.
-    expect(backfillShowPlaysIfEmpty()).toBe(0);
-
-    const all = getTrending(10).windows.all.map((r) => r.show_id);
-    expect(all).toContain("show-A");
-    expect(all).toContain("show-B");
-  });
-
-  it("returns empty arrays when there are no events", () => {
+  it("empty events → empty windows, valid timestamp", () => {
+    rebuildShowListensRollup();
     const result = getTrending(10);
     expect(result.windows.now).toEqual([]);
     expect(result.windows.week).toEqual([]);
     expect(result.windows.month).toEqual([]);
     expect(result.windows.all).toEqual([]);
     expect(typeof result.generated_at).toBe("string");
+  });
+
+  it("rebuild is idempotent — running twice yields the same rollup", () => {
+    const t = Date.now() - HOUR_MS;
+    insertEvents([play("u1", "s1", "show-A", t)]);
+
+    rebuildShowListensRollup();
+    const first = getTrending(10);
+    rebuildShowListensRollup();
+    const second = getTrending(10);
+
+    expect(first.windows.now).toEqual(second.windows.now);
+    expect(first.windows.all).toEqual(second.windows.all);
+  });
+
+  it("ignores events without a show_id", () => {
+    const t = Date.now() - HOUR_MS;
+    getAnalyticsDb()
+      .prepare(
+        `INSERT INTO analytics_events (event, ts, iid, sid, platform, app_version, props)
+         VALUES ('playback_start', ?, 'a', 's', 'ios', '2.30.0', NULL)`,
+      )
+      .run(t);
+    rebuildShowListensRollup();
+    expect(getTrending(10).windows.all).toEqual([]);
   });
 });

--- a/api/src/db/analytics.ts
+++ b/api/src/db/analytics.ts
@@ -78,14 +78,24 @@ function initSchema(db: Database.Database): void {
       PRIMARY KEY (day, event, platform, app_version)
     );
 
-    CREATE TABLE IF NOT EXISTS show_plays_daily (
-      day TEXT NOT NULL,
+    -- Pre-computed top-N per window for the trending endpoint. Fully
+    -- rebuilt by rebuildShowListensRollup() each hour from analytics_events,
+    -- so the endpoint never queries raw events. Replaces the day-keyed
+    -- show_plays_daily table — see ADR-0004 for why session-based dedup was
+    -- replaced with logical-listen aggregation.
+    CREATE TABLE IF NOT EXISTS show_listens_rollup (
+      window TEXT NOT NULL,         -- 'now' | 'week' | 'month' | 'all'
       show_id TEXT NOT NULL,
-      sessions INTEGER NOT NULL,
-      plays INTEGER NOT NULL,
-      PRIMARY KEY (day, show_id)
+      listens INTEGER NOT NULL,     -- logical listens (dedup-aware)
+      plays INTEGER NOT NULL,       -- raw playback_start count in window
+      installs INTEGER NOT NULL,    -- distinct iids contributing
+      PRIMARY KEY (window, show_id)
     );
-    CREATE INDEX IF NOT EXISTS idx_show_plays_day ON show_plays_daily(day);
+    CREATE INDEX IF NOT EXISTS idx_show_listens_window ON show_listens_rollup(window);
+
+    -- One-shot migration: the old day-keyed table is no longer load-bearing.
+    -- Listings are now rebuilt from raw events on every rollup tick.
+    DROP TABLE IF EXISTS show_plays_daily;
 
     CREATE TABLE IF NOT EXISTS watched_installs (
       iid TEXT PRIMARY KEY,
@@ -1732,8 +1742,13 @@ export function getInstallEvents(iid: string): InstallSummary | null {
 
 export interface TrendingShow {
   show_id: string;
-  sessions: number;
+  /** Logical listens — runs of plays from one install on one show, deduped
+   *  across app restarts. Primary ranking signal. See ADR-0004. */
+  listens: number;
+  /** Raw playback_start count in the window. Engagement-weighted secondary. */
   plays: number;
+  /** Distinct installs that contributed any play to this show in the window. */
+  installs: number;
 }
 
 export interface TrendingResponse {
@@ -1747,133 +1762,121 @@ export interface TrendingResponse {
 }
 
 /**
- * Upserts a day's row in `show_plays_daily` from raw events. Called hourly for
- * today, once at startup for yesterday. "Day" is UTC-aligned to match the
- * `date(ts/1000, 'unixepoch')` expression used everywhere else in this file.
- *
- * `sessions` counts distinct (iid, sid) tuples for the day — one app session
- * sitting down to play a show counts once, regardless of how many tracks they
- * played through. `plays` is the raw track-start count.
+ * Logical-listen rollup window definitions. `sinceMs` is computed against
+ * Date.now() at rebuild time; "all" uses 0 to mean "since the epoch".
  */
-export function rollupShowPlaysDay(day: string): void {
+const TRENDING_WINDOWS = ["now", "week", "month", "all"] as const;
+type TrendingWindowName = (typeof TRENDING_WINDOWS)[number];
+
+function windowSinceMs(name: TrendingWindowName, now: number): number {
+  switch (name) {
+    case "now":   return now - 24 * 3600 * 1000;
+    case "week":  return now -  7 * 24 * 3600 * 1000;
+    case "month": return now - 30 * 24 * 3600 * 1000;
+    case "all":   return 0;
+  }
+}
+
+/** Gap that splits two same-show plays into separate logical listens. */
+const LISTEN_GAP_MS = 6 * 3600 * 1000;
+
+/** How many shows we cache per window. UI serves a smaller `limit` slice. */
+const ROLLUP_PER_WINDOW = 50;
+
+/**
+ * Rebuild `show_listens_rollup` from raw events for all four windows.
+ *
+ * Ranking primitive is a **logical listen** — a maximal run of
+ * `playback_start` events from one install on one show, broken by either
+ * (a) a play of a *different* show in between, or (b) a gap of more than
+ * `LISTEN_GAP_MS`. This dedupes the case where the same listener stops
+ * and restarts the same show within one sitting (which the previous
+ * session-based primitive counted as multiple votes — see ADR-0004).
+ *
+ * Runs hourly in a background job. The endpoint never touches raw events;
+ * it just reads precomputed top-N rows from this table.
+ */
+export function rebuildShowListensRollup(): void {
   const db = getAnalyticsDb();
-  db.prepare(`
-    DELETE FROM show_plays_daily WHERE day = ?
-  `).run(day);
-  db.prepare(`
-    INSERT INTO show_plays_daily (day, show_id, sessions, plays)
+  const now = Date.now();
+
+  // SQL inserts the top-N for one window, given (gap, windowName, sinceMs, limit).
+  // The LAG scan runs over the full event history (no `ts >` filter), so
+  // listen-start detection is correct even when a listen straddles the
+  // window boundary; the WHERE on `ts > sinceMs` filters which listen-start
+  // events count toward this window.
+  const insertWindow = db.prepare(`
+    INSERT INTO show_listens_rollup (window, show_id, listens, plays, installs)
+    WITH plays AS (
+      SELECT iid,
+             json_extract(props, '$.show_id') AS show_id,
+             ts,
+             LAG(json_extract(props, '$.show_id')) OVER w AS prev_show,
+             LAG(ts)                              OVER w AS prev_ts
+      FROM analytics_events
+      WHERE event = 'playback_start'
+        AND json_extract(props, '$.show_id') IS NOT NULL
+      WINDOW w AS (PARTITION BY iid ORDER BY ts)
+    ),
+    listens AS (
+      SELECT iid, show_id, ts,
+             CASE
+               WHEN prev_show IS NULL
+                 OR prev_show != show_id
+                 OR (ts - prev_ts) > ?
+               THEN 1 ELSE 0
+             END AS is_new
+      FROM plays
+    )
     SELECT
-      date(ts / 1000, 'unixepoch') AS day,
-      json_extract(props, '$.show_id') AS show_id,
-      COUNT(DISTINCT iid || '|' || sid) AS sessions,
-      COUNT(*) AS plays
-    FROM analytics_events
-    WHERE event = 'playback_start'
-      AND date(ts / 1000, 'unixepoch') = ?
-      AND json_extract(props, '$.show_id') IS NOT NULL
-    GROUP BY day, show_id
-  `).run(day);
+      ?         AS window,
+      show_id,
+      SUM(is_new)         AS listens,
+      COUNT(*)            AS plays,
+      COUNT(DISTINCT iid) AS installs
+    FROM listens
+    WHERE ts > ?
+    GROUP BY show_id
+    HAVING SUM(is_new) > 0
+    ORDER BY listens DESC, plays DESC
+    LIMIT ?
+  `);
+
+  const tx = db.transaction(() => {
+    db.exec(`DELETE FROM show_listens_rollup`);
+    for (const name of TRENDING_WINDOWS) {
+      insertWindow.run(LISTEN_GAP_MS, name, windowSinceMs(name, now), ROLLUP_PER_WINDOW);
+    }
+  });
+  tx();
 }
 
 /**
- * Trending shows across four time windows. Used by the home screen.
- *
- * The "now" window is rolling 24h queried directly from analytics_events,
- * so it stays current between hourly rollups. The other windows aggregate
- * from `show_plays_daily`, summing per show. Summing sessions across days
- * slightly overcounts because a single human spanning multiple days is
- * counted per day — that's an engagement-weighted signal we prefer for
- * ranking, per ADR-0004.
+ * Trending shows across four time windows. Reads precomputed rows from
+ * `show_listens_rollup` — no event scan, no Redis round-trip — so it's
+ * cheap even under traffic spikes.
  */
 export function getTrending(limit = 10): TrendingResponse {
   const db = getAnalyticsDb();
-  const now = Date.now();
-  const dayAgo = now - 24 * 3600 * 1000;
-  const weekStart = todayUtcMinusDays(6); // inclusive of today = 7 days
-  const monthStart = todayUtcMinusDays(29);
-
-  const nowRows = db
-    .prepare(
-      `SELECT
-         json_extract(props, '$.show_id') AS show_id,
-         COUNT(DISTINCT iid || '|' || sid) AS sessions,
-         COUNT(*) AS plays
-       FROM analytics_events
-       WHERE event = 'playback_start'
-         AND ts > ?
-         AND json_extract(props, '$.show_id') IS NOT NULL
-       GROUP BY show_id
-       ORDER BY sessions DESC, plays DESC
-       LIMIT ?`,
-    )
-    .all(dayAgo, limit) as TrendingShow[];
-
-  const weekRows = trendingFromRollup(weekStart, limit);
-  const monthRows = trendingFromRollup(monthStart, limit);
-  const allRows = trendingFromRollup(null, limit);
+  const stmt = db.prepare(
+    `SELECT show_id, listens, plays, installs
+     FROM show_listens_rollup
+     WHERE window = ?
+     ORDER BY listens DESC, plays DESC
+     LIMIT ?`,
+  );
+  const fetch = (name: TrendingWindowName): TrendingShow[] =>
+    stmt.all(name, limit) as TrendingShow[];
 
   return {
-    generated_at: new Date(now).toISOString(),
+    generated_at: new Date().toISOString(),
     windows: {
-      now: nowRows,
-      week: weekRows,
-      month: monthRows,
-      all: allRows,
+      now: fetch("now"),
+      week: fetch("week"),
+      month: fetch("month"),
+      all: fetch("all"),
     },
   };
-}
-
-/**
- * Backfill any day present in analytics_events that has no rows in
- * show_plays_daily yet. Runs every startup — cheap when there's nothing
- * to do, self-heals after `make db-pull-analytics` or any other event
- * that introduces historical days the rollup never saw.
- *
- * Returns the number of days rolled up (0 = nothing to backfill).
- */
-export function backfillShowPlaysIfEmpty(): number {
-  const db = getAnalyticsDb();
-
-  const missingDays = db
-    .prepare(
-      `SELECT DISTINCT date(e.ts / 1000, 'unixepoch') AS day
-       FROM analytics_events e
-       WHERE e.event = 'playback_start'
-         AND json_extract(e.props, '$.show_id') IS NOT NULL
-         AND NOT EXISTS (
-           SELECT 1 FROM show_plays_daily r
-           WHERE r.day = date(e.ts / 1000, 'unixepoch')
-         )
-       ORDER BY day`,
-    )
-    .all() as Array<{ day: string }>;
-
-  for (const { day } of missingDays) rollupShowPlaysDay(day);
-  return missingDays.length;
-}
-
-function trendingFromRollup(sinceDay: string | null, limit: number): TrendingShow[] {
-  const db = getAnalyticsDb();
-  const where = sinceDay ? "WHERE day >= ?" : "";
-  const params: (string | number)[] = sinceDay ? [sinceDay, limit] : [limit];
-  return db
-    .prepare(
-      `SELECT show_id,
-              SUM(sessions) AS sessions,
-              SUM(plays) AS plays
-       FROM show_plays_daily
-       ${where}
-       GROUP BY show_id
-       ORDER BY sessions DESC, plays DESC
-       LIMIT ?`,
-    )
-    .all(...params) as TrendingShow[];
-}
-
-function todayUtcMinusDays(daysBack: number): string {
-  const d = new Date();
-  d.setUTCDate(d.getUTCDate() - daysBack);
-  return d.toISOString().slice(0, 10);
 }
 
 // ── Cleanup ──────────────────────────────────────────────────────────

--- a/api/src/routes/trending.ts
+++ b/api/src/routes/trending.ts
@@ -1,9 +1,5 @@
 import type { FastifyInstance } from "fastify";
-import {
-  backfillShowPlaysIfEmpty,
-  getTrending,
-  rollupShowPlaysDay,
-} from "../db/analytics.js";
+import { getTrending, rebuildShowListensRollup } from "../db/analytics.js";
 import { getPublisher } from "../db/redis.js";
 
 const CACHE_KEY = "trending:v1";
@@ -14,8 +10,9 @@ const trendingShowSchema = {
   type: "object",
   properties: {
     show_id: { type: "string" },
-    sessions: { type: "number" },
+    listens: { type: "number" },
     plays: { type: "number" },
+    installs: { type: "number" },
   },
 } as const;
 
@@ -28,7 +25,8 @@ export async function trendingRoutes(app: FastifyInstance): Promise<void> {
         summary: "Trending shows for the home screen",
         description:
           "Returns four time windows (now=24h, week, month, all-time) of " +
-          "the most-played shows. Cached for 10 minutes in Redis.",
+          "the most-played shows ranked by logical listens. Cached for 10 " +
+          "minutes in Redis. See ADR-0004 for the ranking algorithm.",
         response: {
           200: {
             type: "object",
@@ -50,7 +48,7 @@ export async function trendingRoutes(app: FastifyInstance): Promise<void> {
     },
     async (_request, reply) => {
       // Try Redis first. Failure (no Redis available, network blip) falls
-      // through to a direct query — better to be uncached than to 500.
+      // through to the rollup table — better to be uncached than to 500.
       try {
         const cached = await getPublisher().get(CACHE_KEY);
         if (cached) {
@@ -58,7 +56,7 @@ export async function trendingRoutes(app: FastifyInstance): Promise<void> {
           return reply.type("application/json").send(cached);
         }
       } catch {
-        // Fall through to direct query.
+        // Fall through to rollup read.
       }
 
       const fresh = getTrending(TRENDING_LIMIT);
@@ -79,20 +77,16 @@ export async function trendingRoutes(app: FastifyInstance): Promise<void> {
 // ── Scheduled tasks (call from server.ts) ────────────────────────────
 
 /**
- * Rolls up today + yesterday on startup, then once per hour. Yesterday is
- * re-rolled to catch any late-arriving events that landed after midnight UTC.
- * Today's row is the one that actually drives the week/month/all windows
- * being fresh on the home screen.
+ * Rebuilds `show_listens_rollup` from raw events at startup, then once per
+ * hour. The rebuild is the entire job — there's no incremental path. At
+ * current scale (~7k playback_start events) the scan is milliseconds; at
+ * 100× scale it's still single-digit seconds in a background tick. The
+ * endpoint never queries `analytics_events`.
  */
 export function startTrendingSchedules(): void {
   const runRollup = (): void => {
     try {
-      const today = new Date().toISOString().slice(0, 10);
-      const yesterday = new Date(Date.now() - 24 * 3600 * 1000)
-        .toISOString()
-        .slice(0, 10);
-      rollupShowPlaysDay(yesterday);
-      rollupShowPlaysDay(today);
+      rebuildShowListensRollup();
       // Bust cache so the next request reflects the fresh rollup.
       getPublisher()
         .del(CACHE_KEY)
@@ -101,18 +95,6 @@ export function startTrendingSchedules(): void {
       console.error("Trending rollup error:", err);
     }
   };
-
-  // First-run backfill: if show_plays_daily is empty, populate it from
-  // every day present in analytics_events. Self-healing — drop the table
-  // and restart to re-roll history.
-  try {
-    const filled = backfillShowPlaysIfEmpty();
-    if (filled > 0) {
-      console.log(`[trending] backfilled ${filled} day(s) of show plays`);
-    }
-  } catch (err) {
-    console.error("Trending backfill error:", err);
-  }
 
   runRollup();
   setInterval(runRollup, 3600_000).unref();

--- a/docs/adr/0004-trending-shows.md
+++ b/docs/adr/0004-trending-shows.md
@@ -410,6 +410,167 @@ with a "Reset Home Screen to Defaults" action at the bottom. The
 density of home knobs reached a tipping point during this round; one
 big "Preferences" section was getting hard to scan.
 
+## Algorithm change: logical-listen ranking (2026-05-25 cont.)
+
+Within hours of shipping the original endpoint the bias the ADR's
+*Negative consequences* section warned about ("a single power user can
+move the `now` rankings") turned out to be much bigger than predicted —
+not because we underestimated power users, but because the *primitive*
+was wrong, not the user base.
+
+### What was wrong
+
+The original ranking was `COUNT(DISTINCT install_id || '|' || session_id)`,
+where `session_id` is one app lifetime. Each time the app got killed and
+relaunched mid-show, the resumed playback fired a fresh `playback_start`
+with a new `sid`. So one listener restarting the Greek 5 times in 30
+minutes registered as 5 "sessions" — indistinguishable from 5 different
+people each listening once.
+
+The 1982-05-23 Greek showed 19 sessions in the week window. The new
+primitive shows 10 listens from 7 distinct installs. Most of the
+deflation is the same one or two people getting de-duplicated.
+
+The Stanley Theatre 9/27/72 example is even cleaner: 35 plays from 1
+install used to look like a strong signal under any "plays"-weighted
+ranking. It's now 1 listen / 1 install — exactly as a human would
+describe what happened.
+
+### New primitive: logical listens
+
+A **logical listen** is a maximal run of `playback_start` events from
+one install on one show, where the run is broken by either:
+
+1. A play of a *different* show in between, or
+2. A gap of more than 6 hours.
+
+Walking each install's events in time order and incrementing a counter
+when a new listen starts gives the count. The 6h gap threshold means
+"come back the next morning" counts as a second listen (which matches
+intuition), but "lock phone, come back 30 min later" does not.
+
+```sql
+WITH plays AS (
+  SELECT iid, json_extract(props, '$.show_id') AS show_id, ts,
+         LAG(json_extract(props, '$.show_id')) OVER w AS prev_show,
+         LAG(ts)                              OVER w AS prev_ts
+  FROM analytics_events
+  WHERE event = 'playback_start'
+    AND json_extract(props, '$.show_id') IS NOT NULL
+  WINDOW w AS (PARTITION BY iid ORDER BY ts)
+),
+listens AS (
+  SELECT iid, show_id, ts,
+         CASE WHEN prev_show IS NULL
+                OR prev_show != show_id
+                OR (ts - prev_ts) > 21600000  -- 6h
+              THEN 1 ELSE 0 END AS is_new
+  FROM plays
+)
+SELECT show_id,
+       SUM(is_new)         AS listens,
+       COUNT(*)            AS plays,
+       COUNT(DISTINCT iid) AS installs
+FROM listens
+WHERE ts > :window_start
+GROUP BY show_id
+HAVING SUM(is_new) > 0
+ORDER BY listens DESC, plays DESC
+LIMIT :n;
+```
+
+The LAG scan deliberately runs *over the full event history*, not
+filtered to the window — so listen-start detection is correct even when
+a listen straddles the window boundary. The window filter applies to
+which listen-start events count toward this window, not which events
+participate in the LAG.
+
+### Storage: window-keyed rollup, not day-keyed
+
+The previous `show_plays_daily` table summed per-day session counts
+across windows. That worked when sessions were the primitive, because
+sessions are scoped to a single day anyway (a session ID rarely
+survives across the midnight UTC boundary). It does **not** work for
+logical listens: an install playing Cornell at 11pm and again at 1am
+crosses a day boundary inside one listen.
+
+The fix: a new table keyed by `(window, show_id)`, fully rebuilt each
+hour from raw events:
+
+```sql
+CREATE TABLE show_listens_rollup (
+  window TEXT NOT NULL,         -- 'now' | 'week' | 'month' | 'all'
+  show_id TEXT NOT NULL,
+  listens INTEGER NOT NULL,
+  plays INTEGER NOT NULL,
+  installs INTEGER NOT NULL,
+  PRIMARY KEY (window, show_id)
+);
+```
+
+The rebuild is a single transaction: `DELETE` all rows, then 4 INSERTs
+(one per window) using the query above. We cache the top 50 per window;
+the endpoint serves top 10. Storing the extra headroom lets us change
+the served limit without re-running the rollup.
+
+The old `show_plays_daily` table is dropped on startup. There's no
+migration concern — every value in it was derivable from
+`analytics_events`, which is the source of truth.
+
+### Cost shape
+
+The rollup is the only thing that scans `analytics_events`. The
+endpoint reads a small precomputed table behind a 10-minute Redis
+cache, so the request path is constant-time regardless of analytics
+volume. At ~7,000 events total today the rollup takes under 20 ms; at
+10× growth, ~200 ms in a background hourly tick. Nothing in the
+critical path scales with analytics-events count.
+
+The original ADR's "self-improving signal as user base grows"
+prediction was right in spirit — the rankings *do* get cleaner with
+more users — but the algorithm bias was masking that benefit. The
+new primitive makes the asymptote land where it should: more users
+means more distinct installs hitting the rollup, which is the signal
+we actually want.
+
+### Why we kept `plays` and added `installs`
+
+`plays` (raw `playback_start` count) is kept in the response and used
+only as a tiebreaker, not the primary signal. It's still useful
+operationally — it tells you, when ranking is tight, which show people
+went deep on.
+
+`installs` (distinct iids in the window) is new in the response. It's
+the most human-readable number — "how many different people played
+this show" — and matches what most people imagine when they ask "what
+are trending shows." We deliberately rank by `listens` rather than
+`installs`, though, because someone playing the same show on two
+different days *is* a stronger signal than someone playing it once,
+and the logical-listen count captures that without inflating from
+session restarts the way the old primitive did.
+
+### What we deliberately did *not* do
+
+- **Engagement weighting (e.g. count by `listened_ms`).** Tempting,
+  especially now that we know `playback_end` carries `listened_ms`
+  and a `reason` field. Held off because (a) the ranking change here
+  already addresses the user-visible complaint, (b) the duration data
+  is a separate axis from the dedup question, and (c) "this person
+  actually listened to most of it" is a fundamentally different
+  signal than "this show came up in someone's listening." Worth
+  revisiting if the new ranking still feels off.
+- **Engagement gate (require ≥N tracks before counting).** Would
+  drop the "Scarlet > Fire only" case, which is real signal. The
+  logical-listen primitive already treats one-track and 22-track
+  plays as 1 listen each, which is the right symmetry: depth
+  doesn't get rewarded *or* penalized.
+- **Velocity / momentum ranking.** Still deferred from v1. The
+  current windowing (now / week / month / all) already differentiates
+  short-window novelty from long-window perennials; adding a "spike
+  vs baseline" score would mostly help when a single show suddenly
+  appears, which doesn't happen often in a catalog of known shows
+  with stable taste.
+
 ## References
 
 - `api-data/analytics.db` — production analytics database (pulled via


### PR DESCRIPTION
## Summary

Replaces the session-based dedup primitive in `/api/trending` with a **logical-listen** primitive. Same listener restarting the same show across app launches now counts as one listen instead of N.

### What was wrong

Original ranking was `COUNT(DISTINCT iid || '|' || sid)`. A `sid` is one app lifetime, so one person force-killing and resuming the Greek 5 times in 30 minutes registered as 5 votes — same as 5 different people each listening once. The 5/23/82 Greek floated to the top of the week window largely on a single user's restarts; 9/27/72 Stanley Theatre showed `35 plays` from `1 install` and dominated similarly.

### What changes

- **Algorithm**: a logical listen is a maximal run of `playback_start` events from one install on one show, broken by either (a) a play of a different show in between, or (b) a gap > 6h. Walking each install's events in time order and incrementing a counter when a new listen starts gives the count.
- **Storage**: drop `show_plays_daily`, add `show_listens_rollup` keyed by `(window, show_id)`. Fully rebuilt hourly in a single transaction — top 50 per window cached, top 10 served.
- **Endpoint**: reads precomputed rows behind the existing Redis cache. No live query path. Request-path cost is constant in analytics volume.
- **Response shape**: `{ show_id, listens, plays, installs }`. `listens` is the new primary signal; `plays` is the tiebreaker; `installs` is the human-readable "how many distinct people."
- **Mobile clients**: only consume `show_id`, so the field rename ships with no client churn needed.

### Spike results (against pulled prod analytics)

| Show | Old (sessions) | New (listens) | Installs |
|---|---|---|---|
| Greek '82 5/23 (week) | 19 | **10** | 7 |
| Cornell (all) | 67 | **55** | 33 |
| Stanley Theatre 9/27/72 (now) | inflated by depth | **1** | 1 |

Greek dropped 47% (mostly one user de-duped). Cornell only 18% (genuine diverse listenership). Exactly the shape we wanted.

### Tests

11 new tests covering: 5 restarts → 1 listen, same show 7h apart → 2 listens, A→B→A interleave → 2 A-listens, deep listen (22 tracks, 1 person) loses ranking to 3 light listens from different installs, window correctness, idempotency.

### ADR

ADR-0004 amended with the algorithm change, new storage shape, the SQL query, and what we deliberately did *not* pursue (engagement weighting, min-track gates, velocity).

## Test plan

- [ ] `npm test` in `api/` — 33 tests pass locally.
- [ ] Deploy to prod; confirm the rollup job populates `show_listens_rollup` with 4 windows.
- [ ] Hit `/api/trending` and confirm the Greek's week count is materially lower than 19.
- [ ] Spot-check that shows with high `plays` but low `installs` (deep-listen power users) no longer dominate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)