### PR TITLE
feat: Fan Favorites rail (decade-bucketed popular shows)

### DIFF
--- a/PLANS/home-discovery-rails.md
+++ b/PLANS/home-discovery-rails.md
@@ -25,7 +25,12 @@ session can pick up cold.
 
 ## Upcoming units
 
-### Unit 2 — "Popular" rail (show favorites)
+### Unit 2 — "Fan Favorites" rail (show favorites)
+
+**Display name:** "Fan Favorites" in UI. Internal name stays `popular`
+(API path `/api/popular`, prefs `homePopularCardSize`, etc.).
+
+**Card size:** default **small**, like Trending. Same plumbing pattern.
 
 **Source of truth.** `analytics_events` where `event='feature_use' AND
 feature='add_favorite'`. Show id is in `target_id` (with a legacy `show_id`
@@ -120,6 +125,37 @@ designing the browsable-content hierarchy from scratch.
   is what makes the surface worthwhile.
 - **Track favorites exist** but mixed in with show favorites in `target_id`
   — needs schema verification before Unit 3.
+
+## Deferred (parked, not dropped)
+
+### Drag-list home reorder
+
+Replace the current `homeTrendingAboveToday` boolean with an ordered
+list of section IDs (recent / trending / today / fan-favorites /
+collections / …). A Settings sub-screen lets the user drag to reorder.
+
+- iOS: trivial (`List` + `.onMove`, ~40 lines).
+- Android: medium — no native equivalent. Either pull in
+  `sh.calvin.reorderable` or hand-roll with `detectDragGesturesAfterLongPress`.
+  ~150 lines hand-rolled.
+- Migration: derive initial list from existing pref.
+
+Held until after Unit 2 ships so we have multiple rails to actually
+reorder. The Trending-above-Today toggle stays in place until then.
+
+## Index footgun (worth knowing)
+
+`analytics_events` has a unique index on `(iid, sid, event, ts)` to
+neutralize client retries. The index keys on primitive columns only —
+`props` is *not* part of the key. Two same-ms events from the same
+install/session with different `props` collide and one is silently
+dropped by `INSERT OR IGNORE`. Surfaced while writing the popular
+tests (alice favoriting two shows at the same `t` lost one favorite).
+
+Real-world risk is low (clients emit serially with ms granularity).
+Becomes a real bug if we ever build a bulk-action UI ("favorite all",
+batch import). Mitigations when needed: stagger timestamps client-side
+or widen the index to include `props` (or a hash of it).
 
 ## Things explicitly out of scope (don't drift)
 

--- a/PLANS/home-discovery-rails.md
+++ b/PLANS/home-discovery-rails.md
@@ -18,47 +18,67 @@ session can pick up cold.
   - `playback_start` within 45 min OR `playback_end` within 2 min → live.
   - Covers mid-long-jam (Dark Star = 30+ min) and between-tracks gap.
 
+### Shipped (on `feat/popular-rail`, not yet on main)
+- Unit 2 — "Fan Favorites" rail (see [ADR-0005](../docs/adr/0005-fan-favorites-rail.md)
+  for the design rationale). Final shape diverged materially from the
+  original plan below — what shipped:
+  - `/api/popular` returns four per-decade *pools* (60s/70s/80s/90s),
+    each ≤20 shows, drawn via a 4h-rotated deterministic shuffle.
+  - Client picks the 4-show display set locally:
+    - `all` pref → 1 show per non-empty decade.
+    - Specific decade pref → 4 shows from that pool with year-spread.
+  - "Show more" link bumps a local seed → instant re-roll, no fetch.
+  - Decade choice lives in Settings → Home Screen (segmented picker).
+  - Env-tunable: `POPULAR_MIN_FAVORITES` (floor, default 1),
+    `POPULAR_PER_DECADE` (pool size, default 20),
+    `POPULAR_ROTATION_HOURS` (default 4).
+- Commits: `67057322` (initial ratio-ranked, replaced),
+  `5d626407` (mobile rail + in-header cycler, replaced),
+  `fa59ea67` (floor/limit tuning, replaced),
+  `19a9ea6b` (decade pools — current), `d8383e9b` (Show More — current).
+
 ### Not yet released
 - Trending toggle ships in the mobile app on next iOS/Android release. Until
   then, existing app users hit the server with no query param → see filtered
   trending (the new default), which is what we want.
+- Fan Favorites rail ships in the next iOS/Android release.
 
 ## Upcoming units
 
-### Unit 2 — "Fan Favorites" rail (show favorites)
+### Unit 2 — "Fan Favorites" rail (show favorites) — SHIPPED
 
-**Display name:** "Fan Favorites" in UI. Internal name stays `popular`
-(API path `/api/popular`, prefs `homePopularCardSize`, etc.).
+Final design is documented in [ADR-0005](../docs/adr/0005-fan-favorites-rail.md).
 
-**Card size:** default **small**, like Trending. Same plumbing pattern.
+The original plan in this doc proposed a ratio-ranked top-5 globally,
+with a floor of ~3 favoriters. That shipped briefly in `67057322` and
+was replaced — see ADR-0005 *Alternatives considered* for the full
+reasoning. **Lessons worth carrying into Units 3/4:**
 
-**Source of truth.** `analytics_events` where `event='feature_use' AND
-feature='add_favorite'`. Show id is in `target_id` (with a legacy `show_id`
-fallback). `top_shows_by_action.favorited` in the analytics summary already
-computes this — we'd surface the same signal as a home rail.
-
-**Sort.** Default: ratio of favorites to logical listens (the "people *kept*
-this" signal, not "people *tapped* it"). Use logical listens as denominator
-(already computed in `show_listens_rollup`) since raw `playback_start` is
-inflated by per-track events. Min-favorites floor (e.g. 3 users) to avoid
-single-favorite shows topping the list.
-
-**Window.** Last 30 days, like the summary endpoint uses.
-
-**Server.** New rollup row type, or query at request time — favorites
-volume is low enough (425 adds over 30d at current scale) that an on-demand
-query is cheap. Lean toward on-demand first.
-
-**Endpoint shape.** `GET /api/popular` returning `{ shows: [{ show_id,
-favorites, listens, ratio }] }`. Or fold into `/api/trending` as a fifth
-window. Standalone endpoint reads cleaner.
-
-**Client.** Home rail under Trending. Each platform's `HomeService`
-combines the new flow alongside trending. Mirror the existing TrendingService
-plumbing (it's the closest pattern).
-
-**Settings.** Position toggle (above/below Trending?), card-size pref like
-the others. Track `set_home_popular_card_size`, etc.
+- **Distribution is flatter than expected** at the current install base.
+  ~97 users across ~84 favorited shows means most shows sit at 1–2
+  favoriters; any minimum-volume floor ≥ 2 produces an empty rail.
+  Plan Units 3/4 (track favorites) assuming a similar shape until
+  proven otherwise — the per-track distribution will almost certainly
+  be even sparser.
+- **Pure ranking made the rail feel dead.** Refreshes happen only when
+  someone favorites a show, which at current volume is every 1–2
+  hours. The 4h-rotated shuffle + client re-roll combination is what
+  made the rail feel alive without sacrificing return-visit stability.
+  Same trick is reusable for Unit 3.
+- **The catalog has era texture worth preserving.** Decade-bucketed
+  pools surface 60s and 90s shows that would never crack a global
+  ranking. Track favorites will have analogous song-era texture
+  (early Pigpen-era setlist staples vs late Brent-era openers vs
+  Vince-era setlists) — worth designing for from the start.
+- **Server-tunable knobs save you.** `POPULAR_MIN_FAVORITES`,
+  `POPULAR_PER_DECADE`, `POPULAR_ROTATION_HOURS` as env vars meant
+  we could fix the floor-too-tight problem in prod without an app
+  release. Build the equivalent into Unit 3 from day one.
+- **Show ID format gotcha.** Prod uses slug-form
+  (`1977-05-11-st-paul-...`), older fixtures use `gd1977-...`. The
+  decade extractor matches the first 4-digit run regardless. If
+  Unit 3 keys on track IDs (`<show-slug>/<track-index>`), the same
+  liberal parsing applies.
 
 ### Unit 3 — "Best..." rail (track favorites)
 
@@ -123,6 +143,13 @@ designing the browsable-content hierarchy from scratch.
   Healthy add/remove ratio, but distribution is flat — top shows sit at
   1–2 users each. Low volume isn't the bug; the *signal* (people kept it)
   is what makes the surface worthwhile.
+- **Show-id format in prod:** slug form
+  `1977-05-11-st-paul-civic-center-...` (year is the first 4-digit run).
+  Older test fixtures use `gd1977-...`. Liberal parsing handles both.
+- **Decade distribution of favorited shows (snapshot):** mostly 70s
+  and 80s, with a meaningful 60s tail and a smaller 90s presence.
+  Decade-bucketed pools surface all four; a global ranking would
+  strip the 60s/90s entirely.
 - **Track favorites exist** but mixed in with show favorites in `target_id`
   — needs schema verification before Unit 3.
 
@@ -142,6 +169,11 @@ collections / …). A Settings sub-screen lets the user drag to reorder.
 
 Held until after Unit 2 ships so we have multiple rails to actually
 reorder. The Trending-above-Today toggle stays in place until then.
+
+Now unblocked since Unit 2 is on the branch — main has Trending + Today
++ Featured Collections + Recently Played, and Fan Favorites lands next
+release. Worth picking up before Unit 3 so the new track-favorites rail
+slots into the ordered list rather than getting another bespoke toggle.
 
 ## Index footgun (worth knowing)
 

--- a/PLANS/home-discovery-rails.md
+++ b/PLANS/home-discovery-rails.md
@@ -1,0 +1,132 @@
+# Home discovery rails — Popular, Best, CarPlay/AA
+
+Working plan for the Trending follow-up units. Trending itself shipped in
+PR #44 (merged) plus follow-up fix `743daba6` on main. This doc captures
+what's left and the constraints we've already locked in, so a future
+session can pick up cold.
+
+## Where we are
+
+### Shipped (already on main)
+- `acde63ef` (PR #43) — trending ranks by logical listens (not session dedup).
+- `c8b840c9` (PR #44) — TIGDH filter on `now` window + opt-in toggle, plus:
+  - `feature_use` audit; added missing `set_favorites_display_mode` tracking.
+  - Listening Now soft 90s boundary (later corrected).
+  - Growth chart window picker (7/30/90/365), Y-axis, mobile tap-to-select.
+  - Web header player: close button, narrow-viewport wrap.
+- `743daba6` — Listening Now **dual-window** boundary:
+  - `playback_start` within 45 min OR `playback_end` within 2 min → live.
+  - Covers mid-long-jam (Dark Star = 30+ min) and between-tracks gap.
+
+### Not yet released
+- Trending toggle ships in the mobile app on next iOS/Android release. Until
+  then, existing app users hit the server with no query param → see filtered
+  trending (the new default), which is what we want.
+
+## Upcoming units
+
+### Unit 2 — "Popular" rail (show favorites)
+
+**Source of truth.** `analytics_events` where `event='feature_use' AND
+feature='add_favorite'`. Show id is in `target_id` (with a legacy `show_id`
+fallback). `top_shows_by_action.favorited` in the analytics summary already
+computes this — we'd surface the same signal as a home rail.
+
+**Sort.** Default: ratio of favorites to logical listens (the "people *kept*
+this" signal, not "people *tapped* it"). Use logical listens as denominator
+(already computed in `show_listens_rollup`) since raw `playback_start` is
+inflated by per-track events. Min-favorites floor (e.g. 3 users) to avoid
+single-favorite shows topping the list.
+
+**Window.** Last 30 days, like the summary endpoint uses.
+
+**Server.** New rollup row type, or query at request time — favorites
+volume is low enough (425 adds over 30d at current scale) that an on-demand
+query is cheap. Lean toward on-demand first.
+
+**Endpoint shape.** `GET /api/popular` returning `{ shows: [{ show_id,
+favorites, listens, ratio }] }`. Or fold into `/api/trending` as a fifth
+window. Standalone endpoint reads cleaner.
+
+**Client.** Home rail under Trending. Each platform's `HomeService`
+combines the new flow alongside trending. Mirror the existing TrendingService
+plumbing (it's the closest pattern).
+
+**Settings.** Position toggle (above/below Trending?), card-size pref like
+the others. Track `set_home_popular_card_size`, etc.
+
+### Unit 3 — "Best..." rail (track favorites)
+
+**Source of truth.** Same `feature_use` event, but `target_type='track'`
+and `target_id` is a track path (`gd1988-06-30.../19`). Need to verify the
+schema cleanly distinguishes show-favorite from track-favorite — saw one
+mixed example in the analytics data, so an early task is auditing the
+client-side emission to make sure `target_type` is consistently set.
+
+**UI shape.** Collapse by *song title* (not by performance). Row reads
+"Sugar Magnolia · 17 favorites" with a tap → expand to top performances of
+that song. This is the Grateful Dead question ("*which* Sugar Magnolia?")
+rather than the analytics one ("which moments?"). Flat per-performance
+list is the drill-down, not the default.
+
+**Track-title resolution.** Track paths don't carry song titles directly —
+need to resolve `gd1988-06-30.sbd.miller.../19` → "Sugar Magnolia" via the
+local track catalog. Should be a straight DB join; verify the catalog has
+clean canonical titles (likely yes, but a normalization pass may be
+needed — `Sugar Mag` vs `Sugar Magnolia` etc.).
+
+**Open question.** Same song favorited from multiple shows — UI treatment
+of duplicate titles needs a decision. Probably: rank within-song by count,
+show the top performance with a "(N more)" link.
+
+### Unit 4 — CarPlay / Android Auto integration
+
+**Scope.** Surface Trending + Popular + Best in CarPlay (iOS) and Android
+Auto media browser hierarchies. Three new top-level categories.
+
+**Why separate.** Different code paths (MPPlayableContentManager on iOS,
+MediaBrowserService on Android), different testing (drive somewhere or use
+AA Desktop Head Unit), and the *data* for Units 2/3 needs to ship first.
+
+**Dependencies.** Unit 2 + Unit 3 must be on main with stable data shapes.
+Trending CarPlay/AA path doesn't exist yet either — building this means
+designing the browsable-content hierarchy from scratch.
+
+## Constraints & decisions already locked in
+
+- **Logical listens is the canonical "popularity" signal** (ADR-0004 + #43).
+  Use it as the denominator for ratios, not raw `playback_start`.
+- **Anniversary (MM-DD ±1) is the right filter granularity** for the `now`
+  window. Verified against prod data — only ~6% of all-time top-50 would
+  be excluded on a peak day; never strips a full top-10.
+- **Settings tracking pattern:** `analyticsService.track("feature_use", { feature,
+  category: "preference", value })`. Match this for all new toggles.
+- **Cross-platform parity:** iOS gets `.onChange` observer, Android gets
+  StateFlow `drop(1).collect`. Wire refetch through HomeViewModel (Android)
+  / HomeScreen (iOS) — TrendingServiceImpl init observer alone was unreliable.
+- **Scroll reset on data change:** Android rails need
+  `LaunchedEffect(firstId, …) { listState.scrollToItem(0) }`. iOS already
+  did this via `ScrollViewReader`.
+
+## Data signals worth remembering
+
+(snapshot from 2026-05-27 prod pull — re-verify when picking back up)
+
+- **Trending volume:** ~200–700 `playback_start` events/day, 24h top-10
+  ~10–70 plays per show.
+- **Favoriting volume:** 425 adds / 39 removes over 30d, 97 distinct users.
+  Healthy add/remove ratio, but distribution is flat — top shows sit at
+  1–2 users each. Low volume isn't the bug; the *signal* (people kept it)
+  is what makes the surface worthwhile.
+- **Track favorites exist** but mixed in with show favorites in `target_id`
+  — needs schema verification before Unit 3.
+
+## Things explicitly out of scope (don't drift)
+
+- Don't fold Popular into Trending. They answer different questions
+  ("what's hot" vs "what holds up") and mixing dilutes both.
+- Don't add a settings toggle for things we can default well. The TIGDH
+  toggle exists because the user explicitly wanted user choice; smaller
+  prefs (card sizes, etc.) get defaults.
+- Don't track dev-only toggles (forceOnline, hermetic mode). User-facing
+  prefs only.

--- a/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/HomeService.kt
+++ b/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/HomeService.kt
@@ -47,12 +47,14 @@ data class HomeContent(
     val trendingWindow: TrendingWindow,
     /** When true, Trending renders above Today in History; otherwise below. */
     val trendingAboveToday: Boolean,
-    /** "Fan Favorites" — shows ranked by net favorites / all-time logical listens. */
-    val popularShows: List<Show>,
+    /** "Fan Favorites" — per-decade pools; the section picks its 4-show display set. */
+    val popularContent: PopularContent,
     /** When true, render the Fan Favorites carousel on the home screen. */
     val popularEnabled: Boolean,
     /** Card size for the Fan Favorites carousel: "small" or "large". */
     val popularCardSize: String,
+    /** Currently-selected decade filter for the Fan Favorites rail (from Settings). */
+    val popularDecade: PopularDecade,
     /** How many rows of Recently Played to render (1..4). Each row = 2 shows. */
     val recentRows: Int,
     /** Card size for the Trending carousel: "small" or "large". */
@@ -71,9 +73,10 @@ data class HomeContent(
             trendingShows = emptyList(),
             trendingWindow = TrendingWindow.NOW,
             trendingAboveToday = false,
-            popularShows = emptyList(),
+            popularContent = PopularContent.initial(),
             popularEnabled = true,
             popularCardSize = "small",
+            popularDecade = PopularDecade.ALL,
             recentRows = 2,
             trendingCardSize = "small",
             todayCardSize = "large",

--- a/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/HomeService.kt
+++ b/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/HomeService.kt
@@ -47,6 +47,12 @@ data class HomeContent(
     val trendingWindow: TrendingWindow,
     /** When true, Trending renders above Today in History; otherwise below. */
     val trendingAboveToday: Boolean,
+    /** "Fan Favorites" — shows ranked by net favorites / all-time logical listens. */
+    val popularShows: List<Show>,
+    /** When true, render the Fan Favorites carousel on the home screen. */
+    val popularEnabled: Boolean,
+    /** Card size for the Fan Favorites carousel: "small" or "large". */
+    val popularCardSize: String,
     /** How many rows of Recently Played to render (1..4). Each row = 2 shows. */
     val recentRows: Int,
     /** Card size for the Trending carousel: "small" or "large". */
@@ -65,6 +71,9 @@ data class HomeContent(
             trendingShows = emptyList(),
             trendingWindow = TrendingWindow.NOW,
             trendingAboveToday = false,
+            popularShows = emptyList(),
+            popularEnabled = true,
+            popularCardSize = "small",
             recentRows = 2,
             trendingCardSize = "small",
             todayCardSize = "large",

--- a/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/PopularService.kt
+++ b/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/PopularService.kt
@@ -66,6 +66,24 @@ data class PopularContent(
      * [seed] controls the random selection; bumping it on "Show more"
      * re-rolls without re-fetching. Returned shows are date-sorted.
      */
+    /**
+     * Full pool(s) for the in-car surface, date-sorted.
+     * - [PopularDecade.ALL]: every show across all four decade pools.
+     * - Specific decade: that decade's full pool.
+     * Android Auto / CarPlay have no "Show more" affordance, so we surface
+     * the whole pool rather than the 4-show home-rail teaser.
+     */
+    fun allShows(decade: PopularDecade): List<Show> {
+        val shows = when (decade) {
+            PopularDecade.ALL -> pool60 + pool70 + pool80 + pool90
+            PopularDecade.S60 -> pool60
+            PopularDecade.S70 -> pool70
+            PopularDecade.S80 -> pool80
+            PopularDecade.S90 -> pool90
+        }
+        return shows.sortedBy { it.date }
+    }
+
     fun displayShows(decade: PopularDecade, seed: Int): List<Show> {
         val picks: List<Show> = when (decade) {
             PopularDecade.ALL -> pickOnePerDecade(seed)

--- a/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/PopularService.kt
+++ b/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/PopularService.kt
@@ -2,26 +2,124 @@ package com.grateful.deadly.core.api.home
 
 import com.grateful.deadly.core.model.Show
 import kotlinx.coroutines.flow.StateFlow
+import kotlin.random.Random
 
 /**
- * "Fan Favorites" shows for the home screen, ranked server-side by net
- * favorites / all-time logical listens (see /api/popular). Surfaces what
- * listeners *kept*, complementing Trending's what-just-got-played signal.
- *
- * Single all-time list (no windowing — the retention signal is meant to
- * change slowly). The implementation hydrates server-returned show IDs
- * into full Show objects from the local catalog.
+ * "Fan Favorites" pools for the home screen. The server returns four
+ * decade pools (60s/70s/80s/90s); the home rail picks its 4-show display
+ * set from those pools locally via [PopularContent.displayShows], so the
+ * "Show more" action can re-roll without a re-fetch.
  */
 interface PopularService {
     val popular: StateFlow<PopularContent>
     suspend fun refresh(): Result<Unit>
 }
 
+enum class PopularDecade {
+    ALL, S60, S70, S80, S90;
+
+    /** Short label rendered on the Settings picker and the rail header. */
+    val label: String get() = when (this) {
+        ALL -> "all"
+        S60 -> "60s"
+        S70 -> "70s"
+        S80 -> "80s"
+        S90 -> "90s"
+    }
+
+    /** Persisted preference key. Stable across label tweaks. */
+    val key: String get() = when (this) {
+        ALL -> "all"
+        S60 -> "60s"
+        S70 -> "70s"
+        S80 -> "80s"
+        S90 -> "90s"
+    }
+
+    companion object {
+        fun fromKey(key: String): PopularDecade = when (key) {
+            "60s" -> S60
+            "70s" -> S70
+            "80s" -> S80
+            "90s" -> S90
+            else -> ALL
+        }
+    }
+}
+
 data class PopularContent(
-    val shows: List<Show>,
+    val pool60: List<Show>,
+    val pool70: List<Show>,
+    val pool80: List<Show>,
+    val pool90: List<Show>,
     val lastRefresh: Long,
 ) {
-    companion object {
-        fun initial() = PopularContent(shows = emptyList(), lastRefresh = 0L)
+    val hasAnyContent: Boolean get() =
+        pool60.isNotEmpty() || pool70.isNotEmpty() || pool80.isNotEmpty() || pool90.isNotEmpty()
+
+    /**
+     * Compute the home-rail display set.
+     * - [PopularDecade.ALL]: one show from each non-empty decade pool (≤4).
+     * - Specific decade: up to [DISPLAY_COUNT] shows from that pool,
+     *   biased toward distinct years within the decade so the rail spans
+     *   the era.
+     * [seed] controls the random selection; bumping it on "Show more"
+     * re-rolls without re-fetching. Returned shows are date-sorted.
+     */
+    fun displayShows(decade: PopularDecade, seed: Int): List<Show> {
+        val picks: List<Show> = when (decade) {
+            PopularDecade.ALL -> pickOnePerDecade(seed)
+            PopularDecade.S60 -> pickWithYearSpread(pool60, DISPLAY_COUNT, seed)
+            PopularDecade.S70 -> pickWithYearSpread(pool70, DISPLAY_COUNT, seed)
+            PopularDecade.S80 -> pickWithYearSpread(pool80, DISPLAY_COUNT, seed)
+            PopularDecade.S90 -> pickWithYearSpread(pool90, DISPLAY_COUNT, seed)
+        }
+        return picks.sortedBy { it.date }
     }
+
+    private fun pickOnePerDecade(seed: Int): List<Show> {
+        val pools = listOf("60s" to pool60, "70s" to pool70, "80s" to pool80, "90s" to pool90)
+        return pools.mapNotNull { (name, pool) ->
+            if (pool.isEmpty()) null
+            else pool.shuffled(Random(combinedSeed(seed, name))).first()
+        }
+    }
+
+    private fun pickWithYearSpread(pool: List<Show>, count: Int, seed: Int): List<Show> {
+        if (pool.isEmpty()) return emptyList()
+        val shuffled = pool.shuffled(Random(combinedSeed(seed, "decade")))
+        val seenYears = mutableSetOf<Int>()
+        val primary = mutableListOf<Show>()
+        val fallback = mutableListOf<Show>()
+        for (show in shuffled) {
+            if (seenYears.contains(show.year)) {
+                fallback += show
+            } else {
+                primary += show
+                seenYears += show.year
+            }
+        }
+        return (primary + fallback).take(count)
+    }
+
+    companion object {
+        const val DISPLAY_COUNT = 4
+        fun initial() = PopularContent(
+            pool60 = emptyList(),
+            pool70 = emptyList(),
+            pool80 = emptyList(),
+            pool90 = emptyList(),
+            lastRefresh = 0L,
+        )
+    }
+}
+
+private fun combinedSeed(a: Int, b: String): Int {
+    // Mix the caller seed with a per-decade tag so "60s" and "70s"
+    // produce distinct streams from the same caller seed.
+    var h = a
+    for (c in b) {
+        h = h * 31 + c.code
+    }
+    return h
 }

--- a/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/PopularService.kt
+++ b/androidApp/core/api/home/src/main/java/com/grateful/deadly/core/api/home/PopularService.kt
@@ -1,0 +1,27 @@
+package com.grateful.deadly.core.api.home
+
+import com.grateful.deadly.core.model.Show
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * "Fan Favorites" shows for the home screen, ranked server-side by net
+ * favorites / all-time logical listens (see /api/popular). Surfaces what
+ * listeners *kept*, complementing Trending's what-just-got-played signal.
+ *
+ * Single all-time list (no windowing — the retention signal is meant to
+ * change slowly). The implementation hydrates server-returned show IDs
+ * into full Show objects from the local catalog.
+ */
+interface PopularService {
+    val popular: StateFlow<PopularContent>
+    suspend fun refresh(): Result<Unit>
+}
+
+data class PopularContent(
+    val shows: List<Show>,
+    val lastRefresh: Long,
+) {
+    companion object {
+        fun initial() = PopularContent(shows = emptyList(), lastRefresh = 0L)
+    }
+}

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
@@ -62,6 +62,7 @@ class AppPreferences @Inject constructor(
         private const val KEY_HOME_TRENDING_INCLUDE_ANNIVERSARIES = "home_trending_include_anniversaries"
         private const val KEY_HOME_POPULAR_ENABLED = "home_popular_enabled"
         private const val KEY_HOME_POPULAR_CARD_SIZE = "home_popular_card_size"
+        private const val KEY_HOME_POPULAR_DECADE = "home_popular_decade"
     }
 
     private val _homeTrendingCardSize = MutableStateFlow(
@@ -102,6 +103,7 @@ class AppPreferences @Inject constructor(
         setHomeTrendingIncludeAnniversaries(false)
         setHomePopularEnabled(true)
         setHomePopularCardSize("small")
+        setHomePopularDecade("all")
     }
 
     private val _homePopularEnabled = MutableStateFlow(
@@ -123,6 +125,16 @@ class AppPreferences @Inject constructor(
     fun setHomePopularCardSize(value: String) {
         prefs.edit().putString(KEY_HOME_POPULAR_CARD_SIZE, value).apply()
         _homePopularCardSize.value = value
+    }
+
+    private val _homePopularDecade = MutableStateFlow(
+        prefs.getString(KEY_HOME_POPULAR_DECADE, null) ?: "all"
+    )
+    /** Which decade the Fan Favorites home rail shows: "all"/"60s"/"70s"/"80s"/"90s". */
+    val homePopularDecade: StateFlow<String> = _homePopularDecade.asStateFlow()
+    fun setHomePopularDecade(value: String) {
+        prefs.edit().putString(KEY_HOME_POPULAR_DECADE, value).apply()
+        _homePopularDecade.value = value
     }
 
     private val _homeTrendingIncludeAnniversaries = MutableStateFlow(

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
@@ -60,6 +60,8 @@ class AppPreferences @Inject constructor(
         private const val KEY_HOME_TODAY_CARD_SIZE = "home_today_card_size"
         private const val KEY_HOME_COLLECTIONS_CARD_SIZE = "home_collections_card_size"
         private const val KEY_HOME_TRENDING_INCLUDE_ANNIVERSARIES = "home_trending_include_anniversaries"
+        private const val KEY_HOME_POPULAR_ENABLED = "home_popular_enabled"
+        private const val KEY_HOME_POPULAR_CARD_SIZE = "home_popular_card_size"
     }
 
     private val _homeTrendingCardSize = MutableStateFlow(
@@ -98,6 +100,29 @@ class AppPreferences @Inject constructor(
         setHomeTodayCardSize("large")
         setHomeCollectionsCardSize("large")
         setHomeTrendingIncludeAnniversaries(false)
+        setHomePopularEnabled(true)
+        setHomePopularCardSize("small")
+    }
+
+    private val _homePopularEnabled = MutableStateFlow(
+        prefs.getBoolean(KEY_HOME_POPULAR_ENABLED, true)
+    )
+
+    /** Show the "Fan Favorites" home rail. On by default. */
+    val homePopularEnabled: StateFlow<Boolean> = _homePopularEnabled.asStateFlow()
+
+    fun setHomePopularEnabled(value: Boolean) {
+        prefs.edit().putBoolean(KEY_HOME_POPULAR_ENABLED, value).apply()
+        _homePopularEnabled.value = value
+    }
+
+    private val _homePopularCardSize = MutableStateFlow(
+        prefs.getString(KEY_HOME_POPULAR_CARD_SIZE, null) ?: "small"
+    )
+    val homePopularCardSize: StateFlow<String> = _homePopularCardSize.asStateFlow()
+    fun setHomePopularCardSize(value: String) {
+        prefs.edit().putString(KEY_HOME_POPULAR_CARD_SIZE, value).apply()
+        _homePopularCardSize.value = value
     }
 
     private val _homeTrendingIncludeAnniversaries = MutableStateFlow(

--- a/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/HomeServiceImpl.kt
+++ b/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/HomeServiceImpl.kt
@@ -3,6 +3,7 @@ package com.grateful.deadly.core.home
 import android.util.Log
 import com.grateful.deadly.core.api.home.HomeService
 import com.grateful.deadly.core.api.home.HomeContent
+import com.grateful.deadly.core.api.home.PopularService
 import com.grateful.deadly.core.api.home.TrendingService
 import com.grateful.deadly.core.api.home.TrendingWindow
 import com.grateful.deadly.core.api.recent.RecentShowsService
@@ -40,6 +41,7 @@ class HomeServiceImpl @Inject constructor(
     private val recentShowsService: RecentShowsService,
     private val collectionsService: DeadCollectionsService,
     private val trendingService: TrendingService,
+    private val popularService: PopularService,
     private val appPreferences: AppPreferences
 ) : HomeService {
     
@@ -52,6 +54,10 @@ class HomeServiceImpl @Inject constructor(
     // Reactive combination of all home content sources
     // Bundle the preference flows so the main combine stays at 5 args
     // (Flow.combine's typed overloads top out at 5).
+    // Bundle all home-screen preference flows so the main combine stays
+    // under combine()'s typed-overload limit. Two preference groups now:
+    // trending/layout prefs and popular prefs, kept separate to mirror
+    // which service consumes them.
     private data class HomePrefs(
         val windowKey: String,
         val aboveToday: Boolean,
@@ -59,6 +65,8 @@ class HomeServiceImpl @Inject constructor(
         val trendingCardSize: String,
         val todayCardSize: String,
         val collectionsCardSize: String,
+        val popularEnabled: Boolean,
+        val popularCardSize: String,
     )
     private val homePrefs = combine(
         appPreferences.homeTrendingWindow,
@@ -67,6 +75,8 @@ class HomeServiceImpl @Inject constructor(
         appPreferences.homeTrendingCardSize,
         appPreferences.homeTodayCardSize,
         appPreferences.homeCollectionsCardSize,
+        appPreferences.homePopularEnabled,
+        appPreferences.homePopularCardSize,
     ) { values ->
         HomePrefs(
             windowKey = values[0] as String,
@@ -75,24 +85,40 @@ class HomeServiceImpl @Inject constructor(
             trendingCardSize = values[3] as String,
             todayCardSize = values[4] as String,
             collectionsCardSize = values[5] as String,
+            popularEnabled = values[6] as Boolean,
+            popularCardSize = values[7] as String,
         )
     }
+
+    // Bundle trending + popular into a single flow so the main combine
+    // doesn't exceed combine()'s 5-arg typed overloads.
+    private data class HomeRails(
+        val trending: com.grateful.deadly.core.api.home.TrendingContent,
+        val popular: com.grateful.deadly.core.api.home.PopularContent,
+    )
+    private val homeRails = combine(
+        trendingService.trending,
+        popularService.popular,
+    ) { t, p -> HomeRails(t, p) }
 
     override val homeContent: StateFlow<HomeContent> = combine(
         recentShowsService.recentShows,
         loadTodayInHistoryFlow(),
         collectionsService.featuredCollections,
-        trendingService.trending,
+        homeRails,
         homePrefs
-    ) { recentShows, todayInHistory, featuredCollections, trending, prefs ->
+    ) { recentShows, todayInHistory, featuredCollections, rails, prefs ->
         val window = TrendingWindow.fromKey(prefs.windowKey)
         HomeContent(
             recentShows = recentShows,
             todayInHistory = todayInHistory,
             featuredCollections = featuredCollections,
-            trendingShows = trending.forWindow(window),
+            trendingShows = rails.trending.forWindow(window),
             trendingWindow = window,
             trendingAboveToday = prefs.aboveToday,
+            popularShows = rails.popular.shows,
+            popularEnabled = prefs.popularEnabled,
+            popularCardSize = prefs.popularCardSize,
             recentRows = prefs.recentRows,
             trendingCardSize = prefs.trendingCardSize,
             todayCardSize = prefs.todayCardSize,

--- a/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/HomeServiceImpl.kt
+++ b/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/HomeServiceImpl.kt
@@ -3,6 +3,7 @@ package com.grateful.deadly.core.home
 import android.util.Log
 import com.grateful.deadly.core.api.home.HomeService
 import com.grateful.deadly.core.api.home.HomeContent
+import com.grateful.deadly.core.api.home.PopularDecade
 import com.grateful.deadly.core.api.home.PopularService
 import com.grateful.deadly.core.api.home.TrendingService
 import com.grateful.deadly.core.api.home.TrendingWindow
@@ -67,6 +68,7 @@ class HomeServiceImpl @Inject constructor(
         val collectionsCardSize: String,
         val popularEnabled: Boolean,
         val popularCardSize: String,
+        val popularDecadeKey: String,
     )
     private val homePrefs = combine(
         appPreferences.homeTrendingWindow,
@@ -77,6 +79,7 @@ class HomeServiceImpl @Inject constructor(
         appPreferences.homeCollectionsCardSize,
         appPreferences.homePopularEnabled,
         appPreferences.homePopularCardSize,
+        appPreferences.homePopularDecade,
     ) { values ->
         HomePrefs(
             windowKey = values[0] as String,
@@ -87,6 +90,7 @@ class HomeServiceImpl @Inject constructor(
             collectionsCardSize = values[5] as String,
             popularEnabled = values[6] as Boolean,
             popularCardSize = values[7] as String,
+            popularDecadeKey = values[8] as String,
         )
     }
 
@@ -109,6 +113,7 @@ class HomeServiceImpl @Inject constructor(
         homePrefs
     ) { recentShows, todayInHistory, featuredCollections, rails, prefs ->
         val window = TrendingWindow.fromKey(prefs.windowKey)
+        val decade = PopularDecade.fromKey(prefs.popularDecadeKey)
         HomeContent(
             recentShows = recentShows,
             todayInHistory = todayInHistory,
@@ -116,9 +121,10 @@ class HomeServiceImpl @Inject constructor(
             trendingShows = rails.trending.forWindow(window),
             trendingWindow = window,
             trendingAboveToday = prefs.aboveToday,
-            popularShows = rails.popular.shows,
+            popularContent = rails.popular,
             popularEnabled = prefs.popularEnabled,
             popularCardSize = prefs.popularCardSize,
+            popularDecade = decade,
             recentRows = prefs.recentRows,
             trendingCardSize = prefs.trendingCardSize,
             todayCardSize = prefs.todayCardSize,

--- a/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/PopularServiceImpl.kt
+++ b/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/PopularServiceImpl.kt
@@ -1,0 +1,83 @@
+package com.grateful.deadly.core.home
+
+import android.util.Log
+import com.grateful.deadly.core.api.home.PopularContent
+import com.grateful.deadly.core.api.home.PopularService
+import com.grateful.deadly.core.database.AppPreferences
+import com.grateful.deadly.core.domain.repository.ShowRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Fetches "Fan Favorites" shows from /api/popular and resolves the
+ * returned IDs into Show domain models via the local catalog. Single
+ * list (no windows). Refreshes on init and periodically.
+ */
+@Singleton
+class PopularServiceImpl @Inject constructor(
+    private val appPreferences: AppPreferences,
+    private val showRepository: ShowRepository,
+) : PopularService {
+
+    companion object {
+        private const val TAG = "PopularServiceImpl"
+        private const val REFRESH_INTERVAL_MS = 10 * 60 * 1000L
+    }
+
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val _popular = MutableStateFlow(PopularContent.initial())
+    override val popular: StateFlow<PopularContent> = _popular.asStateFlow()
+
+    init {
+        scope.launch {
+            while (isActive) {
+                refresh()
+                delay(REFRESH_INTERVAL_MS)
+            }
+        }
+    }
+
+    override suspend fun refresh(): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            val raw = fetchJson()
+            val arr = raw.optJSONArray("shows") ?: return@runCatching
+            val ids = List(arr.length()) { i -> arr.getJSONObject(i).getString("show_id") }
+            val byId = showRepository.getShowsByIds(ids).associateBy { it.id }
+            _popular.value = PopularContent(
+                shows = ids.mapNotNull { byId[it] },
+                lastRefresh = System.currentTimeMillis(),
+            )
+        }.onFailure {
+            Log.w(TAG, "Popular refresh failed: ${it.message}")
+        }
+    }
+
+    private fun fetchJson(): JSONObject {
+        val url = URL("${appPreferences.apiBaseUrl}/api/popular")
+        val conn = url.openConnection() as HttpURLConnection
+        try {
+            conn.requestMethod = "GET"
+            conn.connectTimeout = 10_000
+            conn.readTimeout = 10_000
+            val code = conn.responseCode
+            if (code !in 200..299) error("HTTP $code")
+            val body = conn.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+            return JSONObject(body)
+        } finally {
+            conn.disconnect()
+        }
+    }
+}

--- a/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/PopularServiceImpl.kt
+++ b/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/PopularServiceImpl.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.json.JSONArray
 import org.json.JSONObject
 import java.net.HttpURLConnection
 import java.net.URL
@@ -22,9 +23,10 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Fetches "Fan Favorites" shows from /api/popular and resolves the
- * returned IDs into Show domain models via the local catalog. Single
- * list (no windows). Refreshes on init and periodically.
+ * Fetches "Fan Favorites" pools from /api/popular and resolves returned
+ * IDs into Show domain models via the local catalog. Server returns four
+ * per-decade pools (60s/70s/80s/90s); the home rail picks its 4-show
+ * display set locally — see PopularContent.displayShows.
  */
 @Singleton
 class PopularServiceImpl @Inject constructor(
@@ -53,16 +55,28 @@ class PopularServiceImpl @Inject constructor(
     override suspend fun refresh(): Result<Unit> = withContext(Dispatchers.IO) {
         runCatching {
             val raw = fetchJson()
-            val arr = raw.optJSONArray("shows") ?: return@runCatching
-            val ids = List(arr.length()) { i -> arr.getJSONObject(i).getString("show_id") }
-            val byId = showRepository.getShowsByIds(ids).associateBy { it.id }
+            val decades = raw.optJSONObject("decades") ?: return@runCatching
+            val ids60 = extractIds(decades.optJSONArray("60s"))
+            val ids70 = extractIds(decades.optJSONArray("70s"))
+            val ids80 = extractIds(decades.optJSONArray("80s"))
+            val ids90 = extractIds(decades.optJSONArray("90s"))
+            val unionIds = (ids60 + ids70 + ids80 + ids90).distinct()
+            val byId = showRepository.getShowsByIds(unionIds).associateBy { it.id }
             _popular.value = PopularContent(
-                shows = ids.mapNotNull { byId[it] },
+                pool60 = ids60.mapNotNull { byId[it] },
+                pool70 = ids70.mapNotNull { byId[it] },
+                pool80 = ids80.mapNotNull { byId[it] },
+                pool90 = ids90.mapNotNull { byId[it] },
                 lastRefresh = System.currentTimeMillis(),
             )
         }.onFailure {
             Log.w(TAG, "Popular refresh failed: ${it.message}")
         }
+    }
+
+    private fun extractIds(arr: JSONArray?): List<String> {
+        if (arr == null) return emptyList()
+        return List(arr.length()) { i -> arr.getJSONObject(i).getString("show_id") }
     }
 
     private fun fetchJson(): JSONObject {

--- a/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/di/HomeModule.kt
+++ b/androidApp/core/home/src/main/java/com/grateful/deadly/core/home/di/HomeModule.kt
@@ -1,8 +1,10 @@
 package com.grateful.deadly.core.home.di
 
 import com.grateful.deadly.core.api.home.HomeService
+import com.grateful.deadly.core.api.home.PopularService
 import com.grateful.deadly.core.api.home.TrendingService
 import com.grateful.deadly.core.home.HomeServiceImpl
+import com.grateful.deadly.core.home.PopularServiceImpl
 import com.grateful.deadly.core.home.TrendingServiceImpl
 import dagger.Binds
 import dagger.Module
@@ -34,4 +36,10 @@ abstract class HomeModule {
     abstract fun bindTrendingService(
         impl: TrendingServiceImpl
     ): TrendingService
+
+    @Binds
+    @Singleton
+    abstract fun bindPopularService(
+        impl: PopularServiceImpl
+    ): PopularService
 }

--- a/androidApp/core/media/build.gradle.kts
+++ b/androidApp/core/media/build.gradle.kts
@@ -43,7 +43,8 @@ dependencies {
     implementation(project(":core:api:collections"))
     implementation(project(":core:api:favorites"))
     implementation(project(":core:api:search"))
-    
+    implementation(project(":core:api:home"))
+
     implementation("androidx.core:core-ktx:1.12.0")
     
     // Media3/ExoPlayer - Latest stable versions

--- a/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/browse/BrowseMediaId.kt
+++ b/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/browse/BrowseMediaId.kt
@@ -8,6 +8,8 @@ package com.grateful.deadly.core.media.browse
  * ├── library             → My Library
  * │   ├── library_shows   → Favorite Shows
  * │   └── library_songs   → Favorite Songs
+ * ├── trending            → Trending Now (respects user's window pref)
+ * ├── popular             → Fan Favorites (respects user's decade pref)
  * ├── top_rated           → Top Rated Shows
  * ├── today               → Today in Dead History
  * ├── collections         → Collections list
@@ -26,6 +28,8 @@ object BrowseMediaId {
     const val LIBRARY = "library"
     const val LIBRARY_SHOWS = "library_shows"
     const val LIBRARY_SONGS = "library_songs"
+    const val TRENDING = "trending"
+    const val POPULAR = "popular"
     const val TOP_RATED = "top_rated"
     const val TODAY = "today"
     const val COLLECTIONS = "collections"

--- a/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/browse/BrowseTreeProvider.kt
+++ b/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/browse/BrowseTreeProvider.kt
@@ -8,8 +8,13 @@ import androidx.media3.common.MediaMetadata
 import com.grateful.deadly.core.api.collections.DeadCollectionsService
 import com.grateful.deadly.core.api.favorites.FavoritesService
 import com.grateful.deadly.core.api.favorites.ReviewService
+import com.grateful.deadly.core.api.home.PopularDecade
+import com.grateful.deadly.core.api.home.PopularService
+import com.grateful.deadly.core.api.home.TrendingService
+import com.grateful.deadly.core.api.home.TrendingWindow
 import com.grateful.deadly.core.api.recent.RecentShowsService
 import com.grateful.deadly.core.api.search.SearchService
+import com.grateful.deadly.core.database.AppPreferences
 import com.grateful.deadly.core.domain.repository.ShowRepository
 import com.grateful.deadly.core.model.DeadCollection
 import com.grateful.deadly.core.model.FavoriteTrack
@@ -31,7 +36,10 @@ class BrowseTreeProvider @Inject constructor(
     private val favoritesService: FavoritesService,
     private val reviewService: ReviewService,
     private val searchService: SearchService,
-    private val archiveService: ArchiveService
+    private val archiveService: ArchiveService,
+    private val trendingService: TrendingService,
+    private val popularService: PopularService,
+    private val appPreferences: AppPreferences,
 ) {
     companion object {
         private const val TAG = "BrowseTreeProvider"
@@ -43,6 +51,8 @@ class BrowseTreeProvider @Inject constructor(
     fun getRootItems(): List<MediaItem> = listOf(
         buildBrowsableItem(BrowseMediaId.RECENT, "Recent", "Recently played shows"),
         buildBrowsableItem(BrowseMediaId.LIBRARY, "Favorites", "Shows you've saved"),
+        buildBrowsableItem(BrowseMediaId.TRENDING, "Trending", "What others are playing"),
+        buildBrowsableItem(BrowseMediaId.POPULAR, "Fan Favorites", "Shows people kept"),
         buildBrowsableItem(BrowseMediaId.TODAY, "TIGDH", "Today in Grateful Dead History"),
         buildBrowsableItem(BrowseMediaId.YEARS, "Browse by Year", "1965\u20131995"),
         buildBrowsableItem(BrowseMediaId.TOP_RATED, "Top Rated", "Highest rated shows"),
@@ -73,6 +83,20 @@ class BrowseTreeProvider @Inject constructor(
             }
             parentId == BrowseMediaId.TOP_RATED -> {
                 showRepository.getTopRatedShows(50).map(::buildShowItem)
+            }
+            parentId == BrowseMediaId.TRENDING -> {
+                // Trigger a refresh in case the StateFlow hasn't populated yet
+                // (e.g., AA connected before the service's auto-refresh tick).
+                // refresh() returns Result<Unit> — failures are logged inside.
+                trendingService.refresh()
+                val window = TrendingWindow.fromKey(appPreferences.homeTrendingWindow.value)
+                trendingService.trending.value.forWindow(window).map(::buildShowItem)
+            }
+            parentId == BrowseMediaId.POPULAR -> {
+                popularService.refresh()
+                val decade = PopularDecade.fromKey(appPreferences.homePopularDecade.value)
+                // seed=0 — AA surface is stable; no "Show more" re-roll in-car.
+                popularService.popular.value.displayShows(decade, seed = 0).map(::buildShowItem)
             }
             parentId == BrowseMediaId.TODAY -> {
                 val cal = Calendar.getInstance()
@@ -124,6 +148,10 @@ class BrowseTreeProvider @Inject constructor(
             buildBrowsableItem(BrowseMediaId.LIBRARY_SONGS, "Songs", "Favorite songs")
         mediaId == BrowseMediaId.TOP_RATED ->
             buildBrowsableItem(BrowseMediaId.TOP_RATED, "Top Rated", "Highest rated shows")
+        mediaId == BrowseMediaId.TRENDING ->
+            buildBrowsableItem(BrowseMediaId.TRENDING, "Trending", "What others are playing")
+        mediaId == BrowseMediaId.POPULAR ->
+            buildBrowsableItem(BrowseMediaId.POPULAR, "Fan Favorites", "Shows people kept")
         mediaId == BrowseMediaId.TODAY ->
             buildBrowsableItem(BrowseMediaId.TODAY, "TIGDH", "Today in Grateful Dead History")
         mediaId == BrowseMediaId.COLLECTIONS ->

--- a/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/browse/BrowseTreeProvider.kt
+++ b/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/browse/BrowseTreeProvider.kt
@@ -51,9 +51,9 @@ class BrowseTreeProvider @Inject constructor(
     fun getRootItems(): List<MediaItem> = listOf(
         buildBrowsableItem(BrowseMediaId.RECENT, "Recent", "Recently played shows"),
         buildBrowsableItem(BrowseMediaId.LIBRARY, "Favorites", "Shows you've saved"),
+        buildBrowsableItem(BrowseMediaId.TODAY, "TIGDH", "Today in Grateful Dead History"),
         buildBrowsableItem(BrowseMediaId.TRENDING, "Trending", "What others are playing"),
         buildBrowsableItem(BrowseMediaId.POPULAR, "Fan Favorites", "Shows people kept"),
-        buildBrowsableItem(BrowseMediaId.TODAY, "TIGDH", "Today in Grateful Dead History"),
         buildBrowsableItem(BrowseMediaId.YEARS, "Browse by Year", "1965\u20131995"),
         buildBrowsableItem(BrowseMediaId.TOP_RATED, "Top Rated", "Highest rated shows"),
     )

--- a/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/browse/BrowseTreeProvider.kt
+++ b/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/browse/BrowseTreeProvider.kt
@@ -95,8 +95,9 @@ class BrowseTreeProvider @Inject constructor(
             parentId == BrowseMediaId.POPULAR -> {
                 popularService.refresh()
                 val decade = PopularDecade.fromKey(appPreferences.homePopularDecade.value)
-                // seed=0 — AA surface is stable; no "Show more" re-roll in-car.
-                popularService.popular.value.displayShows(decade, seed = 0).map(::buildShowItem)
+                // Android Auto has no "Show more" affordance — surface the
+                // full pool rather than the 4-show home-rail teaser.
+                popularService.popular.value.allShows(decade).map(::buildShowItem)
             }
             parentId == BrowseMediaId.TODAY -> {
                 val cal = Calendar.getInstance()

--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeScreen.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeScreen.kt
@@ -14,6 +14,7 @@ import com.grateful.deadly.feature.home.screens.main.components.HorizontalCollec
 import com.grateful.deadly.feature.home.screens.main.components.HorizontalCollectionItem
 import com.grateful.deadly.feature.home.screens.main.components.CollectionItemType
 import com.grateful.deadly.feature.home.screens.main.components.RecentShowsGrid
+import com.grateful.deadly.feature.home.screens.main.components.FanFavoritesSection
 import com.grateful.deadly.feature.home.screens.main.components.TrendingNowSection
 
 /**
@@ -118,32 +119,19 @@ fun HomeScreen(
         }
 
         // Fan Favorites — sits below the Trending/Today pair. Hidden when
-        // the user has the rail off, or when the rail has no results
-        // (e.g. small install base, nothing has met the favorites floor).
-        if (uiState.homeContent.popularEnabled && uiState.homeContent.popularShows.isNotEmpty()) {
+        // the user has the rail off, or when no decade has any results
+        // (small install base, nothing has met the floor). The selected
+        // decade may be empty even when others aren't; FanFavoritesSection
+        // renders an empty hint in that case so the user can cycle back.
+        if (uiState.homeContent.popularEnabled && uiState.homeContent.popularContent.hasAnyContent) {
             item {
-                val popularCardWidth = cardWidthFor(uiState.homeContent.popularCardSize)
-                val popularItems = uiState.homeContent.popularShows.map { show ->
-                    HorizontalCollectionItem(
-                        id = show.id,
-                        displayText = show.date,
-                        type = CollectionItemType.SHOW,
-                        recordingId = show.bestRecordingId,
-                        imageUrl = show.coverImageUrl
-                    )
-                }
-                HorizontalCollection(
-                    title = "Fan Favorites",
-                    items = popularItems,
-                    cardWidth = popularCardWidth,
-                    onItemClick = { item ->
-                        uiState.homeContent.popularShows.find { it.id == item.id }
-                            ?.let { onNavigateToShow(it.id) }
-                    },
-                    onItemLongPress = { item ->
-                        uiState.homeContent.popularShows.find { it.id == item.id }
-                            ?.let { detailShow = it }
-                    }
+                FanFavoritesSection(
+                    popularContent = uiState.homeContent.popularContent,
+                    decade = uiState.homeContent.popularDecade,
+                    cardSize = uiState.homeContent.popularCardSize,
+                    onShowClick = { show -> onNavigateToShow(show.id) },
+                    onShowLongPress = { show -> detailShow = show },
+                    onShowMore = { viewModel.trackPopularShowMore() },
                 )
             }
         }

--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeScreen.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeScreen.kt
@@ -117,6 +117,37 @@ fun HomeScreen(
             item { trendingItem() }
         }
 
+        // Fan Favorites — sits below the Trending/Today pair. Hidden when
+        // the user has the rail off, or when the rail has no results
+        // (e.g. small install base, nothing has met the favorites floor).
+        if (uiState.homeContent.popularEnabled && uiState.homeContent.popularShows.isNotEmpty()) {
+            item {
+                val popularCardWidth = cardWidthFor(uiState.homeContent.popularCardSize)
+                val popularItems = uiState.homeContent.popularShows.map { show ->
+                    HorizontalCollectionItem(
+                        id = show.id,
+                        displayText = show.date,
+                        type = CollectionItemType.SHOW,
+                        recordingId = show.bestRecordingId,
+                        imageUrl = show.coverImageUrl
+                    )
+                }
+                HorizontalCollection(
+                    title = "Fan Favorites",
+                    items = popularItems,
+                    cardWidth = popularCardWidth,
+                    onItemClick = { item ->
+                        uiState.homeContent.popularShows.find { it.id == item.id }
+                            ?.let { onNavigateToShow(it.id) }
+                    },
+                    onItemLongPress = { item ->
+                        uiState.homeContent.popularShows.find { it.id == item.id }
+                            ?.let { detailShow = it }
+                    }
+                )
+            }
+        }
+
         // Featured Collections Section
         item {
             val collectionItems = uiState.homeContent.featuredCollections.map { collection ->

--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeViewModel.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.grateful.deadly.core.api.home.HomeService
 import com.grateful.deadly.core.api.home.HomeContent
 import com.grateful.deadly.core.api.home.TrendingService
+import com.grateful.deadly.core.database.AnalyticsService
 import com.grateful.deadly.core.database.AppPreferences
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,6 +29,7 @@ class HomeViewModel @Inject constructor(
     private val homeService: HomeService,
     private val trendingService: TrendingService,
     private val appPreferences: AppPreferences,
+    private val analyticsService: AnalyticsService,
 ) : ViewModel() {
 
     companion object {
@@ -100,6 +102,15 @@ class HomeViewModel @Inject constructor(
     /** Cycle the trending window forward (Day → Week → Month → All → Day). */
     fun cycleTrendingWindow() {
         homeService.cycleTrendingWindow()
+    }
+
+    /** Telemetry hook for the Fan Favorites "Show more" re-roll. */
+    fun trackPopularShowMore() {
+        analyticsService.track("feature_use", mapOf(
+            "feature" to "popular_show_more",
+            "category" to "action",
+            "value" to appPreferences.homePopularDecade.value,
+        ))
     }
 
     /**

--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/components/FanFavoritesSection.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/components/FanFavoritesSection.kt
@@ -1,0 +1,105 @@
+package com.grateful.deadly.feature.home.screens.main.components
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.grateful.deadly.core.api.home.PopularContent
+import com.grateful.deadly.core.api.home.PopularDecade
+import com.grateful.deadly.core.model.Show
+
+/**
+ * "Fan Favorites" home section. Always 4 shows.
+ *  - decade = ALL: one show per decade pool.
+ *  - decade = a specific decade: 4 shows from that pool with year spread.
+ *
+ * "Show more" re-rolls the display set client-side (no re-fetch). The
+ * decade choice itself lives in Settings.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun FanFavoritesSection(
+    popularContent: PopularContent,
+    decade: PopularDecade,
+    cardSize: String,
+    onShowClick: (Show) -> Unit,
+    onShowLongPress: (Show) -> Unit,
+    onShowMore: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val isCompact = cardSize == "small"
+    var seed by remember { mutableIntStateOf(0) }
+    val shows = remember(popularContent.lastRefresh, decade, seed) {
+        popularContent.displayShows(decade, seed)
+    }
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            val title = if (decade == PopularDecade.ALL) "Fan Favorites" else "Fan Favorites · ${decade.label}"
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = "Show more",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                modifier = Modifier.clickable {
+                    seed++
+                    onShowMore()
+                },
+            )
+        }
+
+        if (shows.isEmpty()) {
+            Text(
+                text = "Nothing here yet. Try a different decade in Settings.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            return
+        }
+
+        val listState = rememberLazyListState()
+        val firstId = shows.firstOrNull()?.id
+        LaunchedEffect(firstId) {
+            listState.scrollToItem(0)
+        }
+        LazyRow(state = listState, horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            items(shows, key = { it.id }) { show ->
+                CollectionItemCard(
+                    item = HorizontalCollectionItem(
+                        id = show.id,
+                        displayText = show.date,
+                        type = CollectionItemType.SHOW,
+                        recordingId = show.bestRecordingId,
+                        imageUrl = show.coverImageUrl,
+                    ),
+                    cardWidth = if (isCompact) 100.dp else 160.dp,
+                    onItemClick = { onShowClick(show) },
+                    onItemLongPress = { onShowLongPress(show) },
+                )
+            }
+        }
+    }
+}

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
@@ -43,6 +43,8 @@ fun SettingsScreen(
     val homeTrendingCardSize by viewModel.homeTrendingCardSize.collectAsState()
     val homeTodayCardSize by viewModel.homeTodayCardSize.collectAsState()
     val homeCollectionsCardSize by viewModel.homeCollectionsCardSize.collectAsState()
+    val homePopularEnabled by viewModel.homePopularEnabled.collectAsState()
+    val homePopularCardSize by viewModel.homePopularCardSize.collectAsState()
     val authState by viewModel.authState.collectAsState()
     val serverEnvironment by viewModel.serverEnvironment.collectAsState()
     val developerModeUnlocked by viewModel.developerModeUnlocked.collectAsState()
@@ -209,6 +211,24 @@ fun SettingsScreen(
                 subtitle = "Size of cards in the Featured Collections carousel.",
                 current = homeCollectionsCardSize,
                 onSelected = { viewModel.setHomeCollectionsCardSize(it) }
+            )
+        }
+
+        item {
+            PreferenceToggleRow(
+                title = "Show Fan Favorites",
+                subtitle = "Shows other listeners kept — ranked by saved-vs-played ratio.",
+                checked = homePopularEnabled,
+                onCheckedChange = { viewModel.toggleHomePopularEnabled() }
+            )
+        }
+
+        item {
+            HomeCardSizeRow(
+                title = "Fan Favorites card size",
+                subtitle = "Size of cards in the Fan Favorites carousel.",
+                current = homePopularCardSize,
+                onSelected = { viewModel.setHomePopularCardSize(it) }
             )
         }
 

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
@@ -45,6 +45,7 @@ fun SettingsScreen(
     val homeCollectionsCardSize by viewModel.homeCollectionsCardSize.collectAsState()
     val homePopularEnabled by viewModel.homePopularEnabled.collectAsState()
     val homePopularCardSize by viewModel.homePopularCardSize.collectAsState()
+    val homePopularDecade by viewModel.homePopularDecade.collectAsState()
     val authState by viewModel.authState.collectAsState()
     val serverEnvironment by viewModel.serverEnvironment.collectAsState()
     val developerModeUnlocked by viewModel.developerModeUnlocked.collectAsState()
@@ -220,6 +221,13 @@ fun SettingsScreen(
                 subtitle = "Shows other listeners kept — ranked by saved-vs-played ratio.",
                 checked = homePopularEnabled,
                 onCheckedChange = { viewModel.toggleHomePopularEnabled() }
+            )
+        }
+
+        item {
+            HomePopularDecadeRow(
+                currentKey = homePopularDecade,
+                onSelected = { viewModel.setHomePopularDecade(it) }
             )
         }
 
@@ -696,6 +704,47 @@ private fun HomeCardSizeRow(
             options.forEachIndexed { index, (key, label) ->
                 SegmentedButton(
                     selected = current == key,
+                    onClick = { onSelected(key) },
+                    shape = SegmentedButtonDefaults.itemShape(
+                        index = index,
+                        count = options.size
+                    )
+                ) {
+                    Text(label)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HomePopularDecadeRow(
+    currentKey: String,
+    onSelected: (String) -> Unit
+) {
+    val options = listOf(
+        "all" to "All",
+        "60s" to "60s",
+        "70s" to "70s",
+        "80s" to "80s",
+        "90s" to "90s",
+    )
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        Text(text = "Fan Favorites decade", style = MaterialTheme.typography.bodyLarge)
+        Text(
+            text = "Default decade filter for the Fan Favorites rail. Tap the header to cycle.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+            options.forEachIndexed { index, (key, label) ->
+                SegmentedButton(
+                    selected = currentKey == key,
                     onClick = { onSelected(key) },
                     shape = SegmentedButtonDefaults.itemShape(
                         index = index,

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
@@ -135,6 +135,29 @@ class SettingsViewModel @Inject constructor(
         ))
     }
 
+    val homePopularEnabled: StateFlow<Boolean> = appPreferences.homePopularEnabled
+
+    fun toggleHomePopularEnabled() {
+        val newValue = !appPreferences.homePopularEnabled.value
+        appPreferences.setHomePopularEnabled(newValue)
+        analyticsService.track("feature_use", mapOf(
+            "feature" to "set_home_popular_enabled",
+            "category" to "preference",
+            "value" to newValue.toString(),
+        ))
+    }
+
+    val homePopularCardSize: StateFlow<String> = appPreferences.homePopularCardSize
+
+    fun setHomePopularCardSize(value: String) {
+        appPreferences.setHomePopularCardSize(value)
+        analyticsService.track("feature_use", mapOf(
+            "feature" to "set_home_popular_card_size",
+            "category" to "preference",
+            "value" to value,
+        ))
+    }
+
     val homeRecentRows: StateFlow<Int> = appPreferences.homeRecentRows
 
     fun setHomeRecentRows(value: Int) {

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
@@ -158,6 +158,17 @@ class SettingsViewModel @Inject constructor(
         ))
     }
 
+    val homePopularDecade: StateFlow<String> = appPreferences.homePopularDecade
+
+    fun setHomePopularDecade(value: String) {
+        appPreferences.setHomePopularDecade(value)
+        analyticsService.track("feature_use", mapOf(
+            "feature" to "set_home_popular_decade",
+            "category" to "preference",
+            "value" to value,
+        ))
+    }
+
     val homeRecentRows: StateFlow<Int> = appPreferences.homeRecentRows
 
     fun setHomeRecentRows(value: Int) {

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -13,6 +13,7 @@ import { authMiddleware } from "./auth/middleware.js";
 import { connectRoutes } from "./connect/routes.js";
 import { analyticsRoutes } from "./routes/analytics.js";
 import { trendingRoutes } from "./routes/trending.js";
+import { popularRoutes } from "./routes/popular.js";
 import { betaRoutes } from "./routes/beta.js";
 import { devTokenRoutes } from "./auth/dev-token.js";
 import { isDev } from "./env.js";
@@ -65,6 +66,7 @@ export function buildApp() {
   app.register(connectRoutes);
   app.register(analyticsRoutes);
   app.register(trendingRoutes);
+  app.register(popularRoutes);
   app.register(betaRoutes);
 
   if (isDev) {

--- a/api/src/db/__tests__/live-listeners.test.ts
+++ b/api/src/db/__tests__/live-listeners.test.ts
@@ -113,6 +113,45 @@ describe("getLiveListeners — dual live boundary", () => {
     expect(live[0].show_id).toBe("show-B");
   });
 
+  it("app_backgrounded ends do not stop the live keepalive (phone in pocket)", () => {
+    // ~25% of playback_end events in prod are app_backgrounded — the
+    // user locked their phone but audio kept playing. Treating those
+    // as real ends dropped them off Live within 2 min; we now ignore
+    // them so the preceding playback_start remains the keepalive
+    // anchor under the 45-min START window.
+    const now = Date.now();
+    insertEvents([
+      ev("playback_start", "gina", "s1", "show-G", 0, now - 10 * 60_000),
+      ev("playback_end", "gina", "s1", "show-G", 0, now - 9 * 60_000, {
+        reason: "app_backgrounded",
+      }),
+    ]);
+
+    const live = getLiveListeners();
+    expect(live).toHaveLength(1);
+    expect(live[0].iid).toBe("gina");
+    expect(live[0].show_id).toBe("show-G");
+    // started_at should reflect the original start, not the bg end.
+    expect(live[0].started_at).toBe(now - 10 * 60_000);
+
+    // And the same user must NOT also appear in Recent.
+    const recent = getRecentListening(24);
+    expect(recent.find((r) => r.iid === "gina")).toBeUndefined();
+  });
+
+  it("backgrounded user falls off Live once their start ages past 45min", () => {
+    const now = Date.now();
+    insertEvents([
+      ev("playback_start", "harry", "s1", "show-H", 0, now - 50 * 60_000),
+      ev("playback_end", "harry", "s1", "show-H", 0, now - 49 * 60_000, {
+        reason: "app_backgrounded",
+      }),
+    ]);
+    expect(getLiveListeners()).toEqual([]);
+    const recent = getRecentListening(24);
+    expect(recent.find((r) => r.iid === "harry")).toBeDefined();
+  });
+
   it("at most one row per iid even with multiple unmatched starts", () => {
     const now = Date.now();
     insertEvents([

--- a/api/src/db/__tests__/popular.test.ts
+++ b/api/src/db/__tests__/popular.test.ts
@@ -102,22 +102,38 @@ describe("getPopularShows", () => {
     expect(row!.favorites).toBe(3); // bob, carol, dave (not alice)
   });
 
-  it("respects the min-favorites floor", () => {
+  it("sorts higher-favorites shows above single-favorite shows", () => {
     const t = Date.now() - 86400_000;
     // ts values must differ for the same install — the analytics_events
     // unique index is (iid, sid, event, ts), so two same-ts events from
     // alice would dedupe to one.
     insertEvents([
-      // show-Y: 1 favorite — below the default floor of 2
+      // show-Y: 1 favorite (recently added)
       favAction("alice", "show-Y", "add_favorite", t),
-      // show-Z: 2 favorites — meets the floor
+      // show-Z: 2 favorites
       favAction("alice", "show-Z", "add_favorite", t + 1000),
       favAction("bob", "show-Z", "add_favorite", t),
     ]);
 
     const ids = getPopularShows(10).shows.map((s) => s.show_id);
-    expect(ids).toContain("show-Z");
-    expect(ids).not.toContain("show-Y");
+    // Both surface at floor=1, but the 2-favorite show is pinned first.
+    expect(ids[0]).toBe("show-Z");
+    expect(ids).toContain("show-Y");
+  });
+
+  it("orders single-favorite shows by recency of the last favorite action", () => {
+    // Among shows tied on favorites count, the recency tiebreaker keeps
+    // the rail from feeling static — the most recently favorited shows
+    // float toward the top.
+    const t = Date.now() - 86400_000;
+    insertEvents([
+      favAction("alice", "show-old", "add_favorite", t),
+      favAction("bob", "show-recent", "add_favorite", t + 60_000),
+      favAction("carol", "show-newest", "add_favorite", t + 120_000),
+    ]);
+
+    const ids = getPopularShows(10).shows.map((s) => s.show_id);
+    expect(ids).toEqual(["show-newest", "show-recent", "show-old"]);
   });
 
   it("ignores legacy NULL-target_type favorites (unrecoverable)", () => {

--- a/api/src/db/__tests__/popular.test.ts
+++ b/api/src/db/__tests__/popular.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+
+const TMP_DB = path.join(
+  os.tmpdir(),
+  `popular-test-${process.pid}-${Date.now()}.db`,
+);
+process.env.ANALYTICS_DB_PATH = TMP_DB;
+
+const {
+  getAnalyticsDb,
+  insertEvents,
+  getPopularShows,
+  closeAnalyticsDb,
+} = await import("../analytics.js");
+
+function favAction(
+  iid: string,
+  showId: string,
+  feature: "add_favorite" | "remove_favorite",
+  ts: number,
+  targetType: "show" | "recording_track" | null = "show",
+) {
+  return {
+    event: "feature_use",
+    ts,
+    iid,
+    sid: `${iid}-s1`,
+    platform: "ios",
+    app_version: "2.30.0",
+    props: {
+      feature,
+      category: "action",
+      target_type: targetType,
+      target_id: showId,
+    },
+  };
+}
+
+function play(iid: string, showId: string, ts: number, trackIndex = 0) {
+  return {
+    event: "playback_start",
+    ts,
+    iid,
+    sid: `${iid}-s1`,
+    platform: "ios",
+    app_version: "2.30.0",
+    props: { show_id: showId, track_index: trackIndex },
+  };
+}
+
+beforeEach(() => {
+  const db = getAnalyticsDb();
+  db.exec(`DELETE FROM analytics_events; DELETE FROM show_listens_rollup;`);
+});
+
+afterAll(() => {
+  closeAnalyticsDb();
+  if (fs.existsSync(TMP_DB)) fs.unlinkSync(TMP_DB);
+});
+
+describe("getPopularShows", () => {
+  it("ranks by favorites/listens ratio; high-ratio show beats high-play show", () => {
+    const t = Date.now() - 86400_000;
+    insertEvents([
+      // show-A: 2 distinct favorites, 1 listen → ratio 2.0
+      favAction("alice", "show-A", "add_favorite", t),
+      favAction("bob", "show-A", "add_favorite", t),
+      play("alice", "show-A", t + 100),
+      // show-B: 2 favorites, 10 listens → ratio 0.2
+      favAction("carol", "show-B", "add_favorite", t),
+      favAction("dave", "show-B", "add_favorite", t),
+      ...Array.from({ length: 10 }, (_, i) =>
+        play(`listener${i}`, "show-B", t + i * 1000),
+      ),
+    ]);
+
+    const ids = getPopularShows(10).shows.map((s) => s.show_id);
+    expect(ids[0]).toBe("show-A");
+    expect(ids[1]).toBe("show-B");
+  });
+
+  it("nets out add-then-remove favorites (last action wins)", () => {
+    const t = Date.now() - 86400_000;
+    insertEvents([
+      // alice: add then remove → net 0
+      favAction("alice", "show-X", "add_favorite", t),
+      favAction("alice", "show-X", "remove_favorite", t + 1000),
+      // bob: add only → net 1
+      favAction("bob", "show-X", "add_favorite", t),
+      // carol: remove then re-add → net 1
+      favAction("carol", "show-X", "remove_favorite", t),
+      favAction("carol", "show-X", "add_favorite", t + 1000),
+      // dave: just an add to satisfy the floor
+      favAction("dave", "show-X", "add_favorite", t),
+    ]);
+
+    const row = getPopularShows(10).shows.find((s) => s.show_id === "show-X");
+    expect(row).toBeDefined();
+    expect(row!.favorites).toBe(3); // bob, carol, dave (not alice)
+  });
+
+  it("respects the min-favorites floor", () => {
+    const t = Date.now() - 86400_000;
+    // ts values must differ for the same install — the analytics_events
+    // unique index is (iid, sid, event, ts), so two same-ts events from
+    // alice would dedupe to one.
+    insertEvents([
+      // show-Y: 1 favorite — below the default floor of 2
+      favAction("alice", "show-Y", "add_favorite", t),
+      // show-Z: 2 favorites — meets the floor
+      favAction("alice", "show-Z", "add_favorite", t + 1000),
+      favAction("bob", "show-Z", "add_favorite", t),
+    ]);
+
+    const ids = getPopularShows(10).shows.map((s) => s.show_id);
+    expect(ids).toContain("show-Z");
+    expect(ids).not.toContain("show-Y");
+  });
+
+  it("ignores legacy NULL-target_type favorites (unrecoverable)", () => {
+    const t = Date.now() - 86400_000;
+    insertEvents([
+      favAction("alice", "show-Legacy", "add_favorite", t, null),
+      favAction("bob", "show-Legacy", "add_favorite", t, null),
+    ]);
+
+    expect(getPopularShows(10).shows).toEqual([]);
+  });
+
+  it("ignores recording_track favorites (Unit 3 territory)", () => {
+    const t = Date.now() - 86400_000;
+    insertEvents([
+      favAction("alice", "gd1977-05-08.../03", "add_favorite", t, "recording_track"),
+      favAction("bob", "gd1977-05-08.../03", "add_favorite", t, "recording_track"),
+    ]);
+
+    expect(getPopularShows(10).shows).toEqual([]);
+  });
+
+  it("counts logical listens (not raw playback_start) per show", () => {
+    // Same listener firing 5 starts on the same show within an hour =
+    // 1 logical listen. The rail's denominator should reflect that.
+    const t = Date.now() - 86400_000;
+    insertEvents([
+      favAction("alice", "show-L", "add_favorite", t),
+      favAction("bob", "show-L", "add_favorite", t),
+      // alice listens to 5 tracks of show-L back-to-back
+      play("alice", "show-L", t + 100, 0),
+      play("alice", "show-L", t + 200, 1),
+      play("alice", "show-L", t + 300, 2),
+      play("alice", "show-L", t + 400, 3),
+      play("alice", "show-L", t + 500, 4),
+    ]);
+
+    const row = getPopularShows(10).shows.find((s) => s.show_id === "show-L");
+    expect(row!.listens).toBe(1);
+    expect(row!.favorites).toBe(2);
+    expect(row!.ratio).toBe(2);
+  });
+});

--- a/api/src/db/__tests__/popular.test.ts
+++ b/api/src/db/__tests__/popular.test.ts
@@ -16,6 +16,12 @@ const {
   closeAnalyticsDb,
 } = await import("../analytics.js");
 
+// Pin to a single rotation window for deterministic shuffles. Picked
+// arbitrarily — any fixed instant works.
+const FIXED_NOW = Date.parse("2026-05-27T12:00:00Z");
+const ROTATION_HOURS = 4;
+const BUCKET_MS = ROTATION_HOURS * 3600 * 1000;
+
 function favAction(
   iid: string,
   showId: string,
@@ -51,6 +57,34 @@ function play(iid: string, showId: string, ts: number, trackIndex = 0) {
   };
 }
 
+/** Build a show_id whose decade matches. */
+function showId(year: number, slug = "01"): string {
+  return `gd${year}-06-${slug}.sbd.miller`;
+}
+
+/** Seed `count` shows in a single decade with `favsPerShow` distinct favoriters. */
+function seedDecade(
+  decadeYears: number[],
+  favsPerShow: number,
+  baseTs: number,
+) {
+  const events: ReturnType<typeof favAction>[] = [];
+  let ev = 0;
+  for (const year of decadeYears) {
+    for (let f = 0; f < favsPerShow; f++) {
+      events.push(
+        favAction(
+          `user-${year}-${f}`,
+          showId(year, String(year).slice(-2)),
+          "add_favorite",
+          baseTs + ev++,
+        ),
+      );
+    }
+  }
+  return events;
+}
+
 beforeEach(() => {
   const db = getAnalyticsDb();
   db.exec(`DELETE FROM analytics_events; DELETE FROM show_listens_rollup;`);
@@ -61,117 +95,235 @@ afterAll(() => {
   if (fs.existsSync(TMP_DB)) fs.unlinkSync(TMP_DB);
 });
 
-describe("getPopularShows", () => {
-  it("ranks by favorites/listens ratio; high-ratio show beats high-play show", () => {
-    const t = Date.now() - 86400_000;
+describe("getPopularShows — per-decade pools", () => {
+  it("buckets slug-format show_ids (no `gd` prefix) — the prod format", () => {
+    const t = FIXED_NOW - 86400_000;
     insertEvents([
-      // show-A: 2 distinct favorites, 1 listen → ratio 2.0
-      favAction("alice", "show-A", "add_favorite", t),
-      favAction("bob", "show-A", "add_favorite", t),
-      play("alice", "show-A", t + 100),
-      // show-B: 2 favorites, 10 listens → ratio 0.2
-      favAction("carol", "show-B", "add_favorite", t),
-      favAction("dave", "show-B", "add_favorite", t),
-      ...Array.from({ length: 10 }, (_, i) =>
-        play(`listener${i}`, "show-B", t + i * 1000),
-      ),
+      favAction("alice", "1977-05-11-st-paul-civic-center-st-paul-mn-usa", "add_favorite", t),
+      favAction("bob",   "1977-05-11-st-paul-civic-center-st-paul-mn-usa", "add_favorite", t + 1),
+      favAction("carol", "1969-04-05-avalon-ballroom-san-francisco-ca-usa", "add_favorite", t + 2),
+      favAction("dave",  "1969-04-05-avalon-ballroom-san-francisco-ca-usa", "add_favorite", t + 3),
     ]);
 
-    const ids = getPopularShows(10).shows.map((s) => s.show_id);
-    expect(ids[0]).toBe("show-A");
-    expect(ids[1]).toBe("show-B");
+    const { decades } = getPopularShows({
+      nowMs: FIXED_NOW,
+      minFavorites: 2,
+      perDecade: 8,
+      rotationHours: ROTATION_HOURS,
+    });
+
+    expect(decades["70s"].map((s) => s.show_id)).toContain(
+      "1977-05-11-st-paul-civic-center-st-paul-mn-usa",
+    );
+    expect(decades["60s"].map((s) => s.show_id)).toContain(
+      "1969-04-05-avalon-ballroom-san-francisco-ca-usa",
+    );
+  });
+
+  it("buckets shows into 60s/70s/80s/90s by show_id year", () => {
+    const t = FIXED_NOW - 86400_000;
+    insertEvents([
+      ...seedDecade([1968], 2, t),
+      ...seedDecade([1977], 2, t + 1000),
+      ...seedDecade([1985], 2, t + 2000),
+      ...seedDecade([1993], 2, t + 3000),
+    ]);
+
+    const { decades } = getPopularShows({
+      nowMs: FIXED_NOW,
+      minFavorites: 2,
+      perDecade: 8,
+      rotationHours: ROTATION_HOURS,
+    });
+
+    expect(decades["60s"].map((s) => s.show_id)).toEqual([showId(1968, "68")]);
+    expect(decades["70s"].map((s) => s.show_id)).toEqual([showId(1977, "77")]);
+    expect(decades["80s"].map((s) => s.show_id)).toEqual([showId(1985, "85")]);
+    expect(decades["90s"].map((s) => s.show_id)).toEqual([showId(1993, "93")]);
+    // Response no longer carries an `all` bucket — the client computes it.
+    expect("all" in decades).toBe(false);
+  });
+
+  it("enforces the minFavorites floor server-side", () => {
+    const t = FIXED_NOW - 86400_000;
+    insertEvents([
+      // One favoriter — should be filtered when floor=2
+      favAction("alice", showId(1977, "77"), "add_favorite", t),
+      // Two favoriters — passes the floor
+      favAction("alice", showId(1978, "78"), "add_favorite", t + 1),
+      favAction("bob",   showId(1978, "78"), "add_favorite", t + 2),
+    ]);
+
+    const { decades } = getPopularShows({
+      nowMs: FIXED_NOW,
+      minFavorites: 2,
+      perDecade: 8,
+      rotationHours: ROTATION_HOURS,
+    });
+
+    expect(decades["70s"].map((s) => s.show_id)).toEqual([showId(1978, "78")]);
+  });
+
+  it("caps each decade pool at perDecade", () => {
+    const t = FIXED_NOW - 86400_000;
+    // 10 shows in the 70s, all qualifying
+    const years = [1970, 1971, 1972, 1973, 1974, 1975, 1976, 1977, 1978, 1979];
+    insertEvents(seedDecade(years, 2, t));
+
+    const { decades } = getPopularShows({
+      nowMs: FIXED_NOW,
+      minFavorites: 2,
+      perDecade: 5,
+      rotationHours: ROTATION_HOURS,
+    });
+
+    expect(decades["70s"]).toHaveLength(5);
+    // Pool order is shuffled (client picks + sorts); we don't assert order.
+  });
+
+  it("returns the same sample within a rotation window", () => {
+    const t = FIXED_NOW - 86400_000;
+    const years = Array.from({ length: 20 }, (_, i) => 1970 + (i % 10));
+    insertEvents(
+      years.flatMap((y, i) => [
+        favAction(`a${i}`, showId(y, String(i).padStart(2, "0")), "add_favorite", t + i * 2),
+        favAction(`b${i}`, showId(y, String(i).padStart(2, "0")), "add_favorite", t + i * 2 + 1),
+      ]),
+    );
+
+    const a = getPopularShows({
+      nowMs: FIXED_NOW,
+      minFavorites: 2,
+      perDecade: 5,
+      rotationHours: ROTATION_HOURS,
+    });
+    const b = getPopularShows({
+      nowMs: FIXED_NOW + BUCKET_MS - 1, // same bucket
+      minFavorites: 2,
+      perDecade: 5,
+      rotationHours: ROTATION_HOURS,
+    });
+
+    expect(b.decades["70s"].map((s) => s.show_id)).toEqual(
+      a.decades["70s"].map((s) => s.show_id),
+    );
+  });
+
+  it("returns a different sample once the rotation window rolls", () => {
+    const t = FIXED_NOW - 86400_000;
+    // Enough shows that the shuffled top-N is very unlikely to coincide
+    // across two seeds by accident.
+    const events: ReturnType<typeof favAction>[] = [];
+    for (let i = 0; i < 30; i++) {
+      const year = 1970 + (i % 10);
+      const id = showId(year, String(i).padStart(2, "0"));
+      events.push(favAction(`a${i}`, id, "add_favorite", t + i * 2));
+      events.push(favAction(`b${i}`, id, "add_favorite", t + i * 2 + 1));
+    }
+    insertEvents(events);
+
+    const a = getPopularShows({
+      nowMs: FIXED_NOW,
+      minFavorites: 2,
+      perDecade: 5,
+      rotationHours: ROTATION_HOURS,
+    });
+    const b = getPopularShows({
+      nowMs: FIXED_NOW + BUCKET_MS, // next bucket
+      minFavorites: 2,
+      perDecade: 5,
+      rotationHours: ROTATION_HOURS,
+    });
+
+    const sampleA = a.decades["70s"].map((s) => s.show_id);
+    const sampleB = b.decades["70s"].map((s) => s.show_id);
+    expect(sampleB).not.toEqual(sampleA);
+  });
+
+  it("returns empty pools for decades with no qualifying shows", () => {
+    const t = FIXED_NOW - 86400_000;
+    insertEvents([
+      ...seedDecade([1977], 2, t),
+      ...seedDecade([1985], 2, t + 100),
+    ]);
+
+    const { decades } = getPopularShows({
+      nowMs: FIXED_NOW,
+      minFavorites: 2,
+      perDecade: 8,
+      rotationHours: ROTATION_HOURS,
+    });
+
+    expect(decades["70s"]).toHaveLength(1);
+    expect(decades["80s"]).toHaveLength(1);
+    expect(decades["60s"]).toEqual([]);
+    expect(decades["90s"]).toEqual([]);
   });
 
   it("nets out add-then-remove favorites (last action wins)", () => {
-    const t = Date.now() - 86400_000;
+    const t = FIXED_NOW - 86400_000;
+    const id = showId(1977, "77");
     insertEvents([
       // alice: add then remove → net 0
-      favAction("alice", "show-X", "add_favorite", t),
-      favAction("alice", "show-X", "remove_favorite", t + 1000),
+      favAction("alice", id, "add_favorite", t),
+      favAction("alice", id, "remove_favorite", t + 1000),
       // bob: add only → net 1
-      favAction("bob", "show-X", "add_favorite", t),
+      favAction("bob", id, "add_favorite", t),
       // carol: remove then re-add → net 1
-      favAction("carol", "show-X", "remove_favorite", t),
-      favAction("carol", "show-X", "add_favorite", t + 1000),
-      // dave: just an add to satisfy the floor
-      favAction("dave", "show-X", "add_favorite", t),
+      favAction("carol", id, "remove_favorite", t),
+      favAction("carol", id, "add_favorite", t + 1000),
     ]);
 
-    const row = getPopularShows(10).shows.find((s) => s.show_id === "show-X");
+    const { decades } = getPopularShows({
+      nowMs: FIXED_NOW,
+      minFavorites: 2,
+      perDecade: 8,
+      rotationHours: ROTATION_HOURS,
+    });
+    const row = decades["70s"].find((s) => s.show_id === id);
     expect(row).toBeDefined();
-    expect(row!.favorites).toBe(3); // bob, carol, dave (not alice)
+    expect(row!.favorites).toBe(2); // bob, carol (not alice)
   });
 
-  it("sorts higher-favorites shows above single-favorite shows", () => {
-    const t = Date.now() - 86400_000;
-    // ts values must differ for the same install — the analytics_events
-    // unique index is (iid, sid, event, ts), so two same-ts events from
-    // alice would dedupe to one.
+  it("ignores legacy NULL-target_type favorites and recording_track favorites", () => {
+    const t = FIXED_NOW - 86400_000;
     insertEvents([
-      // show-Y: 1 favorite (recently added)
-      favAction("alice", "show-Y", "add_favorite", t),
-      // show-Z: 2 favorites
-      favAction("alice", "show-Z", "add_favorite", t + 1000),
-      favAction("bob", "show-Z", "add_favorite", t),
+      favAction("alice", showId(1977, "77"), "add_favorite", t, null),
+      favAction("bob",   showId(1977, "77"), "add_favorite", t + 1, null),
+      favAction("alice", "gd1977-05-08.../03", "add_favorite", t + 2, "recording_track"),
+      favAction("bob",   "gd1977-05-08.../03", "add_favorite", t + 3, "recording_track"),
     ]);
 
-    const ids = getPopularShows(10).shows.map((s) => s.show_id);
-    // Both surface at floor=1, but the 2-favorite show is pinned first.
-    expect(ids[0]).toBe("show-Z");
-    expect(ids).toContain("show-Y");
-  });
-
-  it("orders single-favorite shows by recency of the last favorite action", () => {
-    // Among shows tied on favorites count, the recency tiebreaker keeps
-    // the rail from feeling static — the most recently favorited shows
-    // float toward the top.
-    const t = Date.now() - 86400_000;
-    insertEvents([
-      favAction("alice", "show-old", "add_favorite", t),
-      favAction("bob", "show-recent", "add_favorite", t + 60_000),
-      favAction("carol", "show-newest", "add_favorite", t + 120_000),
-    ]);
-
-    const ids = getPopularShows(10).shows.map((s) => s.show_id);
-    expect(ids).toEqual(["show-newest", "show-recent", "show-old"]);
-  });
-
-  it("ignores legacy NULL-target_type favorites (unrecoverable)", () => {
-    const t = Date.now() - 86400_000;
-    insertEvents([
-      favAction("alice", "show-Legacy", "add_favorite", t, null),
-      favAction("bob", "show-Legacy", "add_favorite", t, null),
-    ]);
-
-    expect(getPopularShows(10).shows).toEqual([]);
-  });
-
-  it("ignores recording_track favorites (Unit 3 territory)", () => {
-    const t = Date.now() - 86400_000;
-    insertEvents([
-      favAction("alice", "gd1977-05-08.../03", "add_favorite", t, "recording_track"),
-      favAction("bob", "gd1977-05-08.../03", "add_favorite", t, "recording_track"),
-    ]);
-
-    expect(getPopularShows(10).shows).toEqual([]);
+    const { decades } = getPopularShows({
+      nowMs: FIXED_NOW,
+      minFavorites: 2,
+      perDecade: 8,
+      rotationHours: ROTATION_HOURS,
+    });
+    expect(decades["70s"]).toEqual([]);
   });
 
   it("counts logical listens (not raw playback_start) per show", () => {
-    // Same listener firing 5 starts on the same show within an hour =
-    // 1 logical listen. The rail's denominator should reflect that.
-    const t = Date.now() - 86400_000;
+    const t = FIXED_NOW - 86400_000;
+    const id = showId(1977, "77");
     insertEvents([
-      favAction("alice", "show-L", "add_favorite", t),
-      favAction("bob", "show-L", "add_favorite", t),
-      // alice listens to 5 tracks of show-L back-to-back
-      play("alice", "show-L", t + 100, 0),
-      play("alice", "show-L", t + 200, 1),
-      play("alice", "show-L", t + 300, 2),
-      play("alice", "show-L", t + 400, 3),
-      play("alice", "show-L", t + 500, 4),
+      favAction("alice", id, "add_favorite", t),
+      favAction("bob",   id, "add_favorite", t + 1),
+      // alice listens to 5 tracks of the show back-to-back
+      play("alice", id, t + 100, 0),
+      play("alice", id, t + 200, 1),
+      play("alice", id, t + 300, 2),
+      play("alice", id, t + 400, 3),
+      play("alice", id, t + 500, 4),
     ]);
 
-    const row = getPopularShows(10).shows.find((s) => s.show_id === "show-L");
+    const { decades } = getPopularShows({
+      nowMs: FIXED_NOW,
+      minFavorites: 2,
+      perDecade: 8,
+      rotationHours: ROTATION_HOURS,
+    });
+    const row = decades["70s"].find((s) => s.show_id === id);
     expect(row!.listens).toBe(1);
     expect(row!.favorites).toBe(2);
     expect(row!.ratio).toBe(2);

--- a/api/src/db/analytics.ts
+++ b/api/src/db/analytics.ts
@@ -1954,6 +1954,132 @@ export function getTrending(
   };
 }
 
+// ── Popular shows (favorites-driven) ──────────────────────────────────
+
+export interface PopularShow {
+  show_id: string;
+  /** Distinct installs whose latest favorite action on this show is `add`
+   *  (i.e. currently favorited — adds minus subsequent removes). */
+  favorites: number;
+  /** All-time logical listens from show_listens_rollup. */
+  listens: number;
+  /**
+   * favorites / max(listens, 1). The differentiator from Trending: surfaces
+   * shows people *kept*, not shows people *played a lot*. A high ratio
+   * means a high fraction of people who heard it favorited it.
+   */
+  ratio: number;
+}
+
+export interface PopularResponse {
+  generated_at: string;
+  shows: PopularShow[];
+}
+
+/** Default minimum distinct favoriters required to surface a show. Set
+ *  low — current install base is small and a higher floor produces a
+ *  near-empty rail. Revisit as volume grows. */
+const POPULAR_MIN_FAVORITES = 2;
+
+/**
+ * "Popular" shows ranked by retention signal — net favorites (adds minus
+ * subsequent removes per install), divided by all-time logical listens to
+ * favor shows people *kept* over shows that just got tapped a lot.
+ *
+ * `target_type` filter:
+ *   - 'show' → this surface (Unit 2).
+ *   - 'recording_track' → reserved for the future "Best …" rail (Unit 3).
+ *   - NULL → legacy events emitted before target_type was added, which
+ *     also have no target_id. Unrecoverable; filtered out implicitly by
+ *     the IS NOT NULL on target_id.
+ */
+export function getPopularShows(limit = 10): PopularResponse {
+  const db = getAnalyticsDb();
+
+  // Listens are computed inline (not from show_listens_rollup) because the
+  // rollup only retains the top-50 per window — favorited shows outside
+  // the top-50 listened set would otherwise read `listens = 0` and skew
+  // the ratio. The CTE mirrors rebuildShowListensRollup's logical-listen
+  // definition: count distinct "listen runs" per (iid, show_id), where a
+  // run is broken either by a different show or a gap > LISTEN_GAP_MS.
+  const shows = db
+    .prepare(
+      `WITH actions AS (
+         SELECT
+           iid,
+           json_extract(props, '$.target_id') AS show_id,
+           json_extract(props, '$.feature')   AS feature,
+           ts
+         FROM analytics_events
+         WHERE event = 'feature_use'
+           AND json_extract(props, '$.target_type') = 'show'
+           AND json_extract(props, '$.feature') IN ('add_favorite', 'remove_favorite')
+           AND json_extract(props, '$.target_id') IS NOT NULL
+       ),
+       latest AS (
+         -- For each (iid, show_id) keep only the most recent action.
+         -- An install who added then removed nets to a "remove" and is
+         -- excluded; one who removed then re-added nets to "add".
+         SELECT iid, show_id, feature
+         FROM actions a
+         WHERE a.ts = (
+           SELECT MAX(a2.ts) FROM actions a2
+           WHERE a2.iid = a.iid AND a2.show_id = a.show_id
+         )
+       ),
+       favs AS (
+         SELECT show_id, COUNT(DISTINCT iid) AS favorites
+         FROM latest
+         WHERE feature = 'add_favorite'
+         GROUP BY show_id
+         HAVING favorites >= ?
+       ),
+       plays AS (
+         SELECT iid,
+                json_extract(props, '$.show_id') AS show_id,
+                ts,
+                LAG(json_extract(props, '$.show_id')) OVER w AS prev_show,
+                LAG(ts)                              OVER w AS prev_ts
+         FROM analytics_events
+         WHERE event = 'playback_start'
+           AND json_extract(props, '$.show_id') IN (SELECT show_id FROM favs)
+         WINDOW w AS (PARTITION BY iid ORDER BY ts)
+       ),
+       listen_runs AS (
+         SELECT show_id,
+                CASE
+                  WHEN prev_show IS NULL
+                    OR prev_show != show_id
+                    OR (ts - prev_ts) > ?
+                  THEN 1 ELSE 0
+                END AS is_new
+         FROM plays
+       ),
+       show_listens AS (
+         SELECT show_id, SUM(is_new) AS listens
+         FROM listen_runs
+         GROUP BY show_id
+       )
+       SELECT
+         f.show_id,
+         f.favorites,
+         COALESCE(sl.listens, 0) AS listens,
+         CAST(f.favorites AS REAL) /
+           CASE WHEN COALESCE(sl.listens, 0) > 0 THEN sl.listens ELSE 1 END
+           AS ratio
+       FROM favs f
+       LEFT JOIN show_listens sl ON sl.show_id = f.show_id
+       ORDER BY ratio DESC, f.favorites DESC, listens DESC
+       LIMIT ?`,
+    )
+    .all(POPULAR_MIN_FAVORITES, LISTEN_GAP_MS, limit) as PopularShow[];
+
+  return {
+    generated_at: new Date().toISOString(),
+    shows,
+  };
+}
+
 // ── Cleanup ──────────────────────────────────────────────────────────
 
 export function closeAnalyticsDb(): void {

--- a/api/src/db/analytics.ts
+++ b/api/src/db/analytics.ts
@@ -1419,6 +1419,161 @@ export function getRecentListening(
   }));
 }
 
+// ── Network error outcomes ────────────────────────────────────────────
+
+export type NetworkErrorOutcome =
+  | "recover_same_track"
+  | "skipped_to_next"
+  | "skipped_ahead"
+  | "jumped_back"
+  | "next_event_is_end"
+  | "no_followup";
+
+export interface NetworkErrorSummary {
+  /** Window inspected, in days. */
+  days: number;
+  /** Platform filter applied, or null for all platforms. */
+  platform: string | null;
+  /** Total network_error events in the window. */
+  total: number;
+  /** Count by outcome. */
+  outcomes: Array<{ outcome: NetworkErrorOutcome; count: number; avg_gap_s: number | null }>;
+  /** Most recent N errors with their classified outcome. */
+  recent: Array<{
+    ts: number;
+    iid: string;
+    platform: string;
+    app_version: string;
+    show_id: string | null;
+    recording_id: string | null;
+    track_index: number | null;
+    outcome: NetworkErrorOutcome;
+    /** Seconds until the next playback event for this iid+show, if any. */
+    gap_s: number | null;
+    next_track_index: number | null;
+  }>;
+}
+
+export function getNetworkErrorOutcomes(
+  days = 30,
+  platform: string | null = null,
+  recentLimit = 50,
+): NetworkErrorSummary {
+  const db = getAnalyticsDb();
+  const cutoff = Date.now() - days * 24 * 3600 * 1000;
+
+  // Each network_error end is classified by the next playback_start /
+  // playback_end for the same (iid, show_id) — same logic as the
+  // exploratory query that surfaced the 75%-skip pattern.
+  const classifySql = `
+    WITH ne AS (
+      SELECT id, iid, ts, platform, app_version,
+             json_extract(props, '$.show_id') AS show_id,
+             json_extract(props, '$.recording_id') AS recording_id,
+             CAST(json_extract(props, '$.track_index') AS INTEGER) AS track_index
+      FROM analytics_events
+      WHERE event = 'playback_end'
+        AND json_extract(props, '$.reason') = 'network_error'
+        AND ts >= ?
+        ${platform ? "AND platform = ?" : ""}
+    ),
+    classified AS (
+      SELECT
+        ne.id, ne.iid, ne.ts, ne.platform, ne.app_version,
+        ne.show_id, ne.recording_id, ne.track_index,
+        (SELECT n.event FROM analytics_events n
+           WHERE n.iid = ne.iid AND n.ts > ne.ts
+             AND n.event IN ('playback_start','playback_end')
+             AND json_extract(n.props, '$.show_id') = ne.show_id
+           ORDER BY n.ts LIMIT 1) AS next_event,
+        (SELECT CAST(json_extract(n.props, '$.track_index') AS INTEGER) FROM analytics_events n
+           WHERE n.iid = ne.iid AND n.ts > ne.ts
+             AND n.event IN ('playback_start','playback_end')
+             AND json_extract(n.props, '$.show_id') = ne.show_id
+           ORDER BY n.ts LIMIT 1) AS next_trk,
+        (SELECT (n.ts - ne.ts) / 1000.0 FROM analytics_events n
+           WHERE n.iid = ne.iid AND n.ts > ne.ts
+             AND n.event IN ('playback_start','playback_end')
+             AND json_extract(n.props, '$.show_id') = ne.show_id
+           ORDER BY n.ts LIMIT 1) AS gap_s
+      FROM ne
+    )
+    SELECT
+      id, iid, ts, platform, app_version, show_id, recording_id, track_index,
+      gap_s, next_trk,
+      CASE
+        WHEN next_event IS NULL THEN 'no_followup'
+        WHEN next_event = 'playback_end' THEN 'next_event_is_end'
+        WHEN next_event = 'playback_start' AND next_trk = track_index THEN 'recover_same_track'
+        WHEN next_event = 'playback_start' AND next_trk = track_index + 1 THEN 'skipped_to_next'
+        WHEN next_event = 'playback_start' AND next_trk > track_index + 1 THEN 'skipped_ahead'
+        WHEN next_event = 'playback_start' AND next_trk < track_index THEN 'jumped_back'
+        ELSE 'no_followup'
+      END AS outcome
+    FROM classified
+  `;
+
+  const params: Array<number | string> = [cutoff];
+  if (platform) params.push(platform);
+
+  const all = db.prepare(classifySql).all(...params) as Array<{
+    id: number;
+    iid: string;
+    ts: number;
+    platform: string;
+    app_version: string;
+    show_id: string | null;
+    recording_id: string | null;
+    track_index: number | null;
+    gap_s: number | null;
+    next_trk: number | null;
+    outcome: NetworkErrorOutcome;
+  }>;
+
+  const buckets = new Map<NetworkErrorOutcome, { count: number; gapSum: number; gapN: number }>();
+  for (const r of all) {
+    const b = buckets.get(r.outcome) ?? { count: 0, gapSum: 0, gapN: 0 };
+    b.count++;
+    if (r.gap_s !== null) {
+      b.gapSum += r.gap_s;
+      b.gapN++;
+    }
+    buckets.set(r.outcome, b);
+  }
+  const outcomes = Array.from(buckets.entries())
+    .map(([outcome, b]) => ({
+      outcome,
+      count: b.count,
+      avg_gap_s: b.gapN > 0 ? Math.round((b.gapSum / b.gapN) * 10) / 10 : null,
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  const recent = all
+    .slice()
+    .sort((a, b) => b.ts - a.ts)
+    .slice(0, recentLimit)
+    .map((r) => ({
+      ts: r.ts,
+      iid: r.iid,
+      platform: r.platform,
+      app_version: r.app_version,
+      show_id: r.show_id,
+      recording_id: r.recording_id,
+      track_index: r.track_index,
+      outcome: r.outcome,
+      gap_s: r.gap_s,
+      next_track_index: r.next_trk,
+    }));
+
+  return {
+    days,
+    platform,
+    total: all.length,
+    outcomes,
+    recent,
+  };
+}
+
 export function getShowPlaybackSummary(days: number): ShowPlaybackSummary {
   const db = getAnalyticsDb();
   const cutoff = Date.now() - days * 24 * 3600 * 1000;

--- a/api/src/db/analytics.ts
+++ b/api/src/db/analytics.ts
@@ -831,12 +831,25 @@ export interface LiveListener {
  *   - between tracks: latest is an end within END window           → live
  *   - finished:       latest is an end past END window              → not live
  *
+ * `playback_end` with reason `app_backgrounded` is excluded from the
+ * latest-event picker: backgrounding the app does not stop audio
+ * (locked phone in pocket is the modal listening posture). Treating
+ * those as real ends dropped ~25% of finishes off Live within 2 min
+ * even though playback continued. The preceding `playback_start`
+ * remains the keepalive anchor.
+ *
  * Replaced the earlier single-window approach: a 45-min "unmatched
  * start" rule mis-classified between-tracks users as Recent, and a
  * 90-second soft window dropped mid-jam users out of Live.
  */
 const LIVE_START_WINDOW_MS = 45 * 60 * 1000;
 const LIVE_END_WINDOW_MS = 2 * 60 * 1000;
+
+/** Reasons on `playback_end` that do NOT actually stop audio — exclude
+ *  these from the "latest event" calculation so a backgrounded user
+ *  stays Live until their `playback_start` ages out of the 45-min
+ *  window. */
+const NON_TERMINAL_END_REASONS_SQL = `('app_backgrounded')`;
 
 export function getLiveListeners(): LiveListener[] {
   const db = getAnalyticsDb();
@@ -869,6 +882,10 @@ export function getLiveListeners(): LiveListener[] {
          WHERE event IN ('playback_start', 'playback_end')
            AND ts >= ?
            AND json_extract(props, '$.show_id') IS NOT NULL
+           AND NOT (
+             event = 'playback_end'
+             AND json_extract(props, '$.reason') IN ${NON_TERMINAL_END_REASONS_SQL}
+           )
        )
        SELECT
          l.iid,
@@ -1344,11 +1361,19 @@ export function getRecentListening(
          WHERE latest.event IN ('playback_start', 'playback_end')
            AND latest.iid = a.iid
            AND json_extract(latest.props, '$.show_id') = a.show_id
+           AND NOT (
+             latest.event = 'playback_end'
+             AND json_extract(latest.props, '$.reason') IN ${NON_TERMINAL_END_REASONS_SQL}
+           )
            AND latest.ts = (
              SELECT MAX(x.ts) FROM analytics_events x
              WHERE x.event IN ('playback_start', 'playback_end')
                AND x.iid = a.iid
                AND x.ts >= ?
+               AND NOT (
+                 x.event = 'playback_end'
+                 AND json_extract(x.props, '$.reason') IN ${NON_TERMINAL_END_REASONS_SQL}
+               )
            )
            AND (
              (latest.event = 'playback_start' AND latest.ts >= ?)

--- a/api/src/db/analytics.ts
+++ b/api/src/db/analytics.ts
@@ -1981,22 +1981,114 @@ export interface PopularShow {
   ratio: number;
 }
 
-export interface PopularResponse {
-  generated_at: string;
-  shows: PopularShow[];
+export type PopularDecade = "60s" | "70s" | "80s" | "90s";
+
+export interface PopularDecadeBuckets {
+  "60s": PopularShow[];
+  "70s": PopularShow[];
+  "80s": PopularShow[];
+  "90s": PopularShow[];
 }
 
-/** Default minimum distinct favoriters required to surface a show.
- *  Floor=1 in the early stage: with a small install base, requiring 2+
- *  produces a near-empty rail. Recency-ordered tiebreakers keep the
- *  list feeling fresh rather than dumping all 1-favorite shows in
- *  arbitrary order. Raise as volume grows. */
-const POPULAR_MIN_FAVORITES = 1;
+export interface PopularResponse {
+  generated_at: string;
+  decades: PopularDecadeBuckets;
+}
+
+export interface PopularOptions {
+  /** Override Date.now() for deterministic tests. */
+  nowMs?: number;
+  /** Minimum distinct favoriters required to surface a show in the pool. */
+  minFavorites?: number;
+  /** Target sample size drawn from each decade's qualifying pool. */
+  perDecade?: number;
+  /** Rotation window in hours — the time bucket that seeds the shuffle. */
+  rotationHours?: number;
+}
+
+function envNum(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+// Server-tunable so we don't need an app release to retune the rail.
+// Floor stays at 1 in the early stage — current prod data has most shows
+// sitting at 1–2 favoriters, so floor=2 produces empty buckets. Raise via
+// env var once volume grows.
+const POPULAR_MIN_FAVORITES = envNum("POPULAR_MIN_FAVORITES", 1);
+/** Per-decade pool size returned to the client. The client picks 4
+ *  display shows from these pools and re-rolls on "Show more" without
+ *  another round trip, so we want a healthy pool but not the whole tail. */
+const POPULAR_PER_DECADE = envNum("POPULAR_PER_DECADE", 20);
+const POPULAR_ROTATION_HOURS = envNum("POPULAR_ROTATION_HOURS", 4);
+
+const DECADE_KEYS = ["60s", "70s", "80s", "90s"] as const;
+type DecadeKey = (typeof DECADE_KEYS)[number];
+
+function decadeOf(showId: string): DecadeKey | null {
+  // Two show_id formats in the wild:
+  //   - slug:   "1977-05-11-st-paul-civic-center-..." (prod canonical)
+  //   - legacy: "gd1977-05-11.sbd.miller..." (older / test fixtures)
+  // Pull the first 4-digit run regardless of any leading prefix.
+  const m = showId.match(/(\d{4})/);
+  if (!m) return null;
+  const year = parseInt(m[1]!, 10);
+  if (year >= 1960 && year < 1970) return "60s";
+  if (year >= 1970 && year < 1980) return "70s";
+  if (year >= 1980 && year < 1990) return "80s";
+  if (year >= 1990 && year < 2000) return "90s";
+  return null;
+}
+
+/** Sortable date key (`YYYY-MM-DD`) extracted from either show_id format. */
+function dateKey(showId: string): string {
+  const m = showId.match(/(\d{4}-\d{2}-\d{2})/);
+  return m ? m[1]! : showId;
+}
+
+// mulberry32 — small, fast, deterministic PRNG. Good enough for shuffle.
+function mulberry32(seed: number): () => number {
+  let s = seed | 0;
+  return function () {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function seededShuffle<T>(arr: readonly T[], seed: number): T[] {
+  const rng = mulberry32(seed);
+  const out = arr.slice();
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    const tmp = out[i]!;
+    out[i] = out[j]!;
+    out[j] = tmp;
+  }
+  return out;
+}
+
+/** Hash the (bucket index, decade) pair into a 32-bit seed. */
+function decadeSeed(bucket: number, decade: string): number {
+  let h = (bucket * 0x01000193) | 0;
+  for (let i = 0; i < decade.length; i++) {
+    h = Math.imul(h ^ decade.charCodeAt(i), 0x01000193) | 0;
+  }
+  return h >>> 0;
+}
 
 /**
- * "Popular" shows ranked by retention signal — net favorites (adds minus
- * subsequent removes per install), divided by all-time logical listens to
- * favor shows people *kept* over shows that just got tapped a lot.
+ * "Popular" shows surfaced as four decade *pools* (60s/70s/80s/90s). Each
+ * pool is `perDecade` shows drawn via a uniform shuffle seeded by the
+ * current rotation window, so the underlying pool is stable for
+ * ~`rotationHours` and rotates on its own. The client picks the 4-show
+ * display set from these pools and re-rolls on "Show more" without
+ * another round trip — that's why the server returns pools, not a
+ * pre-picked display set.
  *
  * `target_type` filter:
  *   - 'show' → this surface (Unit 2).
@@ -2005,8 +2097,12 @@ const POPULAR_MIN_FAVORITES = 1;
  *     also have no target_id. Unrecoverable; filtered out implicitly by
  *     the IS NOT NULL on target_id.
  */
-export function getPopularShows(limit = 10): PopularResponse {
+export function getPopularShows(options: PopularOptions = {}): PopularResponse {
   const db = getAnalyticsDb();
+  const nowMs = options.nowMs ?? Date.now();
+  const minFavorites = options.minFavorites ?? POPULAR_MIN_FAVORITES;
+  const perDecade = options.perDecade ?? POPULAR_PER_DECADE;
+  const rotationHours = options.rotationHours ?? POPULAR_ROTATION_HOURS;
 
   // Listens are computed inline (not from show_listens_rollup) because the
   // rollup only retains the top-50 per window — favorited shows outside
@@ -2014,7 +2110,7 @@ export function getPopularShows(limit = 10): PopularResponse {
   // the ratio. The CTE mirrors rebuildShowListensRollup's logical-listen
   // definition: count distinct "listen runs" per (iid, show_id), where a
   // run is broken either by a different show or a gap > LISTEN_GAP_MS.
-  const shows = db
+  const pool = db
     .prepare(
       `WITH actions AS (
          SELECT
@@ -2029,9 +2125,6 @@ export function getPopularShows(limit = 10): PopularResponse {
            AND json_extract(props, '$.target_id') IS NOT NULL
        ),
        latest AS (
-         -- For each (iid, show_id) keep only the most recent action.
-         -- An install who added then removed nets to a "remove" and is
-         -- excluded; one who removed then re-added nets to "add".
          SELECT iid, show_id, feature, ts
          FROM actions a
          WHERE a.ts = (
@@ -2042,8 +2135,7 @@ export function getPopularShows(limit = 10): PopularResponse {
        favs AS (
          SELECT
            show_id,
-           COUNT(DISTINCT iid) AS favorites,
-           MAX(ts) AS last_favorite_ts
+           COUNT(DISTINCT iid) AS favorites
          FROM latest
          WHERE feature = 'add_favorite'
          GROUP BY show_id
@@ -2083,19 +2175,39 @@ export function getPopularShows(limit = 10): PopularResponse {
            CASE WHEN COALESCE(sl.listens, 0) > 0 THEN sl.listens ELSE 1 END
            AS ratio
        FROM favs f
-       LEFT JOIN show_listens sl ON sl.show_id = f.show_id
-       -- favorites DESC keeps the genuinely-popular shows (2+ favoriters)
-       -- pinned at the top; recency tiebreaker keeps the rail feeling
-       -- fresh in the long single-favorite tail. Pure random would shuffle
-       -- the list on every refresh and feel unstable.
-       ORDER BY f.favorites DESC, f.last_favorite_ts DESC, ratio DESC
-       LIMIT ?`,
+       LEFT JOIN show_listens sl ON sl.show_id = f.show_id`,
     )
-    .all(POPULAR_MIN_FAVORITES, LISTEN_GAP_MS, limit) as PopularShow[];
+    .all(minFavorites, LISTEN_GAP_MS) as PopularShow[];
+
+  const byDecade: Record<DecadeKey, PopularShow[]> = {
+    "60s": [],
+    "70s": [],
+    "80s": [],
+    "90s": [],
+  };
+  for (const row of pool) {
+    const d = decadeOf(row.show_id);
+    if (d) byDecade[d].push(row);
+  }
+
+  const bucket = Math.floor(nowMs / (rotationHours * 3600 * 1000));
+  const buckets: PopularDecadeBuckets = {
+    "60s": [],
+    "70s": [],
+    "80s": [],
+    "90s": [],
+  };
+  for (const d of DECADE_KEYS) {
+    // Stable per-rotation shuffle, then take the per-decade pool. The
+    // client picks the 4-show display set from these pools and re-rolls
+    // on "Show more" without another round trip.
+    const shuffled = seededShuffle(byDecade[d], decadeSeed(bucket, d));
+    buckets[d] = shuffled.slice(0, perDecade);
+  }
 
   return {
-    generated_at: new Date().toISOString(),
-    shows,
+    generated_at: new Date(nowMs).toISOString(),
+    decades: buckets,
   };
 }
 

--- a/api/src/db/analytics.ts
+++ b/api/src/db/analytics.ts
@@ -25,6 +25,16 @@ export function getAnalyticsDb(): Database.Database {
  * Existing dupes block index creation, so we pre-dedupe on first run only —
  * the check on `sqlite_master` keeps subsequent startups O(1) instead of
  * scanning the table.
+ *
+ * FOOTGUN: the index keys on primitive columns only — `props` is not
+ * considered. Two events from the same install/session at the exact same
+ * millisecond with *different* props (e.g. two `add_favorite`s for
+ * different shows, two `playback_start`s for different tracks) collide and
+ * one gets silently dropped. In practice clients emit events serially so
+ * collisions are vanishingly rare; if we ever ship a bulk-action UI (e.g.
+ * "favorite all", batch import), the client must stagger timestamps or we
+ * widen the index. Surfaced during getPopularShows test setup — see the
+ * popular.test.ts comments and PLANS/home-discovery-rails.md.
  */
 function ensureUniqueEventIndex(db: Database.Database): void {
   const exists = db

--- a/api/src/db/analytics.ts
+++ b/api/src/db/analytics.ts
@@ -1986,10 +1986,12 @@ export interface PopularResponse {
   shows: PopularShow[];
 }
 
-/** Default minimum distinct favoriters required to surface a show. Set
- *  low — current install base is small and a higher floor produces a
- *  near-empty rail. Revisit as volume grows. */
-const POPULAR_MIN_FAVORITES = 2;
+/** Default minimum distinct favoriters required to surface a show.
+ *  Floor=1 in the early stage: with a small install base, requiring 2+
+ *  produces a near-empty rail. Recency-ordered tiebreakers keep the
+ *  list feeling fresh rather than dumping all 1-favorite shows in
+ *  arbitrary order. Raise as volume grows. */
+const POPULAR_MIN_FAVORITES = 1;
 
 /**
  * "Popular" shows ranked by retention signal — net favorites (adds minus
@@ -2030,7 +2032,7 @@ export function getPopularShows(limit = 10): PopularResponse {
          -- For each (iid, show_id) keep only the most recent action.
          -- An install who added then removed nets to a "remove" and is
          -- excluded; one who removed then re-added nets to "add".
-         SELECT iid, show_id, feature
+         SELECT iid, show_id, feature, ts
          FROM actions a
          WHERE a.ts = (
            SELECT MAX(a2.ts) FROM actions a2
@@ -2038,7 +2040,10 @@ export function getPopularShows(limit = 10): PopularResponse {
          )
        ),
        favs AS (
-         SELECT show_id, COUNT(DISTINCT iid) AS favorites
+         SELECT
+           show_id,
+           COUNT(DISTINCT iid) AS favorites,
+           MAX(ts) AS last_favorite_ts
          FROM latest
          WHERE feature = 'add_favorite'
          GROUP BY show_id
@@ -2079,7 +2084,11 @@ export function getPopularShows(limit = 10): PopularResponse {
            AS ratio
        FROM favs f
        LEFT JOIN show_listens sl ON sl.show_id = f.show_id
-       ORDER BY ratio DESC, f.favorites DESC, listens DESC
+       -- favorites DESC keeps the genuinely-popular shows (2+ favoriters)
+       -- pinned at the top; recency tiebreaker keeps the rail feeling
+       -- fresh in the long single-favorite tail. Pure random would shuffle
+       -- the list on every refresh and feel unstable.
+       ORDER BY f.favorites DESC, f.last_favorite_ts DESC, ratio DESC
        LIMIT ?`,
     )
     .all(POPULAR_MIN_FAVORITES, LISTEN_GAP_MS, limit) as PopularShow[];

--- a/api/src/routes/analytics.ts
+++ b/api/src/routes/analytics.ts
@@ -17,6 +17,7 @@ import {
   getSearchQuality,
   getLiveListeners,
   getRecentListening,
+  getNetworkErrorOutcomes,
   getGrowthByPlatform,
   getTopShows,
   getWatchedInstalls,
@@ -740,6 +741,40 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
       return {
         sessions: getRecentListening(clampedHours, clampedLimit),
       };
+    },
+  );
+
+  // GET /api/analytics/network-errors — outcome of each network_error end.
+  app.get(
+    "/api/analytics/network-errors",
+    {
+      schema: {
+        tags: ["analytics"],
+        summary: "Network error recovery outcomes (admin)",
+        querystring: {
+          type: "object",
+          properties: {
+            days: { type: "number", default: 30 },
+            platform: { type: "string" },
+            limit: { type: "number", default: 50 },
+          },
+        },
+      },
+      preHandler: requireAdmin,
+    },
+    async (request) => {
+      const { days, platform, limit } = request.query as {
+        days?: number;
+        platform?: string;
+        limit?: number;
+      };
+      const clampedDays = Math.min(Math.max(days ?? 30, 1), 90);
+      const clampedLimit = Math.min(Math.max(limit ?? 50, 1), 200);
+      const platformFilter =
+        platform === "ios" || platform === "android" || platform === "web"
+          ? platform
+          : null;
+      return getNetworkErrorOutcomes(clampedDays, platformFilter, clampedLimit);
     },
   );
 

--- a/api/src/routes/popular.ts
+++ b/api/src/routes/popular.ts
@@ -2,9 +2,12 @@ import type { FastifyInstance } from "fastify";
 import { getPopularShows } from "../db/analytics.js";
 import { getPublisher } from "../db/redis.js";
 
-const CACHE_KEY = "popular:v1";
+// Cache only the default home-rail size; a future "View All" page can
+// hit ?limit=100 etc. and skip the cache (uncached query is cheap).
+const CACHE_KEY_DEFAULT = "popular:v1";
 const CACHE_TTL_SECONDS = 600; // 10 minutes — matches trending
-const POPULAR_LIMIT = 10;
+const POPULAR_LIMIT_DEFAULT = 5;
+const POPULAR_LIMIT_MAX = 100;
 
 const popularShowSchema = {
   type: "object",
@@ -17,16 +20,21 @@ const popularShowSchema = {
 } as const;
 
 export async function popularRoutes(app: FastifyInstance): Promise<void> {
-  app.get(
+  app.get<{ Querystring: { limit?: number } }>(
     "/api/popular",
     {
       schema: {
         tags: ["analytics"],
         summary: "Popular shows for the home screen",
         description:
-          "Shows ranked by net favorites / all-time logical listens. " +
-          "Surfaces what listeners *kept*, complementing Trending's " +
-          "what-just-got-played signal. Cached for 10 minutes in Redis.",
+          "Shows ranked first by net-favorites count, then by recency of " +
+          "the most recent favorite action, then by saved-vs-played ratio. " +
+          "Default returns the top 5 for the home rail; pass ?limit=N " +
+          "(capped at 100) for a deeper list (future \"View All\" page).",
+        querystring: {
+          type: "object",
+          properties: { limit: { type: "number", default: POPULAR_LIMIT_DEFAULT } },
+        },
         response: {
           200: {
             type: "object",
@@ -38,27 +46,40 @@ export async function popularRoutes(app: FastifyInstance): Promise<void> {
         },
       },
     },
-    async (_request, reply) => {
-      try {
-        const cached = await getPublisher().get(CACHE_KEY);
-        if (cached) {
-          reply.header("X-Popular-Cache", "hit");
-          return reply.type("application/json").send(cached);
+    async (request, reply) => {
+      const requested = request.query?.limit ?? POPULAR_LIMIT_DEFAULT;
+      const limit = Math.min(Math.max(requested, 1), POPULAR_LIMIT_MAX);
+      const isDefault = limit === POPULAR_LIMIT_DEFAULT;
+
+      if (isDefault) {
+        try {
+          const cached = await getPublisher().get(CACHE_KEY_DEFAULT);
+          if (cached) {
+            reply.header("X-Popular-Cache", "hit");
+            return reply.type("application/json").send(cached);
+          }
+        } catch {
+          // Fall through to live query — better uncached than 500.
         }
-      } catch {
-        // Fall through to live query — better uncached than 500.
       }
 
-      const fresh = getPopularShows(POPULAR_LIMIT);
+      const fresh = getPopularShows(limit);
       const payload = JSON.stringify(fresh);
 
-      try {
-        await getPublisher().set(CACHE_KEY, payload, "EX", CACHE_TTL_SECONDS);
-      } catch {
-        // Cache write best-effort.
+      if (isDefault) {
+        try {
+          await getPublisher().set(
+            CACHE_KEY_DEFAULT,
+            payload,
+            "EX",
+            CACHE_TTL_SECONDS,
+          );
+        } catch {
+          // Cache write best-effort.
+        }
       }
 
-      reply.header("X-Popular-Cache", "miss");
+      reply.header("X-Popular-Cache", isDefault ? "miss" : "bypass");
       return reply.type("application/json").send(payload);
     },
   );

--- a/api/src/routes/popular.ts
+++ b/api/src/routes/popular.ts
@@ -1,0 +1,65 @@
+import type { FastifyInstance } from "fastify";
+import { getPopularShows } from "../db/analytics.js";
+import { getPublisher } from "../db/redis.js";
+
+const CACHE_KEY = "popular:v1";
+const CACHE_TTL_SECONDS = 600; // 10 minutes — matches trending
+const POPULAR_LIMIT = 10;
+
+const popularShowSchema = {
+  type: "object",
+  properties: {
+    show_id: { type: "string" },
+    favorites: { type: "number" },
+    listens: { type: "number" },
+    ratio: { type: "number" },
+  },
+} as const;
+
+export async function popularRoutes(app: FastifyInstance): Promise<void> {
+  app.get(
+    "/api/popular",
+    {
+      schema: {
+        tags: ["analytics"],
+        summary: "Popular shows for the home screen",
+        description:
+          "Shows ranked by net favorites / all-time logical listens. " +
+          "Surfaces what listeners *kept*, complementing Trending's " +
+          "what-just-got-played signal. Cached for 10 minutes in Redis.",
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              generated_at: { type: "string" },
+              shows: { type: "array", items: popularShowSchema },
+            },
+          },
+        },
+      },
+    },
+    async (_request, reply) => {
+      try {
+        const cached = await getPublisher().get(CACHE_KEY);
+        if (cached) {
+          reply.header("X-Popular-Cache", "hit");
+          return reply.type("application/json").send(cached);
+        }
+      } catch {
+        // Fall through to live query — better uncached than 500.
+      }
+
+      const fresh = getPopularShows(POPULAR_LIMIT);
+      const payload = JSON.stringify(fresh);
+
+      try {
+        await getPublisher().set(CACHE_KEY, payload, "EX", CACHE_TTL_SECONDS);
+      } catch {
+        // Cache write best-effort.
+      }
+
+      reply.header("X-Popular-Cache", "miss");
+      return reply.type("application/json").send(payload);
+    },
+  );
+}

--- a/api/src/routes/popular.ts
+++ b/api/src/routes/popular.ts
@@ -2,12 +2,12 @@ import type { FastifyInstance } from "fastify";
 import { getPopularShows } from "../db/analytics.js";
 import { getPublisher } from "../db/redis.js";
 
-// Cache only the default home-rail size; a future "View All" page can
-// hit ?limit=100 etc. and skip the cache (uncached query is cheap).
-const CACHE_KEY_DEFAULT = "popular:v1";
-const CACHE_TTL_SECONDS = 600; // 10 minutes — matches trending
-const POPULAR_LIMIT_DEFAULT = 5;
-const POPULAR_LIMIT_MAX = 100;
+// Response is stable for the duration of the rotation window (see
+// POPULAR_ROTATION_HOURS in analytics.ts). The cache key includes the
+// current bucket index so a new rotation gets a fresh key and old keys
+// age out naturally via TTL.
+const CACHE_KEY_PREFIX = "popular:v3:b";
+const CACHE_TTL_SECONDS = 6 * 3600; // > one rotation window, ages out old buckets
 
 const popularShowSchema = {
   type: "object",
@@ -19,67 +19,73 @@ const popularShowSchema = {
   },
 } as const;
 
+const decadeArraySchema = { type: "array", items: popularShowSchema } as const;
+
+function envNum(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
 export async function popularRoutes(app: FastifyInstance): Promise<void> {
-  app.get<{ Querystring: { limit?: number } }>(
+  app.get(
     "/api/popular",
     {
       schema: {
         tags: ["analytics"],
-        summary: "Popular shows for the home screen",
+        summary: "Popular shows by decade for the home screen",
         description:
-          "Shows ranked first by net-favorites count, then by recency of " +
-          "the most recent favorite action, then by saved-vs-played ratio. " +
-          "Default returns the top 5 for the home rail; pass ?limit=N " +
-          "(capped at 100) for a deeper list (future \"View All\" page).",
-        querystring: {
-          type: "object",
-          properties: { limit: { type: "number", default: POPULAR_LIMIT_DEFAULT } },
-        },
+          "Returns four per-decade pools (60s/70s/80s/90s) of shows people " +
+          "kept (net favorites ≥ floor), uniformly sampled via a " +
+          "deterministic shuffle seeded by the current rotation window. " +
+          "The client picks its 4-show display set from these pools and " +
+          "re-rolls locally on 'Show more'. Floor, per-decade pool size, " +
+          "and rotation window are env-tunable.",
         response: {
           200: {
             type: "object",
             properties: {
               generated_at: { type: "string" },
-              shows: { type: "array", items: popularShowSchema },
+              decades: {
+                type: "object",
+                properties: {
+                  "60s": decadeArraySchema,
+                  "70s": decadeArraySchema,
+                  "80s": decadeArraySchema,
+                  "90s": decadeArraySchema,
+                },
+              },
             },
           },
         },
       },
     },
-    async (request, reply) => {
-      const requested = request.query?.limit ?? POPULAR_LIMIT_DEFAULT;
-      const limit = Math.min(Math.max(requested, 1), POPULAR_LIMIT_MAX);
-      const isDefault = limit === POPULAR_LIMIT_DEFAULT;
+    async (_request, reply) => {
+      const rotationHours = envNum("POPULAR_ROTATION_HOURS", 4);
+      const bucket = Math.floor(Date.now() / (rotationHours * 3600 * 1000));
+      const cacheKey = `${CACHE_KEY_PREFIX}${bucket}`;
 
-      if (isDefault) {
-        try {
-          const cached = await getPublisher().get(CACHE_KEY_DEFAULT);
-          if (cached) {
-            reply.header("X-Popular-Cache", "hit");
-            return reply.type("application/json").send(cached);
-          }
-        } catch {
-          // Fall through to live query — better uncached than 500.
+      try {
+        const cached = await getPublisher().get(cacheKey);
+        if (cached) {
+          reply.header("X-Popular-Cache", "hit");
+          return reply.type("application/json").send(cached);
         }
+      } catch {
+        // Fall through to live query — better uncached than 500.
       }
 
-      const fresh = getPopularShows(limit);
+      const fresh = getPopularShows();
       const payload = JSON.stringify(fresh);
 
-      if (isDefault) {
-        try {
-          await getPublisher().set(
-            CACHE_KEY_DEFAULT,
-            payload,
-            "EX",
-            CACHE_TTL_SECONDS,
-          );
-        } catch {
-          // Cache write best-effort.
-        }
+      try {
+        await getPublisher().set(cacheKey, payload, "EX", CACHE_TTL_SECONDS);
+      } catch {
+        // Cache write best-effort.
       }
 
-      reply.header("X-Popular-Cache", isDefault ? "miss" : "bypass");
+      reply.header("X-Popular-Cache", "miss");
       return reply.type("application/json").send(payload);
     },
   );

--- a/api/src/routes/trending.ts
+++ b/api/src/routes/trending.ts
@@ -105,10 +105,12 @@ export function startTrendingSchedules(): void {
   const runRollup = (): void => {
     try {
       rebuildShowListensRollup();
-      // Bust both cache variants so the next request reflects the fresh rollup.
+      // Bust caches so the next request reflects the fresh rollup.
+      // Popular reads `listens` from the same rollup, so it gets busted too.
       const pub = getPublisher();
       pub.del(CACHE_KEY_DEFAULT).catch(() => {});
       pub.del(CACHE_KEY_WITH_ANNIVERSARIES).catch(() => {});
+      pub.del("popular:v1").catch(() => {});
     } catch (err) {
       console.error("Trending rollup error:", err);
     }

--- a/docs/adr/0005-fan-favorites-rail.md
+++ b/docs/adr/0005-fan-favorites-rail.md
@@ -1,0 +1,299 @@
+# ADR-0005: Fan Favorites rail (decade pools)
+
+## Status
+
+Accepted (2026-05-27)
+
+## Context
+
+ADR-0004 shipped the **Trending** rail, which surfaces "what people are
+playing right now" via logical-listen counts. Trending answers the
+listening question well, but it does not answer a different one the
+user explicitly wanted on the home screen: **"what shows did people
+keep?"** — i.e. retention signal, not consumption signal.
+
+The data exists. Every `add_favorite` and `remove_favorite` action
+fires a `feature_use` event with `target_type='show'` and the show id
+in `target_id`. At time of writing the prod database holds **425
+favorite-adds and 39 removes over 30 days from 97 distinct users**.
+Roughly 84 distinct shows have at least one current favoriter.
+
+A naive design — "show the top N shows by net favorites" — runs into
+several issues that surfaced during the first attempt (commit
+`67057322`, replaced by the design in this ADR):
+
+1. **Distribution is flat.** With ~97 users across 84 favorited shows,
+   most shows sit at 1–2 favoriters. The top of the global ranking is
+   determined by 1–2 marginal favorites, not by a meaningfully stronger
+   signal.
+
+2. **The list felt static.** A favorites-ranked list refreshes only
+   when someone adds a favorite, which at current volume is roughly
+   every 1–2 hours. The same 5 shows sat at the top for the entire
+   day, making the rail feel dead.
+
+3. **The catalog has natural era texture.** The Dead played
+   1965–1995 — five decades that fans pick favorites from for very
+   different reasons (60s = early experiments, 70s = peak, 80s =
+   second wind, 90s = late-era). A global ranking erases that texture;
+   the top of the list is heavily 70s and 80s for the same reasons
+   they're heavily represented in the catalog.
+
+4. **There's product appetite for a "show me something new" gesture.**
+   The user explicitly wanted a "Show more" affordance — "I want to
+   roll the dice again on this rail." A pure-rank design has nothing
+   to roll.
+
+The product goal here is **discovery via retention signal**, not
+consensus ranking. Different from Trending: we are not trying to find
+"the" most-loved shows; we want to use the favorites signal as a
+filter to surface shows that *someone* kept, and let the user keep
+re-rolling within that filtered universe.
+
+## Decision
+
+### Endpoint shape
+
+A single `GET /api/popular` returns four per-decade *pools*:
+
+```json
+{
+  "generated_at": "2026-05-27T22:00:00Z",
+  "decades": {
+    "60s": [ { "show_id": "...", "favorites": 2, "listens": 7, "ratio": 0.29 }, ... ≤20 ],
+    "70s": [ ... ≤20 ],
+    "80s": [ ... ≤20 ],
+    "90s": [ ... ≤20 ]
+  }
+}
+```
+
+The server returns **pools**, not a pre-picked display set. The client
+picks its 4-show display set locally from these pools and re-rolls on
+"Show more" without another network call.
+
+The response is cached in Redis under `popular:v3:b{bucket}` with a
+6-hour TTL (longer than one rotation window so old buckets age out
+naturally). Cache key includes the rotation bucket index so a new
+rotation gets a fresh key.
+
+### Pool construction: stable 4h shuffle
+
+For each decade D ∈ {60s, 70s, 80s, 90s}:
+
+1. **Qualifying set** = all shows with net favorites ≥
+   `POPULAR_MIN_FAVORITES` (default 1) whose `show_id` resolves to a
+   year in that decade.
+2. **Shuffle** with a deterministic seed derived from
+   `floor(now_ms / (POPULAR_ROTATION_HOURS * 3600_000))` and the
+   decade name. Same rotation window → same shuffle.
+3. **Take the first `POPULAR_PER_DECADE`** (default 20) → that decade's
+   pool.
+
+The shuffle uses a small SplitMix-style PRNG so the result is fully
+deterministic for a given (rotation window, decade) pair. A user
+returning within the same 4h window sees the same pool; the rail
+rotates on its own at the window boundary.
+
+### Display-set selection: client side
+
+The home rail always shows **4 shows**. Two modes:
+
+- **`all`** (default): one show from each non-empty decade pool
+  (≤ 4 total), date-sorted.
+- **Specific decade** (60s / 70s / 80s / 90s): 4 shows from that
+  pool, biased toward **year diversity within the decade** so the
+  rail spans the era. Implemented as: shuffle the pool with a
+  client seed, then greedily pick shows whose year hasn't been
+  picked yet, filling any leftover slots from repeats.
+
+Both modes are driven by a local `shuffleSeed` (an integer counter).
+"Show more" bumps the seed → instant re-roll, no network round-trip.
+
+### Decade preference lives in Settings
+
+The user's decade choice is a persisted preference
+(`homePopularDecade`), set via a segmented control in
+Settings → Home Screen. There is **no in-header cycler** for the
+decade — that role belongs to "Show more," which re-rolls the
+*content* within the user-chosen decade rather than changing the
+decade itself.
+
+### Year extraction from `show_id`
+
+Show IDs in prod are slug-form: `1977-05-11-st-paul-civic-center-...`.
+The decade-bucketing code extracts the year by matching the first
+4-digit run in the ID. This is intentionally tolerant — older test
+fixtures use the `gd1977-...` form, and both work.
+
+### Tunable knobs (env vars, no app release required)
+
+| Variable | Default | What it controls |
+|---|---|---|
+| `POPULAR_MIN_FAVORITES` | 1 | Floor: minimum net favoriters to enter a decade pool. |
+| `POPULAR_PER_DECADE` | 20 | Cap on the per-decade pool size returned. |
+| `POPULAR_ROTATION_HOURS` | 4 | How long a pool is stable before it rotates. |
+
+Floor stays at 1 in the early stage because the current data has most
+shows at 1–2 favoriters; floor=2 produced a near-empty rail in
+manual testing. Raise as the install base grows.
+
+### What "net favorites" means
+
+Per (install, show), keep only the install's most recent favorite
+action. An add followed by a remove nets to zero (excluded). A
+remove followed by a re-add nets to one (included). Count distinct
+installs whose last action is `add_favorite` per show. This avoids
+double-counting indecisive users and gives us a true
+"currently favorited by N people" number.
+
+### Ratio is kept in the response but not used for ranking
+
+The `ratio = favorites / max(listens, 1)` field is preserved in the
+wire format because it's still the cleanest one-number "retention
+intensity" signal. We don't rank by it anymore — pool membership is
+binary (passes the floor or doesn't), and within-pool ordering comes
+from the shuffle. The field is exposed for transparency and possible
+future use (e.g., debug overlay).
+
+## Consequences
+
+### Positive
+
+- **Discovery survives small-N data.** With ~84 favorited shows
+  spread across four decades, sampling pools instead of ranking
+  globally lets every decade contribute regardless of how popular
+  the *most-favorited* show in another decade is.
+- **The rail feels alive.** The 4h rotation gives a fresh set
+  several times a day without any user input; "Show more" gives
+  unlimited re-rolls. Both are deterministic locally so re-renders
+  are stable.
+- **Return-visit stability.** Within the 4h window, the pools are
+  the same. A user who sees a show they liked yesterday and comes
+  back today within the window can still find it. Pure random per
+  request would have failed this test.
+- **Settings-driven decade preference is honest.** The user picks
+  the era they're in the mood for; the app doesn't try to be clever
+  about it. Year-spread within a decade means the rail meaningfully
+  covers the era rather than four shows from '77.
+- **Cheap.** Server work is one favorite-pool query per request,
+  cached for the rotation window. Client work is in-memory shuffle
+  of ≤20 items. No new tables, no rollup job, no scheduled tasks.
+- **Server-tunable.** Floor, pool size, rotation window are all env
+  vars. We can tune the rail's behavior as the install base grows
+  without shipping app updates.
+
+### Negative
+
+- **Floor=1 surfaces 1-user picks.** A show favorited by exactly
+  one person can show up in someone else's home rail. At current
+  scale this is the only way the rail can be non-empty for the 60s
+  and 90s, so we accept it. Raise the floor via env var once the
+  long tail thickens.
+- **"All" is a shallow view.** Four cards — one per decade — is the
+  whole flyover. Users wanting more variety have to either tap
+  "Show more" repeatedly or pick a specific decade.
+- **Each client re-implements the picking logic.** iOS and Android
+  each have their own `displayShows(decade, seed)` implementation,
+  with a seeded PRNG and the year-spread algorithm. Drift is a
+  real risk if one side gets edited without the other. Mitigation:
+  the algorithm is small and each side has its commit message and
+  this ADR as the canonical reference; web (when it exists) gets
+  a port from one of these.
+- **The "all" set seen by the client may not match what any
+  server-computed `all` would return.** We removed the server's
+  `all` bucket explicitly to avoid this confusion — there is only
+  one source of truth for "all," and it's the client.
+- **"Show more" telemetry doesn't tell us which shows the user
+  saw.** We track the tap as a `feature_use` event with the
+  selected decade, but not the resulting display set. If we ever
+  want to know "did users keep tapping until they hit something
+  they liked," we'd need to instrument the displayed show IDs
+  too. Deferred.
+- **Slug-format show IDs assume year is the first 4-digit run.**
+  This works for the current catalog but is a small implicit
+  schema dependency. If show IDs ever stop carrying the year in
+  the slug, the decade bucketing breaks silently (everything goes
+  to no-decade).
+
+## Alternatives considered
+
+**Ratio-ranked top-5 (shipped briefly in commit `67057322`).**
+Ranked by `favorites/listens` with floor=3, top-5 globally. Rejected
+after a few days: the list felt static (no rotation), the floor was
+too aggressive for current data, and the single ranking erased era
+texture. Replaced by this design.
+
+**Pure random per request.** No seeding, fresh shuffle each call.
+Rejected because returning users had no way to find a show they'd
+seen earlier — the rail churned constantly. The 4h stable shuffle
+preserves return-visit recognition.
+
+**Server-side re-roll via `?seed=N` query param.** Each "Show more"
+tap fires a fetch. Rejected because (a) it makes the tap feel slow
+(visible network roundtrip), (b) it requires the server to be
+involved in what is fundamentally a UI animation, and (c) the
+client already has all the data it needs once the pool is fetched.
+
+**Floor ≥ 2.** Tried this as the initial default. Empties the 60s and
+90s buckets entirely against current prod data — those decades have
+fewer shows in the catalog and fewer favoriters overall. Bumped
+back to 1; the env var stays so we can re-raise as volume grows.
+
+**Per-decade pool sizes that vary.** E.g., 30 for 70s/80s, 10 for
+60s/90s to match where the catalog density actually is. Considered.
+Rejected for v1 because the client only ever displays 4 from each
+pool; a larger pool just gives more re-roll variety, which is the
+same value whether the decade is dense or sparse.
+
+**Weighted-by-favorites sampling within a decade.** Pick shows from
+the qualifying pool with probability proportional to favorites,
+rather than uniform. Considered. Rejected because the user
+explicitly wanted a *discovery* surface — uniform sampling gives the
+long tail real visibility, which is the point.
+
+**Server returns the "all" flyover.** Earlier iteration of this
+design did. Removed because we had to compute it twice — once on
+the server, then again on the client because the client owns the
+re-roll. Two sources of truth for the same data felt wrong, and
+deleting the server's `all` was simpler than keeping them in sync.
+
+**In-header decade cycler ("Show 70s", "Show 80s", …).** Shipped
+briefly in commit `5d626407`. Replaced because (a) the cycler
+combined two different actions — change decade *and* re-roll — into
+the same tap, which was confusing once "Show more" became its own
+thing, and (b) the small chip target had questionable accessibility.
+The Settings picker is the explicit decade choice; "Show more" is
+the unlimited re-roll within that choice.
+
+**Engagement weighting (e.g., favor shows the user spent time on).**
+Out of scope for this rail — that's a personalization question, and
+Fan Favorites is deliberately *global*. The personalized equivalent
+would be a separate rail.
+
+## Open questions
+
+- **Floor when volume grows.** What's the right floor at 1,000 users?
+  10,000? Need to revisit after the install base grows by 10×. The
+  env var means we can tune in production without re-deploying app.
+- **Track-favorites ("Best of <song>") rail.** Sibling design with
+  the same retention-signal motivation but ranked by track, not show.
+  Unit 3 in `PLANS/home-discovery-rails.md`, deferred until track
+  favoriting telemetry is clean.
+- **Cross-platform parity for the picking algorithm.** Manual right
+  now. If we add a web client we should consider a shared algorithm
+  spec or a tiny shared library; not warranted for two clients.
+
+## References
+
+- `PLANS/home-discovery-rails.md` — discovery rails plan, of which
+  this is Unit 2.
+- ADR-0004 — Trending shows, the sibling discovery rail.
+- `api/src/db/analytics.ts` — `getPopularShows` implementation.
+- `api/src/routes/popular.ts` — `/api/popular` route.
+- `iosApp/deadly/Core/Service/PopularService.swift` — iOS pool model
+  and `displayShows(for:seed:)` picking.
+- `androidApp/core/api/home/.../PopularService.kt` — Android pool
+  model and `displayShows(decade, seed)` picking.
+- Commits: `67057322` (initial ratio-ranked), `5d626407` (in-header
+  cycler), `19a9ea6b` (decade pools), `d8383e9b` (Show More).

--- a/iosApp/deadly/App/AppContainer.swift
+++ b/iosApp/deadly/App/AppContainer.swift
@@ -18,6 +18,7 @@ final class AppContainer {
     let searchService: SearchServiceImpl
     let homeService: HomeServiceImpl
     let trendingService: TrendingServiceImpl
+    let popularService: PopularServiceImpl
     let favoritesService: FavoritesServiceImpl
     let collectionsService: CollectionsServiceImpl
     let streamPlayer: StreamPlayer
@@ -162,6 +163,14 @@ final class AppContainer {
             // the local show catalog. @MainActor; safe to init inline.
             trendingService = MainActor.assumeIsolated {
                 TrendingServiceImpl(
+                    appPreferences: prefs,
+                    showRepository: showRepo
+                )
+            }
+
+            // "Fan Favorites" — show favorites ranked by kept/listened ratio.
+            popularService = MainActor.assumeIsolated {
+                PopularServiceImpl(
                     appPreferences: prefs,
                     showRepository: showRepo
                 )

--- a/iosApp/deadly/Core/Service/AppPreferences.swift
+++ b/iosApp/deadly/Core/Service/AppPreferences.swift
@@ -24,6 +24,8 @@ final class AppPreferences {
     private static let homeRecentRowsKey = "home_recent_rows"
     private static let homeTrendingCardSizeKey = "home_trending_card_size"
     private static let homeTrendingIncludeAnniversariesKey = "home_trending_include_anniversaries"
+    private static let homePopularEnabledKey = "home_popular_enabled"
+    private static let homePopularCardSizeKey = "home_popular_card_size"
     private static let homeTodayCardSizeKey = "home_today_card_size"
     private static let homeCollectionsCardSizeKey = "home_collections_card_size"
 
@@ -135,6 +137,16 @@ final class AppPreferences {
         didSet { UserDefaults.standard.set(homeTrendingIncludeAnniversaries, forKey: Self.homeTrendingIncludeAnniversariesKey) }
     }
 
+    /// Show the "Fan Favorites" home rail. On by default.
+    var homePopularEnabled: Bool {
+        didSet { UserDefaults.standard.set(homePopularEnabled, forKey: Self.homePopularEnabledKey) }
+    }
+
+    /// Card size for the Fan Favorites carousel: "small" or "large".
+    var homePopularCardSize: String {
+        didSet { UserDefaults.standard.set(homePopularCardSize, forKey: Self.homePopularCardSizeKey) }
+    }
+
     /// Card size for the Today in History carousel: "small" or "large".
     var homeTodayCardSize: String {
         didSet { UserDefaults.standard.set(homeTodayCardSize, forKey: Self.homeTodayCardSizeKey) }
@@ -154,6 +166,8 @@ final class AppPreferences {
         homeTodayCardSize = "large"
         homeCollectionsCardSize = "large"
         homeTrendingIncludeAnniversaries = false
+        homePopularEnabled = true
+        homePopularCardSize = "small"
     }
 
     /// Persistent install ID (UUID). Generated once on first access, survives opt-out/opt-in cycles.
@@ -184,6 +198,8 @@ final class AppPreferences {
             Self.homeTodayCardSizeKey: "large",
             Self.homeCollectionsCardSizeKey: "large",
             Self.homeTrendingIncludeAnniversariesKey: false,
+            Self.homePopularEnabledKey: true,
+            Self.homePopularCardSizeKey: "small",
         ])
         includeShowsWithoutRecordings = UserDefaults.standard.bool(forKey: Self.includeShowsWithoutRecordingsKey)
         customServerUrl = UserDefaults.standard.string(forKey: Self.customServerUrlKey) ?? ""
@@ -211,6 +227,10 @@ final class AppPreferences {
         homeTodayCardSize = UserDefaults.standard.string(forKey: Self.homeTodayCardSizeKey) ?? "large"
         homeCollectionsCardSize = UserDefaults.standard.string(forKey: Self.homeCollectionsCardSizeKey) ?? "large"
         homeTrendingIncludeAnniversaries = UserDefaults.standard.bool(forKey: Self.homeTrendingIncludeAnniversariesKey)
+        homePopularEnabled = UserDefaults.standard.object(forKey: Self.homePopularEnabledKey) == nil
+            ? true
+            : UserDefaults.standard.bool(forKey: Self.homePopularEnabledKey)
+        homePopularCardSize = UserDefaults.standard.string(forKey: Self.homePopularCardSizeKey) ?? "small"
         analyticsEnabled = UserDefaults.standard.object(forKey: Self.analyticsEnabledKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: Self.analyticsEnabledKey)

--- a/iosApp/deadly/Core/Service/AppPreferences.swift
+++ b/iosApp/deadly/Core/Service/AppPreferences.swift
@@ -26,6 +26,7 @@ final class AppPreferences {
     private static let homeTrendingIncludeAnniversariesKey = "home_trending_include_anniversaries"
     private static let homePopularEnabledKey = "home_popular_enabled"
     private static let homePopularCardSizeKey = "home_popular_card_size"
+    private static let homePopularDecadeKey = "home_popular_decade"
     private static let homeTodayCardSizeKey = "home_today_card_size"
     private static let homeCollectionsCardSizeKey = "home_collections_card_size"
 
@@ -147,6 +148,11 @@ final class AppPreferences {
         didSet { UserDefaults.standard.set(homePopularCardSize, forKey: Self.homePopularCardSizeKey) }
     }
 
+    /// Which decade the Fan Favorites home rail shows: "all"/"60s"/"70s"/"80s"/"90s".
+    var homePopularDecade: String {
+        didSet { UserDefaults.standard.set(homePopularDecade, forKey: Self.homePopularDecadeKey) }
+    }
+
     /// Card size for the Today in History carousel: "small" or "large".
     var homeTodayCardSize: String {
         didSet { UserDefaults.standard.set(homeTodayCardSize, forKey: Self.homeTodayCardSizeKey) }
@@ -168,6 +174,7 @@ final class AppPreferences {
         homeTrendingIncludeAnniversaries = false
         homePopularEnabled = true
         homePopularCardSize = "small"
+        homePopularDecade = "all"
     }
 
     /// Persistent install ID (UUID). Generated once on first access, survives opt-out/opt-in cycles.
@@ -200,6 +207,7 @@ final class AppPreferences {
             Self.homeTrendingIncludeAnniversariesKey: false,
             Self.homePopularEnabledKey: true,
             Self.homePopularCardSizeKey: "small",
+            Self.homePopularDecadeKey: "all",
         ])
         includeShowsWithoutRecordings = UserDefaults.standard.bool(forKey: Self.includeShowsWithoutRecordingsKey)
         customServerUrl = UserDefaults.standard.string(forKey: Self.customServerUrlKey) ?? ""
@@ -231,6 +239,7 @@ final class AppPreferences {
             ? true
             : UserDefaults.standard.bool(forKey: Self.homePopularEnabledKey)
         homePopularCardSize = UserDefaults.standard.string(forKey: Self.homePopularCardSizeKey) ?? "small"
+        homePopularDecade = UserDefaults.standard.string(forKey: Self.homePopularDecadeKey) ?? "all"
         analyticsEnabled = UserDefaults.standard.object(forKey: Self.analyticsEnabledKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: Self.analyticsEnabledKey)

--- a/iosApp/deadly/Core/Service/PopularService.swift
+++ b/iosApp/deadly/Core/Service/PopularService.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct PopularContent: Sendable {
+    var shows: [Show] = []
+}
+
+@MainActor
+protocol PopularService {
+    var content: PopularContent { get }
+    func refresh() async
+}

--- a/iosApp/deadly/Core/Service/PopularService.swift
+++ b/iosApp/deadly/Core/Service/PopularService.swift
@@ -47,6 +47,23 @@ struct PopularContent: Sendable {
     ///   distinct years within the decade so the rail spans the era.
     /// `seed` controls the random selection; bumping it on "Show more"
     /// re-rolls without re-fetching. Returned shows are date-sorted.
+    /// Full pool(s) for the in-car surface, date-sorted.
+    /// - `.all`: every show across all four decade pools.
+    /// - specific decade: that decade's full pool.
+    /// CarPlay/Android Auto have no "Show more" affordance, so we surface
+    /// the whole pool rather than the 4-show home-rail teaser.
+    func allShows(for decade: PopularDecade) -> [Show] {
+        let shows: [Show]
+        switch decade {
+        case .all: shows = pool60 + pool70 + pool80 + pool90
+        case .s60: shows = pool60
+        case .s70: shows = pool70
+        case .s80: shows = pool80
+        case .s90: shows = pool90
+        }
+        return shows.sorted { $0.date < $1.date }
+    }
+
     func displayShows(for decade: PopularDecade, seed: Int) -> [Show] {
         let picks: [Show]
         switch decade {

--- a/iosApp/deadly/Core/Service/PopularService.swift
+++ b/iosApp/deadly/Core/Service/PopularService.swift
@@ -1,11 +1,133 @@
 import Foundation
 
+enum PopularDecade: String, CaseIterable, Identifiable {
+    case all
+    case s60 = "60s"
+    case s70 = "70s"
+    case s80 = "80s"
+    case s90 = "90s"
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .all: return "all"
+        case .s60: return "60s"
+        case .s70: return "70s"
+        case .s80: return "80s"
+        case .s90: return "90s"
+        }
+    }
+
+    /// Tolerant of unknown strings — defaults to .all.
+    init(preferenceKey: String) {
+        self = PopularDecade(rawValue: preferenceKey) ?? .all
+    }
+}
+
+/// Per-decade pools returned by /api/popular. Each pool is up to
+/// POPULAR_PER_DECADE shows, drawn with a 4h-rotated stable shuffle.
+/// The display set on the home rail is computed locally via
+/// `displayShows(for:seed:)` so "Show more" can re-roll without a fetch.
 struct PopularContent: Sendable {
-    var shows: [Show] = []
+    var pool60: [Show] = []
+    var pool70: [Show] = []
+    var pool80: [Show] = []
+    var pool90: [Show] = []
+
+    var hasAnyContent: Bool {
+        !pool60.isEmpty || !pool70.isEmpty || !pool80.isEmpty || !pool90.isEmpty
+    }
+
+    /// Number of shows to surface on the home rail in either mode.
+    static let displayCount = 4
+
+    /// Compute the home-rail display set.
+    /// - `.all`: one show from each non-empty decade pool (≤ 4).
+    /// - specific decade: up to 4 shows from that pool, biased toward
+    ///   distinct years within the decade so the rail spans the era.
+    /// `seed` controls the random selection; bumping it on "Show more"
+    /// re-rolls without re-fetching. Returned shows are date-sorted.
+    func displayShows(for decade: PopularDecade, seed: Int) -> [Show] {
+        let picks: [Show]
+        switch decade {
+        case .all:
+            picks = pickOnePerDecade(seed: seed)
+        case .s60:
+            picks = pickWithYearSpread(pool: pool60, count: Self.displayCount, seed: seed)
+        case .s70:
+            picks = pickWithYearSpread(pool: pool70, count: Self.displayCount, seed: seed)
+        case .s80:
+            picks = pickWithYearSpread(pool: pool80, count: Self.displayCount, seed: seed)
+        case .s90:
+            picks = pickWithYearSpread(pool: pool90, count: Self.displayCount, seed: seed)
+        }
+        return picks.sorted { $0.date < $1.date }
+    }
+
+    private func pickOnePerDecade(seed: Int) -> [Show] {
+        let pools: [(name: String, pool: [Show])] = [
+            ("60s", pool60), ("70s", pool70), ("80s", pool80), ("90s", pool90),
+        ]
+        var out: [Show] = []
+        for (name, pool) in pools where !pool.isEmpty {
+            var rng = SeededGenerator(seed: combinedSeed(seed, name))
+            if let pick = pool.shuffled(using: &rng).first {
+                out.append(pick)
+            }
+        }
+        return out
+    }
+
+    private func pickWithYearSpread(pool: [Show], count: Int, seed: Int) -> [Show] {
+        guard !pool.isEmpty else { return [] }
+        var rng = SeededGenerator(seed: combinedSeed(seed, "decade"))
+        let shuffled = pool.shuffled(using: &rng)
+        var seenYears = Set<Int>()
+        var primary: [Show] = []
+        var fallback: [Show] = []
+        for show in shuffled {
+            if seenYears.contains(show.year) {
+                fallback.append(show)
+            } else {
+                primary.append(show)
+                seenYears.insert(show.year)
+            }
+        }
+        return Array((primary + fallback).prefix(count))
+    }
 }
 
 @MainActor
 protocol PopularService {
     var content: PopularContent { get }
     func refresh() async
+}
+
+// MARK: - Seeded RNG
+
+/// SplitMix64 — small, fast, deterministic. Conforms to RandomNumberGenerator
+/// so `Array.shuffled(using:)` works directly.
+struct SeededGenerator: RandomNumberGenerator {
+    private var state: UInt64
+    init(seed: UInt64) { self.state = seed == 0 ? 0xdeadbeefcafebabe : seed }
+    mutating func next() -> UInt64 {
+        state &+= 0x9E3779B97F4A7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58476D1CE4E5B9
+        z = (z ^ (z >> 27)) &* 0x94D049BB133111EB
+        return z ^ (z >> 31)
+    }
+}
+
+private func combinedSeed(_ a: Int, _ b: String) -> UInt64 {
+    // FNV-1a-ish mix so "60s" and "70s" produce distinct streams from the
+    // same caller seed. Mixing a separator the user can't inject keeps
+    // adjacent decades non-trivially different.
+    var h: UInt64 = 0xcbf29ce484222325 &+ UInt64(bitPattern: Int64(a))
+    h = h &* 0x100000001b3
+    for byte in b.utf8 {
+        h ^= UInt64(byte)
+        h = h &* 0x100000001b3
+    }
+    return h
 }

--- a/iosApp/deadly/Core/Service/PopularServiceImpl.swift
+++ b/iosApp/deadly/Core/Service/PopularServiceImpl.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Fetches /api/popular and resolves returned show IDs into Show domain
+/// models from the local catalog. Single window (no trending-style
+/// now/week/month/all variations) — "Fan Favorites" is an all-time
+/// retention signal, not a time-window leaderboard.
+@Observable
+@MainActor
+final class PopularServiceImpl: PopularService {
+    private let appPreferences: AppPreferences
+    private let showRepository: any ShowRepository
+    private let session: URLSession
+
+    private(set) var content = PopularContent()
+
+    init(
+        appPreferences: AppPreferences,
+        showRepository: any ShowRepository,
+        session: URLSession = .shared
+    ) {
+        self.appPreferences = appPreferences
+        self.showRepository = showRepository
+        self.session = session
+    }
+
+    func refresh() async {
+        do {
+            let payload = try await fetchPayload()
+            let ids = payload.shows.map(\.show_id)
+            let byId: [String: Show] = Dictionary(
+                uniqueKeysWithValues: try showRepository.getShowsByIds(ids).map { ($0.id, $0) }
+            )
+            content = PopularContent(shows: ids.compactMap { byId[$0] })
+        } catch {
+            // Leave previous content in place on failure.
+        }
+    }
+
+    private func fetchPayload() async throws -> PopularPayload {
+        let url = URL(string: "\(appPreferences.apiBaseUrl)/api/popular")!
+        let (data, response) = try await session.data(from: url)
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            throw URLError(.badServerResponse)
+        }
+        return try JSONDecoder().decode(PopularPayload.self, from: data)
+    }
+
+    // MARK: - Wire format
+
+    private struct PopularPayload: Decodable {
+        let shows: [Entry]
+        struct Entry: Decodable {
+            let show_id: String
+        }
+    }
+}

--- a/iosApp/deadly/Core/Service/PopularServiceImpl.swift
+++ b/iosApp/deadly/Core/Service/PopularServiceImpl.swift
@@ -1,9 +1,10 @@
 import Foundation
 
 /// Fetches /api/popular and resolves returned show IDs into Show domain
-/// models from the local catalog. Single window (no trending-style
-/// now/week/month/all variations) — "Fan Favorites" is an all-time
-/// retention signal, not a time-window leaderboard.
+/// models from the local catalog. The server returns four decade *pools*
+/// (60s/70s/80s/90s); the home rail picks its display set from those
+/// pools locally via PopularContent.displayShows(for:seed:) — see ADR /
+/// PLANS for the design.
 @Observable
 @MainActor
 final class PopularServiceImpl: PopularService {
@@ -26,11 +27,21 @@ final class PopularServiceImpl: PopularService {
     func refresh() async {
         do {
             let payload = try await fetchPayload()
-            let ids = payload.shows.map(\.show_id)
-            let byId: [String: Show] = Dictionary(
-                uniqueKeysWithValues: try showRepository.getShowsByIds(ids).map { ($0.id, $0) }
+            let allIds = Set(
+                payload.decades.s60.map(\.show_id)
+                + payload.decades.s70.map(\.show_id)
+                + payload.decades.s80.map(\.show_id)
+                + payload.decades.s90.map(\.show_id)
             )
-            content = PopularContent(shows: ids.compactMap { byId[$0] })
+            let byId: [String: Show] = Dictionary(
+                uniqueKeysWithValues: try showRepository.getShowsByIds(Array(allIds)).map { ($0.id, $0) }
+            )
+            content = PopularContent(
+                pool60: payload.decades.s60.compactMap { byId[$0.show_id] },
+                pool70: payload.decades.s70.compactMap { byId[$0.show_id] },
+                pool80: payload.decades.s80.compactMap { byId[$0.show_id] },
+                pool90: payload.decades.s90.compactMap { byId[$0.show_id] }
+            )
         } catch {
             // Leave previous content in place on failure.
         }
@@ -48,7 +59,19 @@ final class PopularServiceImpl: PopularService {
     // MARK: - Wire format
 
     private struct PopularPayload: Decodable {
-        let shows: [Entry]
+        let decades: Decades
+        struct Decades: Decodable {
+            let s60: [Entry]
+            let s70: [Entry]
+            let s80: [Entry]
+            let s90: [Entry]
+            enum CodingKeys: String, CodingKey {
+                case s60 = "60s"
+                case s70 = "70s"
+                case s80 = "80s"
+                case s90 = "90s"
+            }
+        }
         struct Entry: Decodable {
             let show_id: String
         }

--- a/iosApp/deadly/Feature/CarPlay/CarPlayManager.swift
+++ b/iosApp/deadly/Feature/CarPlay/CarPlayManager.swift
@@ -83,6 +83,18 @@ final class CarPlayManager {
     }
 
     private func buildDiscoverTab() -> CPListTemplate {
+        let trendingItem = CPListItem(text: "Trending", detailText: "What others are playing")
+        trendingItem.handler = { [weak self] _, completion in
+            self?.showTrending()
+            completion()
+        }
+
+        let popularItem = CPListItem(text: "Fan Favorites", detailText: "Shows people kept")
+        popularItem.handler = { [weak self] _, completion in
+            self?.showFanFavorites()
+            completion()
+        }
+
         let yearsItem = CPListItem(text: "Browse by Year", detailText: "1965–1995")
         yearsItem.handler = { [weak self] _, completion in
             self?.showYearsList()
@@ -95,7 +107,10 @@ final class CarPlayManager {
             completion()
         }
 
-        let template = CPListTemplate(title: "Discover", sections: [CPListSection(items: [yearsItem, topRatedItem])])
+        let template = CPListTemplate(
+            title: "Discover",
+            sections: [CPListSection(items: [trendingItem, popularItem, yearsItem, topRatedItem])]
+        )
         template.tabTitle = "Discover"
         template.tabImage = UIImage(systemName: "magnifyingglass")
         return template
@@ -173,6 +188,35 @@ final class CarPlayManager {
             let shows = (try? container.showRepository.getTopRatedShows(limit: 50)) ?? []
             let items = shows.map { buildShowItem($0) }
             template.updateSections([CPListSection(items: items.isEmpty ? [emptyItem("No shows found")] : items)])
+        }
+    }
+
+    private func showTrending() {
+        let window = TrendingWindow(preferenceKey: container.appPreferences.homeTrendingWindow)
+        let title = "Trending \(window.label)"
+        let template = CPListTemplate(title: title, sections: [CPListSection(items: [loadingItem()])])
+        interfaceController.pushTemplate(template, animated: true, completion: nil)
+
+        Task {
+            await container.trendingService.refresh()
+            let shows = container.trendingService.content.shows(for: window)
+            let items = shows.map { buildShowItem($0) }
+            template.updateSections([CPListSection(items: items.isEmpty ? [emptyItem("No trending shows yet")] : items)])
+        }
+    }
+
+    private func showFanFavorites() {
+        let decade = PopularDecade(preferenceKey: container.appPreferences.homePopularDecade)
+        let title = decade == .all ? "Fan Favorites" : "Fan Favorites \(decade.label)"
+        let template = CPListTemplate(title: title, sections: [CPListSection(items: [loadingItem()])])
+        interfaceController.pushTemplate(template, animated: true, completion: nil)
+
+        Task {
+            await container.popularService.refresh()
+            // seed=0 — CarPlay surface is stable; no "Show more" re-roll in-car.
+            let shows = container.popularService.content.displayShows(for: decade, seed: 0)
+            let items = shows.map { buildShowItem($0) }
+            template.updateSections([CPListSection(items: items.isEmpty ? [emptyItem("No favorites yet")] : items)])
         }
     }
 

--- a/iosApp/deadly/Feature/CarPlay/CarPlayManager.swift
+++ b/iosApp/deadly/Feature/CarPlay/CarPlayManager.swift
@@ -213,8 +213,9 @@ final class CarPlayManager {
 
         Task {
             await container.popularService.refresh()
-            // seed=0 — CarPlay surface is stable; no "Show more" re-roll in-car.
-            let shows = container.popularService.content.displayShows(for: decade, seed: 0)
+            // CarPlay has no "Show more" affordance — surface the full pool
+            // rather than the 4-show home-rail teaser.
+            let shows = container.popularService.content.allShows(for: decade)
             let items = shows.map { buildShowItem($0) }
             template.updateSections([CPListSection(items: items.isEmpty ? [emptyItem("No favorites yet")] : items)])
         }

--- a/iosApp/deadly/Feature/Home/HomeScreen.swift
+++ b/iosApp/deadly/Feature/Home/HomeScreen.swift
@@ -5,6 +5,7 @@ struct HomeScreen: View {
 
     private var homeService: HomeServiceImpl { container.homeService }
     private var trendingService: TrendingServiceImpl { container.trendingService }
+    private var popularService: PopularServiceImpl { container.popularService }
     private var appPreferences: AppPreferences { container.appPreferences }
     private var content: HomeContent { homeService.content }
     private var trendingWindow: TrendingWindow {
@@ -15,6 +16,12 @@ struct HomeScreen: View {
     }
     private var trendingCardSize: CarouselCardSize {
         CarouselCardSize(preferenceKey: appPreferences.homeTrendingCardSize)
+    }
+    private var popularShows: [Show] {
+        popularService.content.shows
+    }
+    private var popularCardSize: CarouselCardSize {
+        CarouselCardSize(preferenceKey: appPreferences.homePopularCardSize)
     }
     private var todayCardSize: CarouselCardSize {
         CarouselCardSize(preferenceKey: appPreferences.homeTodayCardSize)
@@ -44,6 +51,12 @@ struct HomeScreen: View {
                     if !trendingShows.isEmpty { trendingSection }
                 }
 
+                // "Fan Favorites" — sits below the Trending/Today pair until
+                // the drag-list reorder lands.
+                if appPreferences.homePopularEnabled && !popularShows.isEmpty {
+                    fanFavoritesSection
+                }
+
                 if !content.featuredCollections.isEmpty {
                     collectionsSection
                 }
@@ -58,6 +71,7 @@ struct HomeScreen: View {
         .task {
             await homeService.refresh()
             await trendingService.refresh()
+            await popularService.refresh()
         }
         // The trending response depends on the include-anniversaries pref —
         // SwiftUI .task only fires on appearance, so flip-the-toggle-and-stay
@@ -115,6 +129,45 @@ struct HomeScreen: View {
                                 lines: [show.date],
                                 recordingCount: show.recordingCount,
                                 size: trendingCardSize.width
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .contextMenu {
+                            NavigationLink(value: show.id) {
+                                Label("View Show", systemImage: "eye")
+                            }
+                        } preview: {
+                            ShowDetailPopover(
+                                date: show.date,
+                                venue: show.venue.name,
+                                location: show.location.displayText,
+                                rating: show.hasRating ? show.displayRating : nil
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Fan Favorites
+
+    private var fanFavoritesSection: some View {
+        VStack(alignment: .leading, spacing: DeadlySpacing.itemSpacing) {
+            Text("Fan Favorites")
+                .font(.title2)
+                .fontWeight(.bold)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: DeadlySpacing.itemSpacing) {
+                    ForEach(popularShows) { show in
+                        NavigationLink(value: show.id) {
+                            ShowCarouselCard(
+                                imageRecordingId: show.bestRecordingId,
+                                imageUrl: show.coverImageUrl,
+                                lines: [show.date],
+                                recordingCount: show.recordingCount,
+                                size: popularCardSize.width
                             )
                         }
                         .buttonStyle(.plain)

--- a/iosApp/deadly/Feature/Home/HomeScreen.swift
+++ b/iosApp/deadly/Feature/Home/HomeScreen.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct HomeScreen: View {
     @Environment(\.appContainer) private var container
+    @State private var popularShuffleSeed: Int = 0
 
     private var homeService: HomeServiceImpl { container.homeService }
     private var trendingService: TrendingServiceImpl { container.trendingService }
@@ -17,8 +18,14 @@ struct HomeScreen: View {
     private var trendingCardSize: CarouselCardSize {
         CarouselCardSize(preferenceKey: appPreferences.homeTrendingCardSize)
     }
+    private var popularDecade: PopularDecade {
+        PopularDecade(preferenceKey: appPreferences.homePopularDecade)
+    }
     private var popularShows: [Show] {
-        popularService.content.shows
+        popularService.content.displayShows(for: popularDecade, seed: popularShuffleSeed)
+    }
+    private var popularHasAnyContent: Bool {
+        popularService.content.hasAnyContent
     }
     private var popularCardSize: CarouselCardSize {
         CarouselCardSize(preferenceKey: appPreferences.homePopularCardSize)
@@ -52,8 +59,10 @@ struct HomeScreen: View {
                 }
 
                 // "Fan Favorites" — sits below the Trending/Today pair until
-                // the drag-list reorder lands.
-                if appPreferences.homePopularEnabled && !popularShows.isEmpty {
+                // the drag-list reorder lands. Render as long as *some* decade
+                // has content; an empty selected decade still shows the
+                // header so the user can cycle back out.
+                if appPreferences.homePopularEnabled && popularHasAnyContent {
                     fanFavoritesSection
                 }
 
@@ -154,34 +163,69 @@ struct HomeScreen: View {
 
     private var fanFavoritesSection: some View {
         VStack(alignment: .leading, spacing: DeadlySpacing.itemSpacing) {
-            Text("Fan Favorites")
-                .font(.title2)
-                .fontWeight(.bold)
+            let title = popularDecade == .all
+                ? "Fan Favorites"
+                : "Fan Favorites · \(popularDecade.label)"
+            let showMore = {
+                popularShuffleSeed &+= 1
+                container.analyticsService.track("feature_use", props: [
+                    "feature": "popular_show_more",
+                    "category": "action",
+                    "value": popularDecade.rawValue,
+                ])
+            }
+            HStack(spacing: 12) {
+                Text(title)
+                    .font(.title2)
+                    .fontWeight(.bold)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
 
-            ScrollView(.horizontal, showsIndicators: false) {
-                LazyHStack(spacing: DeadlySpacing.itemSpacing) {
-                    ForEach(popularShows) { show in
-                        NavigationLink(value: show.id) {
-                            ShowCarouselCard(
-                                imageRecordingId: show.bestRecordingId,
-                                imageUrl: show.coverImageUrl,
-                                lines: [show.date],
-                                recordingCount: show.recordingCount,
-                                size: popularCardSize.width
-                            )
-                        }
-                        .buttonStyle(.plain)
-                        .contextMenu {
+                Spacer(minLength: 8)
+
+                Button(action: showMore) {
+                    Text("Show more")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Show more Fan Favorites. Tap to re-roll.")
+            }
+
+            if popularShows.isEmpty {
+                Text("Nothing here yet. Try a different decade in Settings.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .padding(.vertical, 8)
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    LazyHStack(spacing: DeadlySpacing.itemSpacing) {
+                        ForEach(popularShows) { show in
                             NavigationLink(value: show.id) {
-                                Label("View Show", systemImage: "eye")
+                                ShowCarouselCard(
+                                    imageRecordingId: show.bestRecordingId,
+                                    imageUrl: show.coverImageUrl,
+                                    lines: [show.date],
+                                    recordingCount: show.recordingCount,
+                                    size: popularCardSize.width
+                                )
                             }
-                        } preview: {
-                            ShowDetailPopover(
-                                date: show.date,
-                                venue: show.venue.name,
-                                location: show.location.displayText,
-                                rating: show.hasRating ? show.displayRating : nil
-                            )
+                            .buttonStyle(.plain)
+                            .contextMenu {
+                                NavigationLink(value: show.id) {
+                                    Label("View Show", systemImage: "eye")
+                                }
+                            } preview: {
+                                ShowDetailPopover(
+                                    date: show.date,
+                                    venue: show.venue.name,
+                                    location: show.location.displayText,
+                                    rating: show.hasRating ? show.displayRating : nil
+                                )
+                            }
                         }
                     }
                 }

--- a/iosApp/deadly/Feature/Settings/SettingsScreen.swift
+++ b/iosApp/deadly/Feature/Settings/SettingsScreen.swift
@@ -325,6 +325,33 @@ struct SettingsScreen: View {
                     set: { container.appPreferences.homeCollectionsCardSize = $0 }
                 )
 
+                Toggle(isOn: Binding(
+                    get: { container.appPreferences.homePopularEnabled },
+                    set: { newValue in
+                        container.appPreferences.homePopularEnabled = newValue
+                        container.analyticsService.track("feature_use", props: [
+                            "feature": "set_home_popular_enabled",
+                            "category": "preference",
+                            "value": String(newValue),
+                        ])
+                    }
+                )) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Show Fan Favorites")
+                        Text("Shows other listeners kept — ranked by saved-vs-played ratio.")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                cardSizePicker(
+                    title: "Fan Favorites card size",
+                    helper: "Size of cards in the Fan Favorites carousel.",
+                    feature: "set_home_popular_card_size",
+                    get: { container.appPreferences.homePopularCardSize },
+                    set: { container.appPreferences.homePopularCardSize = $0 }
+                )
+
                 Button(role: .destructive) {
                     container.appPreferences.resetHomePreferences()
                     container.analyticsService.track("feature_use", props: [

--- a/iosApp/deadly/Feature/Settings/SettingsScreen.swift
+++ b/iosApp/deadly/Feature/Settings/SettingsScreen.swift
@@ -344,6 +344,29 @@ struct SettingsScreen: View {
                     }
                 }
 
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Fan Favorites decade")
+                    Picker("Fan Favorites decade", selection: Binding(
+                        get: { PopularDecade(preferenceKey: container.appPreferences.homePopularDecade) },
+                        set: { newDecade in
+                            container.appPreferences.homePopularDecade = newDecade.rawValue
+                            container.analyticsService.track("feature_use", props: [
+                                "feature": "set_home_popular_decade",
+                                "category": "preference",
+                                "value": newDecade.rawValue,
+                            ])
+                        }
+                    )) {
+                        ForEach(PopularDecade.allCases) { decade in
+                            Text(decade.label).tag(decade)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    Text("Default decade filter for the Fan Favorites rail. Tap the header to cycle.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+
                 cardSizePicker(
                     title: "Fan Favorites card size",
                     helper: "Size of cards in the Fan Favorites carousel.",

--- a/ui/src/app/admin/analytics/AnalyticsDashboard.tsx
+++ b/ui/src/app/admin/analytics/AnalyticsDashboard.tsx
@@ -13,6 +13,7 @@ import SearchQuality from "./components/SearchQuality";
 import PlaysBySource from "./components/PlaysBySource";
 import ListeningNow from "./components/ListeningNow";
 import RecentListening from "./components/RecentListening";
+import NetworkErrorOutcomes from "./components/NetworkErrorOutcomes";
 import GrowthChart from "./components/GrowthChart";
 import FeatureAdoption from "./components/FeatureAdoption";
 import CollapsibleSection from "./components/CollapsibleSection";
@@ -358,6 +359,14 @@ function AnalyticsDashboardInner({ showNames }: { showNames: ShowName[] }) {
           onOpenInstall={openInstall}
           watchedOnly={watchedOnly}
         />
+      </CollapsibleSection>
+
+      {/* Network error recovery */}
+      <CollapsibleSection
+        title="Network error recovery"
+        forceOpen={forceOpen}
+      >
+        <NetworkErrorOutcomes showMap={showMap} onOpenInstall={openInstall} />
       </CollapsibleSection>
 
       {watchedOnly ? null : <>

--- a/ui/src/app/admin/analytics/components/NetworkErrorOutcomes.tsx
+++ b/ui/src/app/admin/analytics/components/NetworkErrorOutcomes.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Outcome =
+  | "recover_same_track"
+  | "skipped_to_next"
+  | "skipped_ahead"
+  | "jumped_back"
+  | "next_event_is_end"
+  | "no_followup";
+
+interface OutcomeBucket {
+  outcome: Outcome;
+  count: number;
+  avg_gap_s: number | null;
+}
+
+interface RecentError {
+  ts: number;
+  iid: string;
+  platform: string;
+  app_version: string;
+  show_id: string | null;
+  recording_id: string | null;
+  track_index: number | null;
+  outcome: Outcome;
+  gap_s: number | null;
+  next_track_index: number | null;
+}
+
+interface NetworkErrorSummary {
+  days: number;
+  platform: string | null;
+  total: number;
+  outcomes: OutcomeBucket[];
+  recent: RecentError[];
+}
+
+interface ShowName {
+  id: string;
+  d: string;
+  v: string;
+  c: string;
+  s: string;
+  tc: number;
+}
+
+// Color + label per outcome. Order also drives the stacked bar.
+const OUTCOME_ORDER: Outcome[] = [
+  "recover_same_track",
+  "skipped_to_next",
+  "skipped_ahead",
+  "jumped_back",
+  "next_event_is_end",
+  "no_followup",
+];
+
+const OUTCOME_META: Record<
+  Outcome,
+  { label: string; color: string; hint: string }
+> = {
+  recover_same_track: {
+    label: "Recovered",
+    color: "#10b981", // emerald
+    hint: "Next event was a playback_start for the same track",
+  },
+  skipped_to_next: {
+    label: "Skipped to next",
+    color: "#f59e0b", // amber
+    hint: "Autoplay advanced one track forward",
+  },
+  skipped_ahead: {
+    label: "Skipped ahead",
+    color: "#ef4444", // red
+    hint: "Next start was 2+ tracks ahead — multiple tracks lost",
+  },
+  jumped_back: {
+    label: "User went back",
+    color: "#6366f1", // indigo
+    hint: "User manually moved to an earlier track",
+  },
+  next_event_is_end: {
+    label: "Another end",
+    color: "#a855f7", // purple
+    hint: "Next event was another playback_end (rare)",
+  },
+  no_followup: {
+    label: "Abandoned",
+    color: "#71717a", // zinc-500
+    hint: "No further playback events for this iid+show",
+  },
+};
+
+function formatGap(s: number | null): string {
+  if (s === null) return "—";
+  if (s < 60) return `${Math.round(s)}s`;
+  if (s < 3600) return `${Math.round(s / 60)}m`;
+  if (s < 86400) return `${(s / 3600).toFixed(1)}h`;
+  return `${(s / 86400).toFixed(1)}d`;
+}
+
+function formatTime(ts: number): string {
+  const d = new Date(ts);
+  const now = Date.now();
+  const diffM = (now - ts) / 60000;
+  if (diffM < 60) return `${Math.round(diffM)}m ago`;
+  if (diffM < 1440) return `${Math.round(diffM / 60)}h ago`;
+  return d.toLocaleDateString();
+}
+
+export default function NetworkErrorOutcomes({
+  showMap,
+  onOpenInstall,
+}: {
+  showMap?: Map<string, ShowName>;
+  onOpenInstall?: (iid: string) => void;
+} = {}) {
+  const [data, setData] = useState<NetworkErrorSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [platform, setPlatform] = useState<"ios" | "android" | "all">("ios");
+  const [days, setDays] = useState<7 | 30 | 90>(30);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const qs = new URLSearchParams({ days: String(days), limit: "50" });
+        if (platform !== "all") qs.set("platform", platform);
+        const res = await fetch(`/api/analytics/network-errors?${qs}`, {
+          credentials: "include",
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const body = (await res.json()) as NetworkErrorSummary;
+        if (!cancelled) {
+          setData(body);
+          setError(null);
+        }
+      } catch (e: unknown) {
+        if (!cancelled)
+          setError(e instanceof Error ? e.message : "Failed to load");
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [platform, days]);
+
+  if (error)
+    return <p className="text-sm text-red-400">Network errors: {error}</p>;
+  if (data === null) return <p className="text-sm text-zinc-500">Loading…</p>;
+
+  const total = data.total;
+  const byOutcome = new Map(data.outcomes.map((o) => [o.outcome, o]));
+
+  return (
+    <div className="space-y-4">
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3 text-xs">
+        <div className="flex items-center gap-1">
+          <span className="text-zinc-500">Platform:</span>
+          {(["ios", "android", "all"] as const).map((p) => (
+            <button
+              key={p}
+              onClick={() => setPlatform(p)}
+              className={`px-2 py-1 rounded ${
+                platform === p
+                  ? "bg-deadly-blue text-white"
+                  : "bg-zinc-800 text-zinc-300 hover:bg-zinc-700"
+              }`}
+            >
+              {p}
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center gap-1">
+          <span className="text-zinc-500">Window:</span>
+          {([7, 30, 90] as const).map((d) => (
+            <button
+              key={d}
+              onClick={() => setDays(d)}
+              className={`px-2 py-1 rounded ${
+                days === d
+                  ? "bg-deadly-blue text-white"
+                  : "bg-zinc-800 text-zinc-300 hover:bg-zinc-700"
+              }`}
+            >
+              {d}d
+            </button>
+          ))}
+        </div>
+        <span className="ml-auto text-zinc-400 tabular-nums">
+          {total} error{total === 1 ? "" : "s"} total
+        </span>
+      </div>
+
+      {total === 0 ? (
+        <p className="text-sm text-zinc-500 italic">
+          No network_error events in this window.
+        </p>
+      ) : (
+        <>
+          {/* Stacked bar */}
+          <div className="space-y-1.5">
+            <div className="flex h-6 w-full rounded-md overflow-hidden bg-zinc-800">
+              {OUTCOME_ORDER.map((o) => {
+                const bucket = byOutcome.get(o);
+                if (!bucket || bucket.count === 0) return null;
+                const pct = (bucket.count / total) * 100;
+                return (
+                  <div
+                    key={o}
+                    className="h-full"
+                    style={{
+                      width: `${pct}%`,
+                      backgroundColor: OUTCOME_META[o].color,
+                    }}
+                    title={`${OUTCOME_META[o].label}: ${bucket.count} (${pct.toFixed(1)}%)`}
+                  />
+                );
+              })}
+            </div>
+
+            {/* Legend */}
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-1 text-xs">
+              {OUTCOME_ORDER.map((o) => {
+                const bucket = byOutcome.get(o);
+                if (!bucket) return null;
+                const pct = (bucket.count / total) * 100;
+                return (
+                  <div
+                    key={o}
+                    className="flex items-center gap-2"
+                    title={OUTCOME_META[o].hint}
+                  >
+                    <span
+                      className="inline-block w-2.5 h-2.5 rounded-sm flex-shrink-0"
+                      style={{ backgroundColor: OUTCOME_META[o].color }}
+                    />
+                    <span className="text-zinc-300">
+                      {OUTCOME_META[o].label}
+                    </span>
+                    <span className="text-zinc-500 tabular-nums ml-auto">
+                      {bucket.count} · {pct.toFixed(0)}%
+                      {bucket.avg_gap_s !== null && (
+                        <> · {formatGap(bucket.avg_gap_s)}</>
+                      )}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Recent list */}
+          {data.recent.length > 0 && (
+            <div className="space-y-1">
+              <p className="text-xs text-zinc-500 uppercase tracking-wide">
+                Recent errors
+              </p>
+              <div className="bg-deadly-surface rounded-lg overflow-hidden">
+                <table className="w-full text-xs">
+                  <thead className="text-zinc-500">
+                    <tr className="text-left">
+                      <th className="px-2 py-1.5 font-normal">When</th>
+                      <th className="px-2 py-1.5 font-normal">Show · track</th>
+                      <th className="px-2 py-1.5 font-normal">Outcome</th>
+                      <th className="px-2 py-1.5 font-normal text-right">Gap</th>
+                      <th className="px-2 py-1.5 font-normal">Install</th>
+                    </tr>
+                  </thead>
+                  <tbody className="text-zinc-300">
+                    {data.recent.map((r, i) => {
+                      const show = r.show_id ? showMap?.get(r.show_id) : null;
+                      const showLabel = show
+                        ? `${show.d} ${show.v}`
+                        : (r.show_id ?? "—");
+                      const meta = OUTCOME_META[r.outcome];
+                      const trackLabel =
+                        r.track_index !== null ? `· tr ${r.track_index}` : "";
+                      const nextTrack =
+                        r.next_track_index !== null && r.outcome !== "no_followup"
+                          ? ` → ${r.next_track_index}`
+                          : "";
+                      return (
+                        <tr
+                          key={`${r.ts}-${i}`}
+                          className="border-t border-zinc-800 hover:bg-zinc-800/40"
+                        >
+                          <td className="px-2 py-1.5 text-zinc-400 whitespace-nowrap">
+                            {formatTime(r.ts)}
+                          </td>
+                          <td className="px-2 py-1.5">
+                            <span className="text-zinc-200 truncate inline-block max-w-[24ch] align-middle">
+                              {showLabel}
+                            </span>
+                            <span className="text-zinc-500">
+                              {" "}
+                              {trackLabel}
+                              {nextTrack}
+                            </span>
+                          </td>
+                          <td className="px-2 py-1.5">
+                            <span className="inline-flex items-center gap-1.5">
+                              <span
+                                className="inline-block w-2 h-2 rounded-sm"
+                                style={{ backgroundColor: meta.color }}
+                              />
+                              {meta.label}
+                            </span>
+                          </td>
+                          <td className="px-2 py-1.5 text-right text-zinc-400 tabular-nums">
+                            {formatGap(r.gap_s)}
+                          </td>
+                          <td className="px-2 py-1.5">
+                            {onOpenInstall ? (
+                              <button
+                                onClick={() => onOpenInstall(r.iid)}
+                                className="text-deadly-blue hover:underline"
+                              >
+                                {r.iid.slice(0, 8)}
+                              </button>
+                            ) : (
+                              <span className="text-zinc-500">
+                                {r.iid.slice(0, 8)}
+                              </span>
+                            )}
+                            <span className="text-zinc-600">
+                              {" "}
+                              {r.platform} {r.app_version}
+                            </span>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Fan Favorites rail (Unit 2)** on mobile home: decade picker (60s/70s/80s/90s), Show More re-roll, 4h stable shuffle
- **Popular service API**: `show-favorites` ranked by kept/listened ratio, decade-bucketed pools, floor=1, top 5, recency tiebreaker, `?limit=` for view-all
- **CarPlay / Android Auto**: surface Trending and Fan Favorites browse rails
- **Analytics**: ignore `app_backgrounded` ends in live-listener boundary; new admin "Network error recovery" panel classifying each `network_error` end by the next playback event for the same iid+show
- **Docs**: ADR-0005 (Fan Favorites rail), PLANS update for Unit 2

## Test plan
- [ ] iOS: Home shows Fan Favorites rail; decade picker re-rolls pool; Show More opens view-all
- [ ] Android: same — Fan Favorites rail + decade picker + Show More
- [ ] CarPlay: Trending + Fan Favorites visible in browse tree
- [ ] Android Auto: Trending + Fan Favorites visible in browse tree
- [ ] API: `GET /api/popular/show-favorites` returns ranked list; `?limit=` honored; decade buckets stable for 4h window
- [ ] API: `GET /api/analytics/network-errors` returns outcome counts + recent classifications; admin auth enforced
- [ ] Admin dashboard: Network error recovery section renders, filters by platform/days
- [ ] Live listeners no longer spike from `app_backgrounded` end events

🤖 Generated with [Claude Code](https://claude.com/claude-code)