### PR TITLE
Dual-window live boundary covers long tracks

### DIFF
--- a/api/src/db/__tests__/live-listeners.test.ts
+++ b/api/src/db/__tests__/live-listeners.test.ts
@@ -47,11 +47,10 @@ afterAll(() => {
   if (fs.existsSync(TMP_DB)) fs.unlinkSync(TMP_DB);
 });
 
-describe("getLiveListeners — soft live boundary", () => {
-  it("a user 30s past a playback_end still counts as live", () => {
-    // This is the reported bug: between tracks (after end of N, before
-    // start of N+1) the user was dropping into Recent Listening with a
-    // "36 seconds ago" timestamp despite actively listening.
+describe("getLiveListeners — dual live boundary", () => {
+  it("a user 30s past a playback_end still counts as live (between-tracks gap)", () => {
+    // Reported bug: between tracks, the user was dropping into Recent
+    // Listening as "36 seconds ago" while still actively listening.
     const now = Date.now();
     insertEvents([
       ev("playback_start", "alice", "s1", "show-A", 0, now - 60_000),
@@ -64,42 +63,49 @@ describe("getLiveListeners — soft live boundary", () => {
     expect(live).toHaveLength(1);
     expect(live[0].iid).toBe("alice");
     expect(live[0].show_id).toBe("show-A");
-    // started_at should reflect the original playback_start, not the end.
     expect(live[0].started_at).toBe(now - 60_000);
   });
 
-  it("a user with only a playback_start within 90s is live", () => {
+  it("a user mid-long-track is live even with no events for 30 minutes", () => {
+    // The case the previous fix broke: Dark Star can run 30+ minutes
+    // with no intervening events. The 45-min START window covers this.
     const now = Date.now();
     insertEvents([
-      ev("playback_start", "bob", "s1", "show-B", 0, now - 10_000),
+      ev("playback_start", "bob", "s1", "show-B", 5, now - 30 * 60_000),
     ]);
 
     const live = getLiveListeners();
     expect(live.map((l) => l.iid)).toEqual(["bob"]);
+    expect(live[0].show_id).toBe("show-B");
   });
 
-  it("a user whose latest event is >90s old is not live", () => {
+  it("a user whose start was >45min ago is no longer live", () => {
     const now = Date.now();
     insertEvents([
-      ev("playback_start", "carol", "s1", "show-C", 0, now - 5 * 60_000),
-      ev("playback_end", "carol", "s1", "show-C", 0, now - 2 * 60_000, {
-        reason: "skipped_next",
-      }),
+      ev("playback_start", "carol", "s1", "show-C", 0, now - 60 * 60_000),
     ]);
-
     expect(getLiveListeners()).toEqual([]);
   });
 
-  it("the latest event wins — switching shows in <90s updates current state", () => {
+  it("a user whose latest end is >2min ago is no longer live (finished)", () => {
     const now = Date.now();
     insertEvents([
-      // Started show A 5 minutes ago, then ended it 60s ago…
-      ev("playback_start", "dave", "s1", "show-A", 0, now - 5 * 60_000),
-      ev("playback_end", "dave", "s1", "show-A", 0, now - 60_000, {
+      ev("playback_start", "dave", "s1", "show-D", 0, now - 5 * 60_000),
+      ev("playback_end", "dave", "s1", "show-D", 0, now - 3 * 60_000, {
+        reason: "completed",
+      }),
+    ]);
+    expect(getLiveListeners()).toEqual([]);
+  });
+
+  it("switching shows updates current state — latest event wins", () => {
+    const now = Date.now();
+    insertEvents([
+      ev("playback_start", "eve", "s1", "show-A", 0, now - 10 * 60_000),
+      ev("playback_end", "eve", "s1", "show-A", 0, now - 60_000, {
         reason: "skipped_next",
       }),
-      // …then started show B 20s ago.
-      ev("playback_start", "dave", "s1", "show-B", 0, now - 20_000),
+      ev("playback_start", "eve", "s1", "show-B", 0, now - 20_000),
     ]);
 
     const live = getLiveListeners();
@@ -108,13 +114,10 @@ describe("getLiveListeners — soft live boundary", () => {
   });
 
   it("at most one row per iid even with multiple unmatched starts", () => {
-    // Crashed-without-end scenario: client emits a second start without
-    // ending the first. We still want one row per listener, picking the
-    // latest event.
     const now = Date.now();
     insertEvents([
-      ev("playback_start", "eve", "s1", "show-A", 0, now - 60_000),
-      ev("playback_start", "eve", "s2", "show-B", 0, now - 20_000),
+      ev("playback_start", "frank", "s1", "show-A", 0, now - 5 * 60_000),
+      ev("playback_start", "frank", "s2", "show-B", 0, now - 60_000),
     ]);
 
     const live = getLiveListeners();
@@ -141,11 +144,11 @@ describe("getRecentListening excludes live listeners under the new boundary", ()
     expect(recent.find((r) => r.iid === "alice" && r.show_id === "show-A")).toBeUndefined();
   });
 
-  it("a user 2 min past their last event appears in Recent, not Live", () => {
+  it("a user 5 min past their last end appears in Recent, not Live", () => {
     const now = Date.now();
     insertEvents([
-      ev("playback_start", "bob", "s1", "show-B", 0, now - 5 * 60_000),
-      ev("playback_end", "bob", "s1", "show-B", 0, now - 2 * 60_000, {
+      ev("playback_start", "bob", "s1", "show-B", 0, now - 10 * 60_000),
+      ev("playback_end", "bob", "s1", "show-B", 0, now - 5 * 60_000, {
         reason: "skipped_next",
       }),
     ]);

--- a/api/src/db/analytics.ts
+++ b/api/src/db/analytics.ts
@@ -812,30 +812,34 @@ export interface LiveListener {
 
 /**
  * "Currently listening" set, defined as: each install's most recent
- * `playback_start` / `playback_end` event whose timestamp is within
- * LIVE_WINDOW_MS. The "soft" boundary (events of *either* kind count)
- * keeps a listener live across the autoplay gap between tracks: when
- * track N ends naturally, the brief moment before track N+1's
- * `playback_start` fires would otherwise drop them into Recent
- * Listening and they'd show as "36s ago" while still actively
- * listening. Sessions that crash or get force-killed without emitting
- * `playback_end` still linger for up to LIVE_WINDOW_MS — same trade
- * as before, just shorter than the old 45-minute window. The
- * shorter window is fine because the new definition no longer
- * relies on "unmatched start" semantics.
+ * `playback_start` keeps a listener live for a long time (mid-track
+ * keepalive — Grateful Dead jams routinely run 25–35 min with no
+ * intervening events) while a recent `playback_end` only keeps them
+ * live for a short window (between-tracks autoplay gap). Together
+ * they cover the three real cases:
+ *   - mid-track:      latest event is a start within START window → live
+ *   - between tracks: latest is an end within END window           → live
+ *   - finished:       latest is an end past END window              → not live
+ *
+ * Replaced the earlier single-window approach: a 45-min "unmatched
+ * start" rule mis-classified between-tracks users as Recent, and a
+ * 90-second soft window dropped mid-jam users out of Live.
  */
-const LIVE_WINDOW_MS = 90 * 1000;
+const LIVE_START_WINDOW_MS = 45 * 60 * 1000;
+const LIVE_END_WINDOW_MS = 2 * 60 * 1000;
 
 export function getLiveListeners(): LiveListener[] {
   const db = getAnalyticsDb();
-  const windowStart = Date.now() - LIVE_WINDOW_MS;
+  const now = Date.now();
+  const startWindowStart = now - LIVE_START_WINDOW_MS;
+  const endWindowStart = now - LIVE_END_WINDOW_MS;
+  const lookbackStart = now - 6 * 3600 * 1000;
 
   // Pick the latest playback event per iid (start or end), then keep
-  // only those whose latest event is inside the live window AND
-  // describes a show. `started_at` is resolved separately as the most
-  // recent `playback_start` for this (iid, show_id) within a generous
-  // lookback so the UI can render "started X ago" correctly even when
-  // the live-keepalive event is an end.
+  // only those whose latest event qualifies under the dual-window rule.
+  // `started_at` is resolved separately as the most recent
+  // `playback_start` for this (iid, show_id) so the UI can render
+  // "started X ago" correctly even when the keepalive event is an end.
   const rows = db
     .prepare(
       `WITH latest AS (
@@ -875,17 +879,13 @@ export function getLiveListeners(): LiveListener[] {
          l.source
        FROM latest l
        WHERE l.rn = 1
-         AND l.ts >= ?
+         AND (
+           (l.event = 'playback_start' AND l.ts >= ?)
+           OR (l.event = 'playback_end' AND l.ts >= ?)
+         )
        ORDER BY l.ts DESC`,
     )
-    .all(
-      // Latest-event lookback: a bit wider than LIVE_WINDOW_MS so the
-      // ROW_NUMBER pick is robust against clock skew / batch flushes.
-      Date.now() - 6 * 3600 * 1000,
-      // started_at lookup: look back 6h to find the original session start.
-      Date.now() - 6 * 3600 * 1000,
-      windowStart,
-    ) as Array<{
+    .all(lookbackStart, lookbackStart, startWindowStart, endWindowStart) as Array<{
       iid: string;
       sid: string;
       platform: string;
@@ -1263,7 +1263,11 @@ export function getRecentListening(
   const db = getAnalyticsDb();
   const now = Date.now();
   const windowStart = now - hours * 3600 * 1000;
-  const liveWindowStart = now - LIVE_WINDOW_MS;
+  const liveStartWindow = now - LIVE_START_WINDOW_MS;
+  const liveEndWindow = now - LIVE_END_WINDOW_MS;
+  // Inner lookback for "what's this iid's most recent event overall" —
+  // must be at least as wide as the longer of the two live windows.
+  const liveLookbackStart = liveStartWindow;
 
   const rows = db
     .prepare(
@@ -1321,14 +1325,14 @@ export function getRecentListening(
               AND event = 'playback_start'
             ORDER BY ts ASC LIMIT 1) AS source
        FROM agg a
-       -- Mirror the live definition in getLiveListeners: exclude
-       -- (iid, show_id) pairs where this iid's most recent playback
-       -- event is within LIVE_WINDOW_MS AND describes this show.
+       -- Mirror the dual-window live definition in getLiveListeners:
+       -- exclude (iid, show_id) pairs where this iid's most recent event
+       -- describes this show AND qualifies as live under either
+       -- (start within START window) OR (end within END window).
        WHERE NOT EXISTS (
          SELECT 1 FROM analytics_events latest
          WHERE latest.event IN ('playback_start', 'playback_end')
            AND latest.iid = a.iid
-           AND latest.ts >= ?
            AND json_extract(latest.props, '$.show_id') = a.show_id
            AND latest.ts = (
              SELECT MAX(x.ts) FROM analytics_events x
@@ -1336,11 +1340,21 @@ export function getRecentListening(
                AND x.iid = a.iid
                AND x.ts >= ?
            )
+           AND (
+             (latest.event = 'playback_start' AND latest.ts >= ?)
+             OR (latest.event = 'playback_end' AND latest.ts >= ?)
+           )
        )
        ORDER BY a.last_event_at DESC
        LIMIT ?`,
     )
-    .all(windowStart, liveWindowStart, liveWindowStart, limit) as Array<{
+    .all(
+      windowStart,
+      liveLookbackStart,
+      liveStartWindow,
+      liveEndWindow,
+      limit,
+    ) as Array<{
       iid: string;
       show_id: string;
       started_at: number;


### PR DESCRIPTION
## Summary

Follow-up to #44. That PR replaced the strict "unmatched playback_start" rule with a soft 90-second window, which fixed the between-tracks gap but introduced a new bug: users mid-long-jam dropped out of Live because no playback events fire during a 30-minute Dark Star.

This PR replaces the single 90s window with a **dual-window** rule on each user's most recent playback event:

- `playback_start` within **45 min** → live (mid-track keepalive, matches old behavior)
- `playback_end` within **2 min** → live (between-tracks autoplay gap, the new bug we fixed in #44)

All three cases are handled cleanly: mid-track, between tracks, and finished. `getRecentListening`'s exclusion subquery is rewritten to mirror the same rule so users don't appear in both lists.

## Test plan

- [x] `npx vitest run` — 34 tests pass (9 live-listener cases now cover both windows)
- [ ] Deploy and verify the admin Listening Now page shows the expected ~all active users in Live (the user reported 1 live / 7 recent under the broken state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)