### PR TITLE
Trending TIGDH filter + analytics polish

### DIFF
--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
@@ -59,6 +59,7 @@ class AppPreferences @Inject constructor(
         private const val KEY_HOME_TRENDING_CARD_SIZE = "home_trending_card_size"
         private const val KEY_HOME_TODAY_CARD_SIZE = "home_today_card_size"
         private const val KEY_HOME_COLLECTIONS_CARD_SIZE = "home_collections_card_size"
+        private const val KEY_HOME_TRENDING_INCLUDE_ANNIVERSARIES = "home_trending_include_anniversaries"
     }
 
     private val _homeTrendingCardSize = MutableStateFlow(
@@ -96,6 +97,24 @@ class AppPreferences @Inject constructor(
         setHomeTrendingCardSize("small")
         setHomeTodayCardSize("large")
         setHomeCollectionsCardSize("large")
+        setHomeTrendingIncludeAnniversaries(false)
+    }
+
+    private val _homeTrendingIncludeAnniversaries = MutableStateFlow(
+        prefs.getBoolean(KEY_HOME_TRENDING_INCLUDE_ANNIVERSARIES, false)
+    )
+
+    /**
+     * When true, "Today in Grateful Dead History" shows are included in the
+     * `now` trending window. Off by default so the 24h ranking surfaces
+     * organic momentum instead of echoing the OTD home rail.
+     */
+    val homeTrendingIncludeAnniversaries: StateFlow<Boolean> =
+        _homeTrendingIncludeAnniversaries.asStateFlow()
+
+    fun setHomeTrendingIncludeAnniversaries(value: Boolean) {
+        prefs.edit().putBoolean(KEY_HOME_TRENDING_INCLUDE_ANNIVERSARIES, value).apply()
+        _homeTrendingIncludeAnniversaries.value = value
     }
 
     private val _homeTrendingAboveToday = MutableStateFlow(

--- a/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/TrendingServiceImpl.kt
+++ b/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/TrendingServiceImpl.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -49,6 +50,13 @@ class TrendingServiceImpl @Inject constructor(
                 delay(REFRESH_INTERVAL_MS)
             }
         }
+        // Refetch immediately when the user flips the anniversaries filter
+        // — the param changes the response, so the cached content is stale.
+        scope.launch {
+            appPreferences.homeTrendingIncludeAnniversaries
+                .drop(1)
+                .collect { refresh() }
+        }
     }
 
     override suspend fun refresh(): Result<Unit> = withContext(Dispatchers.IO) {
@@ -79,7 +87,9 @@ class TrendingServiceImpl @Inject constructor(
     }
 
     private fun fetchTrendingJson(): JSONObject {
-        val url = URL("${appPreferences.apiBaseUrl}/api/trending")
+        val includeAnniv = appPreferences.homeTrendingIncludeAnniversaries.value
+        val query = if (includeAnniv) "?include_anniversaries=true" else ""
+        val url = URL("${appPreferences.apiBaseUrl}/api/trending$query")
         val conn = url.openConnection() as HttpURLConnection
         try {
             conn.requestMethod = "GET"

--- a/androidApp/feature/favorites/src/main/java/com/grateful/deadly/feature/favorites/screens/main/models/FavoritesViewModel.kt
+++ b/androidApp/feature/favorites/src/main/java/com/grateful/deadly/feature/favorites/screens/main/models/FavoritesViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.grateful.deadly.core.api.favorites.FavoritesService
 import com.grateful.deadly.core.api.favorites.ReviewService
+import com.grateful.deadly.core.database.AnalyticsService
 import com.grateful.deadly.core.database.AppPreferences
 import com.grateful.deadly.core.database.service.BackupImportExportService
 import com.grateful.deadly.core.model.*
@@ -43,6 +44,7 @@ class FavoritesViewModel @Inject constructor(
     private val reviewService: ReviewService,
     val appPreferences: AppPreferences,
     private val backupImportExportService: BackupImportExportService,
+    private val analyticsService: AnalyticsService,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
@@ -75,6 +77,11 @@ class FavoritesViewModel @Inject constructor(
 
     fun setDisplayMode(mode: FavoritesDisplayMode) {
         appPreferences.setFavoritesDisplayMode(mode.name)
+        analyticsService.track("feature_use", mapOf(
+            "feature" to "set_favorites_display_mode",
+            "category" to "preference",
+            "value" to mode.name,
+        ))
     }
 
     init {

--- a/androidApp/feature/home/build.gradle.kts
+++ b/androidApp/feature/home/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation(project(":core:design"))
     implementation(project(":core:api:home"))
     implementation(project(":core:home"))
+    implementation(project(":core:database"))
     implementation(project(":core:model"))
     
     // V2 Feature Dependencies

--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeViewModel.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeViewModel.kt
@@ -5,10 +5,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.grateful.deadly.core.api.home.HomeService
 import com.grateful.deadly.core.api.home.HomeContent
+import com.grateful.deadly.core.api.home.TrendingService
+import com.grateful.deadly.core.database.AppPreferences
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -22,19 +25,32 @@ import javax.inject.Inject
  */
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    private val homeService: HomeService
+    private val homeService: HomeService,
+    private val trendingService: TrendingService,
+    private val appPreferences: AppPreferences,
 ) : ViewModel() {
-    
+
     companion object {
         private const val TAG = "HomeViewModel"
     }
-    
+
     private val _uiState = MutableStateFlow(HomeUiState.initial())
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
-    
+
     init {
         Log.d(TAG, "HomeViewModel initialized")
         observeHomeService()
+        // Refetch trending when the user flips the anniversaries filter.
+        // The TrendingService has its own observer too — this is belt-and-
+        // suspenders to make sure the VM's lifecycle catches the change.
+        viewModelScope.launch {
+            appPreferences.homeTrendingIncludeAnniversaries
+                .drop(1)
+                .collect {
+                    Log.d(TAG, "anniversaries pref changed → refresh trending")
+                    trendingService.refresh()
+                }
+        }
     }
     
     /**

--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/components/TrendingNowSection.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/components/TrendingNowSection.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -62,7 +63,16 @@ fun TrendingNowSection(
                 modifier = Modifier.clickable(onClick = onCycleWindow),
             )
         }
-        LazyRow(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+        // Reset scroll to the start when the trending set changes (window
+        // switch, anniversaries toggle, etc.). Without this the user stays
+        // mid-rail and the visible items happen to look similar across
+        // toggles, making it look like nothing updated.
+        val listState = rememberLazyListState()
+        val firstId = shows.firstOrNull()?.id
+        LaunchedEffect(firstId, window) {
+            listState.scrollToItem(0)
+        }
+        LazyRow(state = listState, horizontalArrangement = Arrangement.spacedBy(16.dp)) {
             items(shows, key = { it.id }) { show ->
                 val display = if (isCompact) {
                     show.date

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
@@ -38,6 +38,7 @@ fun SettingsScreen(
     val playerControlsStyle by viewModel.playerControlsStyle.collectAsState()
     val homeTrendingWindow by viewModel.homeTrendingWindow.collectAsState()
     val homeTrendingAboveToday by viewModel.homeTrendingAboveToday.collectAsState()
+    val homeTrendingIncludeAnniversaries by viewModel.homeTrendingIncludeAnniversaries.collectAsState()
     val homeRecentRows by viewModel.homeRecentRows.collectAsState()
     val homeTrendingCardSize by viewModel.homeTrendingCardSize.collectAsState()
     val homeTodayCardSize by viewModel.homeTodayCardSize.collectAsState()
@@ -165,6 +166,15 @@ fun SettingsScreen(
                 subtitle = "Move the Trending section below \"Today In Grateful Dead History\" by turning this off.",
                 checked = homeTrendingAboveToday,
                 onCheckedChange = { viewModel.toggleHomeTrendingAboveToday() }
+            )
+        }
+
+        item {
+            PreferenceToggleRow(
+                title = "Include \"Today in History\" in Trending",
+                subtitle = "Off by default — recommended for variety. The 24-hour Trending window is otherwise dominated by anniversary plays.",
+                checked = homeTrendingIncludeAnniversaries,
+                onCheckedChange = { viewModel.toggleHomeTrendingIncludeAnniversaries() }
             )
         }
 

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
@@ -122,6 +122,19 @@ class SettingsViewModel @Inject constructor(
         ))
     }
 
+    val homeTrendingIncludeAnniversaries: StateFlow<Boolean> =
+        appPreferences.homeTrendingIncludeAnniversaries
+
+    fun toggleHomeTrendingIncludeAnniversaries() {
+        val newValue = !appPreferences.homeTrendingIncludeAnniversaries.value
+        appPreferences.setHomeTrendingIncludeAnniversaries(newValue)
+        analyticsService.track("feature_use", mapOf(
+            "feature" to "set_home_trending_include_anniversaries",
+            "category" to "preference",
+            "value" to newValue.toString(),
+        ))
+    }
+
     val homeRecentRows: StateFlow<Int> = appPreferences.homeRecentRows
 
     fun setHomeRecentRows(value: Int) {

--- a/api/src/db/__tests__/live-listeners.test.ts
+++ b/api/src/db/__tests__/live-listeners.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+
+const TMP_DB = path.join(
+  os.tmpdir(),
+  `live-listeners-test-${process.pid}-${Date.now()}.db`,
+);
+process.env.ANALYTICS_DB_PATH = TMP_DB;
+
+const {
+  getAnalyticsDb,
+  insertEvents,
+  getLiveListeners,
+  getRecentListening,
+  closeAnalyticsDb,
+} = await import("../analytics.js");
+
+function ev(
+  event: "playback_start" | "playback_end",
+  iid: string,
+  sid: string,
+  showId: string,
+  trackIndex: number,
+  ts: number,
+  extra: Record<string, unknown> = {},
+) {
+  return {
+    event,
+    ts,
+    iid,
+    sid,
+    platform: "ios",
+    app_version: "2.30.0",
+    props: { show_id: showId, track_index: trackIndex, ...extra },
+  };
+}
+
+beforeEach(() => {
+  const db = getAnalyticsDb();
+  db.exec(`DELETE FROM analytics_events;`);
+});
+
+afterAll(() => {
+  closeAnalyticsDb();
+  if (fs.existsSync(TMP_DB)) fs.unlinkSync(TMP_DB);
+});
+
+describe("getLiveListeners — soft live boundary", () => {
+  it("a user 30s past a playback_end still counts as live", () => {
+    // This is the reported bug: between tracks (after end of N, before
+    // start of N+1) the user was dropping into Recent Listening with a
+    // "36 seconds ago" timestamp despite actively listening.
+    const now = Date.now();
+    insertEvents([
+      ev("playback_start", "alice", "s1", "show-A", 0, now - 60_000),
+      ev("playback_end", "alice", "s1", "show-A", 0, now - 30_000, {
+        reason: "completed",
+      }),
+    ]);
+
+    const live = getLiveListeners();
+    expect(live).toHaveLength(1);
+    expect(live[0].iid).toBe("alice");
+    expect(live[0].show_id).toBe("show-A");
+    // started_at should reflect the original playback_start, not the end.
+    expect(live[0].started_at).toBe(now - 60_000);
+  });
+
+  it("a user with only a playback_start within 90s is live", () => {
+    const now = Date.now();
+    insertEvents([
+      ev("playback_start", "bob", "s1", "show-B", 0, now - 10_000),
+    ]);
+
+    const live = getLiveListeners();
+    expect(live.map((l) => l.iid)).toEqual(["bob"]);
+  });
+
+  it("a user whose latest event is >90s old is not live", () => {
+    const now = Date.now();
+    insertEvents([
+      ev("playback_start", "carol", "s1", "show-C", 0, now - 5 * 60_000),
+      ev("playback_end", "carol", "s1", "show-C", 0, now - 2 * 60_000, {
+        reason: "skipped_next",
+      }),
+    ]);
+
+    expect(getLiveListeners()).toEqual([]);
+  });
+
+  it("the latest event wins — switching shows in <90s updates current state", () => {
+    const now = Date.now();
+    insertEvents([
+      // Started show A 5 minutes ago, then ended it 60s ago…
+      ev("playback_start", "dave", "s1", "show-A", 0, now - 5 * 60_000),
+      ev("playback_end", "dave", "s1", "show-A", 0, now - 60_000, {
+        reason: "skipped_next",
+      }),
+      // …then started show B 20s ago.
+      ev("playback_start", "dave", "s1", "show-B", 0, now - 20_000),
+    ]);
+
+    const live = getLiveListeners();
+    expect(live).toHaveLength(1);
+    expect(live[0].show_id).toBe("show-B");
+  });
+
+  it("at most one row per iid even with multiple unmatched starts", () => {
+    // Crashed-without-end scenario: client emits a second start without
+    // ending the first. We still want one row per listener, picking the
+    // latest event.
+    const now = Date.now();
+    insertEvents([
+      ev("playback_start", "eve", "s1", "show-A", 0, now - 60_000),
+      ev("playback_start", "eve", "s2", "show-B", 0, now - 20_000),
+    ]);
+
+    const live = getLiveListeners();
+    expect(live).toHaveLength(1);
+    expect(live[0].show_id).toBe("show-B");
+  });
+});
+
+describe("getRecentListening excludes live listeners under the new boundary", () => {
+  it("between-tracks user appears in Live, NOT Recent", () => {
+    // The same scenario that proves the live fix shouldn't also leak
+    // the user into Recent Listening.
+    const now = Date.now();
+    insertEvents([
+      ev("playback_start", "alice", "s1", "show-A", 0, now - 60_000),
+      ev("playback_end", "alice", "s1", "show-A", 0, now - 30_000, {
+        reason: "completed",
+      }),
+    ]);
+
+    const live = getLiveListeners();
+    const recent = getRecentListening(24);
+    expect(live.map((l) => l.iid)).toEqual(["alice"]);
+    expect(recent.find((r) => r.iid === "alice" && r.show_id === "show-A")).toBeUndefined();
+  });
+
+  it("a user 2 min past their last event appears in Recent, not Live", () => {
+    const now = Date.now();
+    insertEvents([
+      ev("playback_start", "bob", "s1", "show-B", 0, now - 5 * 60_000),
+      ev("playback_end", "bob", "s1", "show-B", 0, now - 2 * 60_000, {
+        reason: "skipped_next",
+      }),
+    ]);
+
+    expect(getLiveListeners()).toEqual([]);
+    const recent = getRecentListening(24);
+    expect(recent.find((r) => r.iid === "bob")).toBeDefined();
+  });
+
+  it("a user listening to show B (live) is excluded from B but still appears in Recent for past show A", () => {
+    const now = Date.now();
+    insertEvents([
+      // Past listen to show A, fully ended 1 hour ago.
+      ev("playback_start", "carol", "s1", "show-A", 0, now - 2 * 3600_000),
+      ev("playback_end", "carol", "s1", "show-A", 0, now - 3600_000, {
+        reason: "completed",
+      }),
+      // Current live session on show B.
+      ev("playback_start", "carol", "s2", "show-B", 0, now - 10_000),
+    ]);
+
+    const live = getLiveListeners();
+    expect(live).toHaveLength(1);
+    expect(live[0].show_id).toBe("show-B");
+
+    const recent = getRecentListening(24);
+    const carolRecents = recent.filter((r) => r.iid === "carol");
+    // show-A appears in recent (past), show-B does not (live).
+    expect(carolRecents.map((r) => r.show_id).sort()).toEqual(["show-A"]);
+  });
+});

--- a/api/src/db/__tests__/trending.test.ts
+++ b/api/src/db/__tests__/trending.test.ts
@@ -225,6 +225,48 @@ describe("getTrending window correctness", () => {
     expect(first.windows.all).toEqual(second.windows.all);
   });
 
+  it("filters anniversary shows from the now window by default", () => {
+    // Build show_ids whose date prefix matches today / yesterday / tomorrow
+    // and one that doesn't. Filter should drop the first three from `now`
+    // but leave them in `week` and `all`.
+    const now = new Date();
+    const fmt = (d: Date): string =>
+      `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
+    const yest = new Date(now.getTime() - DAY_MS);
+    const tmrw = new Date(now.getTime() + DAY_MS);
+    // Make the anniversary show-ids look real — `YYYY-MM-DD-venue` — but
+    // shift the year way back so they don't accidentally fall outside the
+    // 7-day "week" window via their own date prefix (the filter is on
+    // show_id, the window is on event ts).
+    const today1977 = `1977-${fmt(now).slice(5)}-venue-a`;
+    const yest1977 = `1977-${fmt(yest).slice(5)}-venue-b`;
+    const tmrw1977 = `1977-${fmt(tmrw).slice(5)}-venue-c`;
+    const nonAnniv = "1985-12-31-venue-d";
+
+    const t = Date.now() - HOUR_MS;
+    insertEvents([
+      play("u1", "s1", today1977, t),
+      play("u2", "s2", yest1977, t),
+      play("u3", "s3", tmrw1977, t),
+      play("u4", "s4", nonAnniv, t),
+    ]);
+    rebuildShowListensRollup();
+
+    const filtered = getTrending(10).windows.now.map((r) => r.show_id);
+    expect(filtered).toEqual([nonAnniv]);
+
+    const withAnniv = getTrending(10, true).windows.now.map((r) => r.show_id);
+    expect(withAnniv.sort()).toEqual(
+      [today1977, yest1977, tmrw1977, nonAnniv].sort(),
+    );
+
+    // Filter is now-only — `all` keeps everything regardless of the flag.
+    const allIds = getTrending(10).windows.all.map((r) => r.show_id).sort();
+    expect(allIds).toEqual(
+      [today1977, yest1977, tmrw1977, nonAnniv].sort(),
+    );
+  });
+
   it("ignores events without a show_id", () => {
     const t = Date.now() - HOUR_MS;
     getAnalyticsDb()

--- a/api/src/db/analytics.ts
+++ b/api/src/db/analytics.ts
@@ -1852,29 +1852,77 @@ export function rebuildShowListensRollup(): void {
 }
 
 /**
+ * MM-DD strings for today and ±1 day, used to exclude "Today in Grateful
+ * Dead History" shows from the `now` window of trending. The 24h window
+ * straddles two calendar dates, and the OTD home rail promotes the
+ * matching anniversary shows, so without this filter the `now` ranking
+ * is dominated by anniversary plays rather than organic listening.
+ * ±1 covers the calendar boundary (yesterday's anniversary plays from
+ * 23:00 are still inside the 24h window at 22:00 today).
+ */
+function anniversaryMonthDays(now: Date): string[] {
+  const fmt = (d: Date): string =>
+    `${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
+  const today = new Date(now);
+  const yesterday = new Date(now.getTime() - 24 * 3600 * 1000);
+  const tomorrow = new Date(now.getTime() + 24 * 3600 * 1000);
+  return [fmt(yesterday), fmt(today), fmt(tomorrow)];
+}
+
+/**
  * Trending shows across four time windows. Reads precomputed rows from
  * `show_listens_rollup` — no event scan, no Redis round-trip — so it's
  * cheap even under traffic spikes.
+ *
+ * `includeAnniversaries` controls whether shows whose date matches
+ * today (MM-DD ±1) are filtered out of the `now` window. Defaults to
+ * false so trending surfaces organic momentum rather than echoing the
+ * OTD home rail. Other windows are never filtered — week/month/all are
+ * long enough that anniversary spikes wash out.
  */
-export function getTrending(limit = 10): TrendingResponse {
+export function getTrending(
+  limit = 10,
+  includeAnniversaries = false,
+): TrendingResponse {
   const db = getAnalyticsDb();
-  const stmt = db.prepare(
+
+  const plainStmt = db.prepare(
     `SELECT show_id, listens, plays, installs
      FROM show_listens_rollup
      WHERE window = ?
      ORDER BY listens DESC, plays DESC
      LIMIT ?`,
   );
-  const fetch = (name: TrendingWindowName): TrendingShow[] =>
-    stmt.all(name, limit) as TrendingShow[];
+
+  // show_id is `YYYY-MM-DD-...`; matching on substr(show_id, 6, 5) lets
+  // SQLite use the WHERE clause without pulling rows through JS.
+  const filteredNowStmt = db.prepare(
+    `SELECT show_id, listens, plays, installs
+     FROM show_listens_rollup
+     WHERE window = 'now'
+       AND substr(show_id, 6, 5) NOT IN (?, ?, ?)
+     ORDER BY listens DESC, plays DESC
+     LIMIT ?`,
+  );
+
+  const fetchPlain = (name: TrendingWindowName): TrendingShow[] =>
+    plainStmt.all(name, limit) as TrendingShow[];
+
+  let nowRows: TrendingShow[];
+  if (includeAnniversaries) {
+    nowRows = fetchPlain("now");
+  } else {
+    const [yest, today, tmrw] = anniversaryMonthDays(new Date());
+    nowRows = filteredNowStmt.all(yest, today, tmrw, limit) as TrendingShow[];
+  }
 
   return {
     generated_at: new Date().toISOString(),
     windows: {
-      now: fetch("now"),
-      week: fetch("week"),
-      month: fetch("month"),
-      all: fetch("all"),
+      now: nowRows,
+      week: fetchPlain("week"),
+      month: fetchPlain("month"),
+      all: fetchPlain("all"),
     },
   };
 }

--- a/api/src/db/analytics.ts
+++ b/api/src/db/analytics.ts
@@ -811,68 +811,81 @@ export interface LiveListener {
 }
 
 /**
- * Approximate "currently listening" set. Returns each `playback_start`
- * from the last 45 minutes that has no subsequent `playback_end` for
- * the same (iid, sid, show_id, track_index). The window is long enough
- * to cover the longest Grateful Dead jams ("Dark Star", "Playin' in
- * the Band", etc, which routinely exceed 25 minutes) without losing
- * an active listener mid-track. Sessions that crash or are force-killed
- * without emitting `playback_end` will linger for up to 45 minutes —
- * a deliberate trade for not requiring a heartbeat.
+ * "Currently listening" set, defined as: each install's most recent
+ * `playback_start` / `playback_end` event whose timestamp is within
+ * LIVE_WINDOW_MS. The "soft" boundary (events of *either* kind count)
+ * keeps a listener live across the autoplay gap between tracks: when
+ * track N ends naturally, the brief moment before track N+1's
+ * `playback_start` fires would otherwise drop them into Recent
+ * Listening and they'd show as "36s ago" while still actively
+ * listening. Sessions that crash or get force-killed without emitting
+ * `playback_end` still linger for up to LIVE_WINDOW_MS — same trade
+ * as before, just shorter than the old 45-minute window. The
+ * shorter window is fine because the new definition no longer
+ * relies on "unmatched start" semantics.
  */
+const LIVE_WINDOW_MS = 90 * 1000;
+
 export function getLiveListeners(): LiveListener[] {
   const db = getAnalyticsDb();
-  const windowStart = Date.now() - 45 * 60 * 1000;
+  const windowStart = Date.now() - LIVE_WINDOW_MS;
 
-  // Pull `sid` too so we can resolve the bitmap for *this* listening session
-  // of this show (rather than every time the listener has ever played it).
-  //
-  // A user can only listen to one thing at a time. The unmatched-start filter
-  // can leave multiple ghosts per iid when the client emits a new
-  // `playback_start` without a corresponding `playback_end` for the previous
-  // one (force-quit, crash, network drop, rapid show switches). Take only the
-  // most recent unmatched start per iid as the listener's current state.
+  // Pick the latest playback event per iid (start or end), then keep
+  // only those whose latest event is inside the live window AND
+  // describes a show. `started_at` is resolved separately as the most
+  // recent `playback_start` for this (iid, show_id) within a generous
+  // lookback so the UI can render "started X ago" correctly even when
+  // the live-keepalive event is an end.
   const rows = db
     .prepare(
-      `SELECT
-         s.iid,
-         s.sid,
-         s.platform,
-         s.app_version,
-         s.ts AS started_at,
-         json_extract(s.props, '$.show_id') AS show_id,
-         json_extract(s.props, '$.recording_id') AS recording_id,
-         json_extract(s.props, '$.track_index') AS track_index,
-         json_extract(s.props, '$.source') AS source
-       FROM analytics_events s
-       WHERE s.event = 'playback_start' AND s.ts >= ?
-         AND NOT EXISTS (
-           SELECT 1 FROM analytics_events e
-           WHERE e.event = 'playback_end'
-             AND e.iid = s.iid
-             AND e.sid = s.sid
-             AND e.ts >= s.ts
-             AND json_extract(e.props, '$.show_id') = json_extract(s.props, '$.show_id')
-             AND json_extract(e.props, '$.track_index') = json_extract(s.props, '$.track_index')
-         )
-         AND s.ts = (
-           SELECT MAX(s2.ts) FROM analytics_events s2
-           WHERE s2.event = 'playback_start'
-             AND s2.iid = s.iid
-             AND s2.ts >= ?
-             AND NOT EXISTS (
-               SELECT 1 FROM analytics_events e2
-               WHERE e2.event = 'playback_end'
-                 AND e2.iid = s2.iid
-                 AND e2.sid = s2.sid
-                 AND e2.ts >= s2.ts
-                 AND json_extract(e2.props, '$.show_id') = json_extract(s2.props, '$.show_id')
-                 AND json_extract(e2.props, '$.track_index') = json_extract(s2.props, '$.track_index')
-             )
-         )
-       ORDER BY s.ts DESC`,
+      `WITH latest AS (
+         SELECT
+           iid,
+           sid,
+           ts,
+           event,
+           platform,
+           app_version,
+           json_extract(props, '$.show_id') AS show_id,
+           json_extract(props, '$.recording_id') AS recording_id,
+           CAST(json_extract(props, '$.track_index') AS INTEGER) AS track_index,
+           json_extract(props, '$.source') AS source,
+           ROW_NUMBER() OVER (PARTITION BY iid ORDER BY ts DESC) AS rn
+         FROM analytics_events
+         WHERE event IN ('playback_start', 'playback_end')
+           AND ts >= ?
+           AND json_extract(props, '$.show_id') IS NOT NULL
+       )
+       SELECT
+         l.iid,
+         l.sid,
+         l.platform,
+         l.app_version,
+         COALESCE(
+           (SELECT MAX(s.ts) FROM analytics_events s
+              WHERE s.event = 'playback_start'
+                AND s.iid = l.iid
+                AND json_extract(s.props, '$.show_id') = l.show_id
+                AND s.ts >= ?),
+           l.ts
+         ) AS started_at,
+         l.show_id,
+         l.recording_id,
+         l.track_index,
+         l.source
+       FROM latest l
+       WHERE l.rn = 1
+         AND l.ts >= ?
+       ORDER BY l.ts DESC`,
     )
-    .all(windowStart, windowStart) as Array<{
+    .all(
+      // Latest-event lookback: a bit wider than LIVE_WINDOW_MS so the
+      // ROW_NUMBER pick is robust against clock skew / batch flushes.
+      Date.now() - 6 * 3600 * 1000,
+      // started_at lookup: look back 6h to find the original session start.
+      Date.now() - 6 * 3600 * 1000,
+      windowStart,
+    ) as Array<{
       iid: string;
       sid: string;
       platform: string;
@@ -1250,7 +1263,7 @@ export function getRecentListening(
   const db = getAnalyticsDb();
   const now = Date.now();
   const windowStart = now - hours * 3600 * 1000;
-  const liveWindowStart = now - 45 * 60 * 1000;
+  const liveWindowStart = now - LIVE_WINDOW_MS;
 
   const rows = db
     .prepare(
@@ -1308,26 +1321,26 @@ export function getRecentListening(
               AND event = 'playback_start'
             ORDER BY ts ASC LIMIT 1) AS source
        FROM agg a
+       -- Mirror the live definition in getLiveListeners: exclude
+       -- (iid, show_id) pairs where this iid's most recent playback
+       -- event is within LIVE_WINDOW_MS AND describes this show.
        WHERE NOT EXISTS (
-         SELECT 1 FROM analytics_events s
-         WHERE s.event = 'playback_start'
-           AND s.iid = a.iid
-           AND json_extract(s.props, '$.show_id') = a.show_id
-           AND s.ts >= ?
-           AND NOT EXISTS (
-             SELECT 1 FROM analytics_events e
-             WHERE e.event = 'playback_end'
-               AND e.iid = s.iid
-               AND e.sid = s.sid
-               AND e.ts >= s.ts
-               AND json_extract(e.props, '$.show_id') = json_extract(s.props, '$.show_id')
-               AND json_extract(e.props, '$.track_index') = json_extract(s.props, '$.track_index')
+         SELECT 1 FROM analytics_events latest
+         WHERE latest.event IN ('playback_start', 'playback_end')
+           AND latest.iid = a.iid
+           AND latest.ts >= ?
+           AND json_extract(latest.props, '$.show_id') = a.show_id
+           AND latest.ts = (
+             SELECT MAX(x.ts) FROM analytics_events x
+             WHERE x.event IN ('playback_start', 'playback_end')
+               AND x.iid = a.iid
+               AND x.ts >= ?
            )
        )
        ORDER BY a.last_event_at DESC
        LIMIT ?`,
     )
-    .all(windowStart, liveWindowStart, limit) as Array<{
+    .all(windowStart, liveWindowStart, liveWindowStart, limit) as Array<{
       iid: string;
       show_id: string;
       started_at: number;

--- a/api/src/routes/trending.ts
+++ b/api/src/routes/trending.ts
@@ -2,7 +2,8 @@ import type { FastifyInstance } from "fastify";
 import { getTrending, rebuildShowListensRollup } from "../db/analytics.js";
 import { getPublisher } from "../db/redis.js";
 
-const CACHE_KEY = "trending:v1";
+const CACHE_KEY_DEFAULT = "trending:v2";
+const CACHE_KEY_WITH_ANNIVERSARIES = "trending:v2:anniv";
 const CACHE_TTL_SECONDS = 600; // 10 minutes
 const TRENDING_LIMIT = 10;
 
@@ -17,7 +18,9 @@ const trendingShowSchema = {
 } as const;
 
 export async function trendingRoutes(app: FastifyInstance): Promise<void> {
-  app.get(
+  app.get<{
+    Querystring: { include_anniversaries?: string };
+  }>(
     "/api/trending",
     {
       schema: {
@@ -25,8 +28,17 @@ export async function trendingRoutes(app: FastifyInstance): Promise<void> {
         summary: "Trending shows for the home screen",
         description:
           "Returns four time windows (now=24h, week, month, all-time) of " +
-          "the most-played shows ranked by logical listens. Cached for 10 " +
-          "minutes in Redis. See ADR-0004 for the ranking algorithm.",
+          "the most-played shows ranked by logical listens. The `now` " +
+          "window excludes shows whose date matches today (MM-DD ±1) by " +
+          "default to avoid echoing the 'Today in History' home rail. " +
+          "Pass `?include_anniversaries=true` to include them. Cached for " +
+          "10 minutes in Redis. See ADR-0004 for the ranking algorithm.",
+        querystring: {
+          type: "object",
+          properties: {
+            include_anniversaries: { type: "string" },
+          },
+        },
         response: {
           200: {
             type: "object",
@@ -46,11 +58,17 @@ export async function trendingRoutes(app: FastifyInstance): Promise<void> {
         },
       },
     },
-    async (_request, reply) => {
+    async (request, reply) => {
+      const includeAnniversaries =
+        request.query?.include_anniversaries === "true";
+      const cacheKey = includeAnniversaries
+        ? CACHE_KEY_WITH_ANNIVERSARIES
+        : CACHE_KEY_DEFAULT;
+
       // Try Redis first. Failure (no Redis available, network blip) falls
       // through to the rollup table — better to be uncached than to 500.
       try {
-        const cached = await getPublisher().get(CACHE_KEY);
+        const cached = await getPublisher().get(cacheKey);
         if (cached) {
           reply.header("X-Trending-Cache", "hit");
           return reply.type("application/json").send(cached);
@@ -59,11 +77,11 @@ export async function trendingRoutes(app: FastifyInstance): Promise<void> {
         // Fall through to rollup read.
       }
 
-      const fresh = getTrending(TRENDING_LIMIT);
+      const fresh = getTrending(TRENDING_LIMIT, includeAnniversaries);
       const payload = JSON.stringify(fresh);
 
       try {
-        await getPublisher().set(CACHE_KEY, payload, "EX", CACHE_TTL_SECONDS);
+        await getPublisher().set(cacheKey, payload, "EX", CACHE_TTL_SECONDS);
       } catch {
         // Cache write best-effort.
       }
@@ -87,10 +105,10 @@ export function startTrendingSchedules(): void {
   const runRollup = (): void => {
     try {
       rebuildShowListensRollup();
-      // Bust cache so the next request reflects the fresh rollup.
-      getPublisher()
-        .del(CACHE_KEY)
-        .catch(() => {});
+      // Bust both cache variants so the next request reflects the fresh rollup.
+      const pub = getPublisher();
+      pub.del(CACHE_KEY_DEFAULT).catch(() => {});
+      pub.del(CACHE_KEY_WITH_ANNIVERSARIES).catch(() => {});
     } catch (err) {
       console.error("Trending rollup error:", err);
     }

--- a/iosApp/deadly/Core/Service/AppPreferences.swift
+++ b/iosApp/deadly/Core/Service/AppPreferences.swift
@@ -23,6 +23,7 @@ final class AppPreferences {
     private static let homeTrendingAboveTodayKey = "home_trending_above_today"
     private static let homeRecentRowsKey = "home_recent_rows"
     private static let homeTrendingCardSizeKey = "home_trending_card_size"
+    private static let homeTrendingIncludeAnniversariesKey = "home_trending_include_anniversaries"
     private static let homeTodayCardSizeKey = "home_today_card_size"
     private static let homeCollectionsCardSizeKey = "home_collections_card_size"
 
@@ -127,6 +128,13 @@ final class AppPreferences {
         didSet { UserDefaults.standard.set(homeTrendingCardSize, forKey: Self.homeTrendingCardSizeKey) }
     }
 
+    /// When true, "Today in Grateful Dead History" shows are included in the
+    /// `now` trending window. Off by default so the 24h ranking surfaces
+    /// organic momentum instead of echoing the OTD home rail.
+    var homeTrendingIncludeAnniversaries: Bool {
+        didSet { UserDefaults.standard.set(homeTrendingIncludeAnniversaries, forKey: Self.homeTrendingIncludeAnniversariesKey) }
+    }
+
     /// Card size for the Today in History carousel: "small" or "large".
     var homeTodayCardSize: String {
         didSet { UserDefaults.standard.set(homeTodayCardSize, forKey: Self.homeTodayCardSizeKey) }
@@ -145,6 +153,7 @@ final class AppPreferences {
         homeTrendingCardSize = "small"
         homeTodayCardSize = "large"
         homeCollectionsCardSize = "large"
+        homeTrendingIncludeAnniversaries = false
     }
 
     /// Persistent install ID (UUID). Generated once on first access, survives opt-out/opt-in cycles.
@@ -174,6 +183,7 @@ final class AppPreferences {
             Self.homeTrendingCardSizeKey: "small",
             Self.homeTodayCardSizeKey: "large",
             Self.homeCollectionsCardSizeKey: "large",
+            Self.homeTrendingIncludeAnniversariesKey: false,
         ])
         includeShowsWithoutRecordings = UserDefaults.standard.bool(forKey: Self.includeShowsWithoutRecordingsKey)
         customServerUrl = UserDefaults.standard.string(forKey: Self.customServerUrlKey) ?? ""
@@ -200,6 +210,7 @@ final class AppPreferences {
         homeTrendingCardSize = UserDefaults.standard.string(forKey: Self.homeTrendingCardSizeKey) ?? "small"
         homeTodayCardSize = UserDefaults.standard.string(forKey: Self.homeTodayCardSizeKey) ?? "large"
         homeCollectionsCardSize = UserDefaults.standard.string(forKey: Self.homeCollectionsCardSizeKey) ?? "large"
+        homeTrendingIncludeAnniversaries = UserDefaults.standard.bool(forKey: Self.homeTrendingIncludeAnniversariesKey)
         analyticsEnabled = UserDefaults.standard.object(forKey: Self.analyticsEnabledKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: Self.analyticsEnabledKey)

--- a/iosApp/deadly/Core/Service/TrendingServiceImpl.swift
+++ b/iosApp/deadly/Core/Service/TrendingServiceImpl.swift
@@ -50,7 +50,11 @@ final class TrendingServiceImpl: TrendingService {
     }
 
     private func fetchPayload() async throws -> TrendingPayload {
-        let url = URL(string: "\(appPreferences.apiBaseUrl)/api/trending")!
+        var components = URLComponents(string: "\(appPreferences.apiBaseUrl)/api/trending")!
+        if appPreferences.homeTrendingIncludeAnniversaries {
+            components.queryItems = [URLQueryItem(name: "include_anniversaries", value: "true")]
+        }
+        let url = components.url!
         let (data, response) = try await session.data(from: url)
         if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
             throw URLError(.badServerResponse)

--- a/iosApp/deadly/Feature/Favorites/FavoritesScreen.swift
+++ b/iosApp/deadly/Feature/Favorites/FavoritesScreen.swift
@@ -406,6 +406,11 @@ struct FavoritesScreen: View {
                     let newMode: FavoritesDisplayMode = displayMode == .list ? .grid : .list
                     displayMode = newMode
                     container.appPreferences.favoritesDisplayMode = newMode.rawValue
+                    container.analyticsService.track("feature_use", props: [
+                        "feature": "set_favorites_display_mode",
+                        "category": "preference",
+                        "value": newMode.rawValue,
+                    ])
                 } label: {
                     Image(systemName: displayMode == .list ? "square.grid.2x2" : "list.bullet")
                         .font(.body)

--- a/iosApp/deadly/Feature/Home/HomeScreen.swift
+++ b/iosApp/deadly/Feature/Home/HomeScreen.swift
@@ -59,6 +59,12 @@ struct HomeScreen: View {
             await homeService.refresh()
             await trendingService.refresh()
         }
+        // The trending response depends on the include-anniversaries pref —
+        // SwiftUI .task only fires on appearance, so flip-the-toggle-and-stay
+        // wouldn't refetch without this observer.
+        .onChange(of: appPreferences.homeTrendingIncludeAnniversaries) { _, _ in
+            Task { await trendingService.refresh() }
+        }
     }
 
     // MARK: - Trending

--- a/iosApp/deadly/Feature/Settings/SettingsScreen.swift
+++ b/iosApp/deadly/Feature/Settings/SettingsScreen.swift
@@ -259,6 +259,25 @@ struct SettingsScreen: View {
                     }
                 }
 
+                Toggle(isOn: Binding(
+                    get: { container.appPreferences.homeTrendingIncludeAnniversaries },
+                    set: { newValue in
+                        container.appPreferences.homeTrendingIncludeAnniversaries = newValue
+                        container.analyticsService.track("feature_use", props: [
+                            "feature": "set_home_trending_include_anniversaries",
+                            "category": "preference",
+                            "value": String(newValue),
+                        ])
+                    }
+                )) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Include \"Today in History\" in Trending")
+                        Text("Off by default — recommended for variety. The 24-hour Trending window is otherwise dominated by anniversary plays.")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Recently Played rows")
                     Picker("Recently Played rows", selection: Binding(

--- a/ui/src/app/admin/analytics/components/GrowthChart.tsx
+++ b/ui/src/app/admin/analytics/components/GrowthChart.tsx
@@ -18,43 +18,95 @@ const PLATFORM_COLORS: Record<"ios" | "android" | "web", string> = {
   web: "bg-purple-500",
 };
 
+const WINDOW_OPTIONS = [
+  { days: 7, label: "7d" },
+  { days: 30, label: "30d" },
+  { days: 90, label: "90d" },
+  { days: 365, label: "1y" },
+] as const;
+
 export default function GrowthChart({
   onDayClick,
 }: {
   onDayClick?: (day: string) => void;
 }) {
+  const [days, setDays] = useState<number>(30);
   const [data, setData] = useState<GrowthDay[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<GrowthDay | null>(null);
 
   useEffect(() => {
-    fetch("/api/analytics/growth?days=60", { credentials: "include" })
+    setData(null);
+    fetch(`/api/analytics/growth?days=${days}`, { credentials: "include" })
       .then(async (res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const body = (await res.json()) as { days: GrowthDay[] };
         setData(body.days);
         setError(null);
+        setSelected(null);
       })
       .catch((e: unknown) =>
         setError(e instanceof Error ? e.message : "Failed to load"),
       );
-  }, []);
+  }, [days]);
+
+  const windowPicker = (
+    <div className="flex items-center gap-1 ml-auto">
+      {WINDOW_OPTIONS.map((opt) => (
+        <button
+          key={opt.days}
+          onClick={() => setDays(opt.days)}
+          className={`px-2 py-0.5 text-xs rounded ${
+            days === opt.days
+              ? "bg-zinc-200 text-zinc-900 font-semibold"
+              : "bg-zinc-800 text-zinc-400 hover:text-zinc-200"
+          }`}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
 
   if (error)
-    return <p className="text-sm text-red-400">Growth error: {error}</p>;
-  if (!data) return <p className="text-sm text-zinc-500">Loading…</p>;
+    return (
+      <div className="space-y-2">
+        <div className="flex">{windowPicker}</div>
+        <p className="text-sm text-red-400">Growth error: {error}</p>
+      </div>
+    );
+  if (!data)
+    return (
+      <div className="space-y-2">
+        <div className="flex">{windowPicker}</div>
+        <p className="text-sm text-zinc-500">Loading…</p>
+      </div>
+    );
   if (data.length === 0)
-    return <p className="text-sm text-zinc-500 italic">No installs yet.</p>;
+    return (
+      <div className="space-y-2">
+        <div className="flex">{windowPicker}</div>
+        <p className="text-sm text-zinc-500 italic">
+          No installs in this window.
+        </p>
+      </div>
+    );
 
-  const max = Math.max(...data.map((p) => p.total));
+  const max = Math.max(...data.map((p) => p.total), 1);
   const total = data.reduce((s, p) => s + p.total, 0);
   const peak = data.reduce(
     (best, p) => (p.total > best.total ? p : best),
     data[0],
   );
 
+  // Pick a "round" max for the Y-axis. Bumps the chart ceiling up to the
+  // next nice number so axis labels read 0/5/10 instead of 0/4.5/9.
+  const niceMax = niceCeiling(max);
+  const yTicks = [0, niceMax / 2, niceMax];
+
   return (
     <div className="space-y-3">
-      <div className="flex items-baseline gap-6 text-xs text-zinc-400 flex-wrap">
+      <div className="flex items-baseline gap-4 text-xs text-zinc-400 flex-wrap">
         <span>
           <span className="text-zinc-200 font-semibold">
             {total.toLocaleString()}
@@ -66,7 +118,7 @@ export default function GrowthChart({
           <span className="text-zinc-200 font-semibold">{peak.total}</span> on{" "}
           {peak.day}
         </span>
-        <div className="flex items-center gap-3 ml-auto">
+        <div className="flex items-center gap-3 ml-2">
           <span className="flex items-center gap-1.5">
             <span className="inline-block w-2.5 h-2.5 bg-blue-500 rounded-sm" />
             iOS
@@ -76,44 +128,98 @@ export default function GrowthChart({
             Android
           </span>
         </div>
+        {windowPicker}
       </div>
 
-      <div className="flex items-end gap-[2px] h-32 bg-zinc-900/40 rounded p-2">
-        {data.map((p) => {
-          const totalPct = max === 0 ? 0 : (p.total / max) * 100;
-          // Within a single bar, slice the height proportionally between
-          // the platforms so iOS sits on top of Android (and Android on
-          // top of web if present).
-          const segments = (
-            [
-              { key: "ios", n: p.ios },
-              { key: "android", n: p.android },
-              { key: "web", n: p.web },
-            ] as const
-          ).filter((s) => s.n > 0);
-          return (
-            <button
-              key={p.day}
-              onClick={() => onDayClick?.(p.day)}
-              className="flex-1 group relative h-full"
-              title={`${p.day}: ${p.ios} iOS + ${p.android} Android${p.web ? ` + ${p.web} web` : ""} = ${p.total}`}
-            >
-              <div className="absolute bottom-0 left-0 right-0 flex flex-col-reverse rounded-t overflow-hidden"
-                   style={{ height: `${totalPct}%`, minHeight: p.total > 0 ? 1 : 0 }}>
-                {segments.map((seg) => (
+      {/* Selection readout — fixed height so the chart doesn't jump when
+          a bar is tapped/clicked. Empty state shows a hint. */}
+      <div className="h-5 text-xs">
+        {selected ? (
+          <span className="text-zinc-200">
+            <span className="font-mono">{selected.day}</span>
+            <span className="text-zinc-500"> · </span>
+            <span className="font-semibold">{selected.total}</span> total
+            <span className="text-zinc-500"> · </span>
+            <span className="text-blue-400">{selected.ios} iOS</span>
+            <span className="text-zinc-500"> · </span>
+            <span className="text-green-400">{selected.android} Android</span>
+            {selected.web > 0 && (
+              <>
+                <span className="text-zinc-500"> · </span>
+                <span className="text-purple-400">{selected.web} web</span>
+              </>
+            )}
+          </span>
+        ) : (
+          <span className="text-zinc-600 italic">
+            Tap a bar for details.
+          </span>
+        )}
+      </div>
+
+      <div className="flex gap-2">
+        {/* Y-axis labels */}
+        <div className="flex flex-col-reverse justify-between h-32 text-[10px] text-zinc-500 font-mono w-6 text-right">
+          {yTicks.map((t) => (
+            <div key={t}>{Math.round(t)}</div>
+          ))}
+        </div>
+
+        {/* Chart area with horizontal gridlines */}
+        <div className="flex-1 relative">
+          <div className="absolute inset-0 flex flex-col-reverse justify-between pointer-events-none">
+            {yTicks.map((t, i) => (
+              <div
+                key={t}
+                className={`w-full ${i === 0 ? "" : "border-t border-zinc-800/60"}`}
+              />
+            ))}
+          </div>
+          <div className="relative flex items-end gap-[2px] h-32 bg-zinc-900/40 rounded p-2">
+            {data.map((p) => {
+              const totalPct = (p.total / niceMax) * 100;
+              const segments = (
+                [
+                  { key: "ios", n: p.ios },
+                  { key: "android", n: p.android },
+                  { key: "web", n: p.web },
+                ] as const
+              ).filter((s) => s.n > 0);
+              const isSelected = selected?.day === p.day;
+              return (
+                <button
+                  key={p.day}
+                  onClick={() => {
+                    setSelected(p);
+                    onDayClick?.(p.day);
+                  }}
+                  className="flex-1 group relative h-full"
+                  title={`${p.day}: ${p.ios} iOS + ${p.android} Android${p.web ? ` + ${p.web} web` : ""} = ${p.total}`}
+                  aria-label={`${p.day}: ${p.total} installs`}
+                >
                   <div
-                    key={seg.key}
-                    className={`${PLATFORM_COLORS[seg.key]} group-hover:brightness-110 transition-[filter] w-full`}
-                    style={{ flexGrow: seg.n }}
-                  />
-                ))}
-              </div>
-            </button>
-          );
-        })}
+                    className={`absolute bottom-0 left-0 right-0 flex flex-col-reverse rounded-t overflow-hidden ${isSelected ? "ring-2 ring-zinc-100" : ""}`}
+                    style={{
+                      height: `${totalPct}%`,
+                      minHeight: p.total > 0 ? 1 : 0,
+                    }}
+                  >
+                    {segments.map((seg) => (
+                      <div
+                        key={seg.key}
+                        className={`${PLATFORM_COLORS[seg.key]} group-hover:brightness-110 transition-[filter] w-full`}
+                        style={{ flexGrow: seg.n }}
+                      />
+                    ))}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
       </div>
 
-      <div className="flex gap-[2px] px-1 -mt-2">
+      <div className="flex gap-[2px] pl-8 -mt-2">
         {data.map((p, i) => {
           const tickEvery = Math.max(1, Math.round(data.length / 9));
           const showTick = i % tickEvery === 0 || i === data.length - 1;
@@ -130,4 +236,17 @@ export default function GrowthChart({
       </div>
     </div>
   );
+}
+
+/** Round up to a nice axis ceiling — 1, 2, 5, 10, 20, 50, 100, … */
+function niceCeiling(max: number): number {
+  if (max <= 1) return 1;
+  const pow = Math.pow(10, Math.floor(Math.log10(max)));
+  const norm = max / pow;
+  let nice: number;
+  if (norm <= 1) nice = 1;
+  else if (norm <= 2) nice = 2;
+  else if (norm <= 5) nice = 5;
+  else nice = 10;
+  return nice * pow;
 }

--- a/ui/src/app/admin/analytics/components/GrowthChart.tsx
+++ b/ui/src/app/admin/analytics/components/GrowthChart.tsx
@@ -30,7 +30,7 @@ export default function GrowthChart({
 }: {
   onDayClick?: (day: string) => void;
 }) {
-  const [days, setDays] = useState<number>(30);
+  const [days, setDays] = useState<number>(7);
   const [data, setData] = useState<GrowthDay[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<GrowthDay | null>(null);
@@ -132,27 +132,39 @@ export default function GrowthChart({
       </div>
 
       {/* Selection readout — fixed height so the chart doesn't jump when
-          a bar is tapped/clicked. Empty state shows a hint. */}
-      <div className="h-5 text-xs">
+          a bar is tapped. Tap once selects; the "View detail" link is the
+          explicit drill-in path, which is what people rarely want by
+          default. */}
+      <div className="flex h-5 items-center gap-2 text-xs">
         {selected ? (
-          <span className="text-zinc-200">
-            <span className="font-mono">{selected.day}</span>
-            <span className="text-zinc-500"> · </span>
-            <span className="font-semibold">{selected.total}</span> total
-            <span className="text-zinc-500"> · </span>
-            <span className="text-blue-400">{selected.ios} iOS</span>
-            <span className="text-zinc-500"> · </span>
-            <span className="text-green-400">{selected.android} Android</span>
-            {selected.web > 0 && (
-              <>
-                <span className="text-zinc-500"> · </span>
-                <span className="text-purple-400">{selected.web} web</span>
-              </>
+          <>
+            <span className="text-zinc-200">
+              <span className="font-mono">{selected.day}</span>
+              <span className="text-zinc-500"> · </span>
+              <span className="font-semibold">{selected.total}</span> total
+              <span className="text-zinc-500"> · </span>
+              <span className="text-blue-400">{selected.ios} iOS</span>
+              <span className="text-zinc-500"> · </span>
+              <span className="text-green-400">{selected.android} Android</span>
+              {selected.web > 0 && (
+                <>
+                  <span className="text-zinc-500"> · </span>
+                  <span className="text-purple-400">{selected.web} web</span>
+                </>
+              )}
+            </span>
+            {onDayClick && (
+              <button
+                onClick={() => onDayClick(selected.day)}
+                className="ml-auto text-zinc-400 underline-offset-2 hover:text-zinc-200 hover:underline"
+              >
+                View detail →
+              </button>
             )}
-          </span>
+          </>
         ) : (
           <span className="text-zinc-600 italic">
-            Tap a bar for details.
+            Tap a bar for stats.
           </span>
         )}
       </div>
@@ -190,8 +202,14 @@ export default function GrowthChart({
                 <button
                   key={p.day}
                   onClick={() => {
-                    setSelected(p);
-                    onDayClick?.(p.day);
+                    // Tap → select. A second tap on the same bar drills in.
+                    // Most of the time the user just wants the stats, so
+                    // detail is opt-in rather than the default.
+                    if (isSelected) {
+                      onDayClick?.(p.day);
+                    } else {
+                      setSelected(p);
+                    }
                   }}
                   className="flex-1 group relative h-full"
                   title={`${p.day}: ${p.ios} iOS + ${p.android} Android${p.web ? ` + ${p.web} web` : ""} = ${p.total}`}

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -38,10 +38,10 @@ export default function RootLayout({
         <ConnectProvider>
         <PlayerProvider>
           <nav className="border-b border-white/10 px-6 py-4">
-            <div className="mx-auto flex max-w-5xl items-center justify-between">
+            <div className="mx-auto flex max-w-5xl items-center justify-between gap-4 overflow-hidden">
               <Link
                 href="/"
-                className="flex items-center gap-2 text-xl font-bold text-white"
+                className="flex flex-shrink-0 items-center gap-2 text-xl font-bold text-white"
               >
                 <Image
                   src="/logo.png"
@@ -51,7 +51,11 @@ export default function RootLayout({
                 />
                 The Deadly
               </Link>
-              <div className="flex items-center gap-4">
+              {/* min-w-0 lets the player shrink instead of blowing out the
+                  page width on narrow viewports; without it a long track
+                  title pushed the right edge past max-w-5xl and broke
+                  downstream page layout. */}
+              <div className="flex min-w-0 flex-1 items-center justify-end gap-4">
                 <HeaderPlayerWrapper />
                 <UserMenu />
               </div>

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -38,10 +38,13 @@ export default function RootLayout({
         <ConnectProvider>
         <PlayerProvider>
           <nav className="border-b border-white/10 px-6 py-4">
-            <div className="mx-auto flex max-w-5xl items-center justify-between gap-4 overflow-hidden">
+            {/* Two-row on narrow, single-row on sm+. On narrow the player
+                wraps to its own row below the logo+UserMenu so a wide
+                player no longer collides with the logo. */}
+            <div className="mx-auto flex max-w-5xl flex-wrap items-center gap-x-4 gap-y-3">
               <Link
                 href="/"
-                className="flex flex-shrink-0 items-center gap-2 text-xl font-bold text-white"
+                className="order-1 flex flex-shrink-0 items-center gap-2 text-xl font-bold text-white"
               >
                 <Image
                   src="/logo.png"
@@ -51,13 +54,11 @@ export default function RootLayout({
                 />
                 The Deadly
               </Link>
-              {/* min-w-0 lets the player shrink instead of blowing out the
-                  page width on narrow viewports; without it a long track
-                  title pushed the right edge past max-w-5xl and broke
-                  downstream page layout. */}
-              <div className="flex min-w-0 flex-1 items-center justify-end gap-4">
-                <HeaderPlayerWrapper />
+              <div className="order-2 ml-auto flex-shrink-0 sm:order-3 sm:ml-0">
                 <UserMenu />
+              </div>
+              <div className="order-3 w-full min-w-0 sm:order-2 sm:w-auto sm:flex-1">
+                <HeaderPlayerWrapper />
               </div>
             </div>
           </nav>

--- a/ui/src/components/player/HeaderPlayer.tsx
+++ b/ui/src/components/player/HeaderPlayer.tsx
@@ -50,6 +50,7 @@ export default function HeaderPlayer() {
     playTrack,
     seek,
     playShow,
+    dismiss,
   } = usePlayer();
 
   const { isConnected, userState, isActiveDevice, claimSession, sendCommand } = useConnect();
@@ -328,6 +329,22 @@ export default function HeaderPlayer() {
           </svg>
         </button>
       </div>
+
+      {/* Clear/close — visible whenever a show is loaded (active, parked, or
+          remote). Without this, a stuck show occupies the header forever and
+          there's no escape from the player state. */}
+      {(isActive || isParked || isRemoteActive) && (
+        <button
+          onClick={dismiss}
+          className="flex-shrink-0 rounded-full p-1.5 text-white/40 transition-colors hover:text-white/70"
+          aria-label="Clear player"
+          title="Clear player"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+          </svg>
+        </button>
+      )}
 
       {/* Queue toggle — only when local playback */}
       {isActive && isActiveDevice && (


### PR DESCRIPTION
## Summary

Trending's 24-hour window was dominated by Today-in-Grateful-Dead-History plays (the OTD home rail promotes anniversary shows, users tap them en masse, they sweep the top-10). This PR ships the filter + toggle, plus a few analytics-dashboard fixes that surfaced along the way.

### Trending
- Server-side filter: `now` window excludes shows whose date matches today's MM-DD ±1. SQL `WHERE` clause, not a re-rollup — toggles cleanly per-request.
- `GET /api/trending?include_anniversaries=true` opts back in. Redis cache splits on the param.
- Week/month/all windows untouched (long enough that anniversary spikes wash out).
- New mobile setting under Home Screen: "Include 'Today in History' in Trending" — off by default, with `feature_use` tracking.
- iOS + Android both refetch on toggle and reset the rail scroll position so the change is visible.

### Settings analytics audit
Audited recent toggles for tracking coverage. Found and fixed one gap: the LIST/GRID toggle on the Favorites screen now fires `feature_use` on both platforms.

### Listening Now boundary (analytics)
The strict "playback_start with no matching playback_end" definition dumped users into Recent Listening for the brief gap between tracks ("36 seconds ago" while still actively listening). New soft definition: most recent playback event (start or end) within 90 seconds.

### Growth chart
- Window picker (7/30/90/365d), default 7d
- Y-axis with rounded tick labels + gridlines
- Tap-to-select with sticky readout (mobile-friendly — old `title=` tooltip didn't fire on touch). Detail drill-in via second tap or explicit "View detail" link.

### Web player + nav
- Close button on the header player — a loaded show with no clear path was sticking around forever.
- Nav layout: player wraps to its own row on narrow viewports instead of colliding with the logo; `min-w-0` keeps it from blowing out page width on wider viewports too.

## Commits

1. `769f4106` fix(api/trending): filter Today-in-History shows from now window
2. `8d1e8c67` feat(mobile/home): toggle to include "Today in History" in Trending
3. `32ffbe99` feat(mobile/favorites): track favorites display mode toggle
4. `f38fb760` fix(mobile/home): refetch + scroll-reset trending on anniversaries toggle
5. `afe296c7` fix(api/analytics): soft live boundary keeps between-track listeners live
6. `dc259c68` feat(web/analytics): growth chart window picker, Y-axis, mobile readout
7. `673194f8` fix(web/player): close button + nav-spacing fix when player is active
8. `73152161` fix(web): player wraps to its own row on narrow; growth defaults 7d

(Plus the existing `7b683db3` logical-listen ranking commit that the branch was originally cut for.)

## Rollout note

The filter is the **server-side default**. Once deployed, every client — including pre-update apps that don't yet know about the new toggle — will see the filtered ranking. The new mobile setting just gives users a way to opt back into the old behavior. App release can happen separately whenever; the server change is the one to deploy ASAP.

## Test plan

- [ ] Server: `npx vitest run` — 33 tests pass (trending + new live-listeners coverage)
- [ ] Deploy to prod and verify `/api/trending` (default) shows no MM-DD ±1 matches today
- [ ] `/api/trending?include_anniversaries=true` returns the anniversary shows at the top
- [ ] iOS app: toggle the new setting in Settings → Home Screen; trending rail updates immediately and scrolls to start
- [ ] Android app: same
- [ ] Admin Listening Now: confirm between-track listeners stay in Live, not Recent
- [ ] Admin Growth: tap a bar → stats; tap again or "View detail" → drill-in
- [ ] Web header on narrow viewport: player wraps to a second row; close button clears it

🤖 Generated with [Claude Code](https://claude.com/claude-code)