### PR TITLE
feat(mobile/home): stable-random Featured Collections with Show more

### DIFF
--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeScreen.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeScreen.kt
@@ -136,9 +136,16 @@ fun HomeScreen(
             }
         }
 
-        // Featured Collections Section
+        // Featured Collections Section — stable shuffle per seed so the
+        // rail order is consistent within a session but "Show more" can
+        // re-roll without a re-fetch. Mirrors the Fan Favorites pattern.
         item {
-            val collectionItems = uiState.homeContent.featuredCollections.map { collection ->
+            var collectionsSeed by remember { mutableIntStateOf(0) }
+            val shuffledCollections = remember(uiState.homeContent.featuredCollections, collectionsSeed) {
+                if (uiState.homeContent.featuredCollections.isEmpty()) emptyList()
+                else uiState.homeContent.featuredCollections.shuffled(kotlin.random.Random(collectionsSeed))
+            }
+            val collectionItems = shuffledCollections.map { collection ->
                 HorizontalCollectionItem(
                     id = collection.id,
                     displayText = "${collection.name}\n${collection.showCountText}",
@@ -152,7 +159,12 @@ fun HomeScreen(
                 cardWidth = collectionsCardWidth,
                 onItemClick = { item ->
                     onNavigateToCollection(item.id)
-                }
+                },
+                actionLabel = if (collectionItems.size > 1) "Show more" else null,
+                onActionClick = {
+                    collectionsSeed++
+                    viewModel.trackCollectionsShowMore()
+                },
             )
         }
     }

--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeViewModel.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/HomeViewModel.kt
@@ -113,6 +113,14 @@ class HomeViewModel @Inject constructor(
         ))
     }
 
+    /** Telemetry hook for the Featured Collections "Show more" re-roll. */
+    fun trackCollectionsShowMore() {
+        analyticsService.track("feature_use", mapOf(
+            "feature" to "collections_show_more",
+            "category" to "action",
+        ))
+    }
+
     /**
      * Clear error state
      */

--- a/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/components/HomeCollectionComponents.kt
+++ b/androidApp/feature/home/src/main/java/com/grateful/deadly/feature/home/screens/main/components/HomeCollectionComponents.kt
@@ -1,6 +1,7 @@
 package com.grateful.deadly.feature.home.screens.main.components
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
@@ -8,6 +9,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
@@ -28,17 +30,37 @@ fun HorizontalCollection(
     modifier: Modifier = Modifier,
     cardWidth: Dp = 160.dp,
     onItemLongPress: ((HorizontalCollectionItem) -> Unit)? = null,
+    actionLabel: String? = null,
+    onActionClick: (() -> Unit)? = null,
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        // Section title
-        Text(
-            text = title,
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold
-        )
+        // Section title (with optional trailing action like "Show more")
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                modifier = Modifier.weight(1f),
+            )
+            if (actionLabel != null && onActionClick != null) {
+                Text(
+                    text = actionLabel,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    modifier = Modifier.clickable(onClick = onActionClick),
+                )
+            }
+        }
 
         // Horizontal scrolling row
         LazyRow(

--- a/iosApp/deadly/Feature/Home/HomeScreen.swift
+++ b/iosApp/deadly/Feature/Home/HomeScreen.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct HomeScreen: View {
     @Environment(\.appContainer) private var container
     @State private var popularShuffleSeed: Int = 0
+    @State private var collectionsShuffleSeed: Int = 0
 
     private var homeService: HomeServiceImpl { container.homeService }
     private var trendingService: TrendingServiceImpl { container.trendingService }
@@ -312,14 +313,44 @@ struct HomeScreen: View {
     }
 
     private var collectionsSection: some View {
-        VStack(alignment: .leading, spacing: DeadlySpacing.itemSpacing) {
-            Text("Featured Collections")
-                .font(.title2)
-                .fontWeight(.bold)
+        // Stable shuffle per seed so the rail order is consistent within a
+        // session but "Show more" can re-roll without a re-fetch. Mirrors
+        // the Fan Favorites pattern.
+        var rng = SeededGenerator(seed: UInt64(bitPattern: Int64(collectionsShuffleSeed)) &+ 0x636f6c6c)
+        let shuffled = content.featuredCollections.shuffled(using: &rng)
+        let showMore = {
+            collectionsShuffleSeed &+= 1
+            container.analyticsService.track("feature_use", props: [
+                "feature": "collections_show_more",
+                "category": "action",
+            ])
+        }
+        return VStack(alignment: .leading, spacing: DeadlySpacing.itemSpacing) {
+            HStack(spacing: 12) {
+                Text("Featured Collections")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+
+                Spacer(minLength: 8)
+
+                if shuffled.count > 1 {
+                    Button(action: showMore) {
+                        Text("Show more")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Show more Featured Collections. Tap to re-roll.")
+                }
+            }
 
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHStack(spacing: DeadlySpacing.itemSpacing) {
-                    ForEach(content.featuredCollections) { collection in
+                    ForEach(shuffled) { collection in
                         NavigationLink(value: CollectionRoute.detail(collection.id)) {
                             ShowCarouselCard(
                                 imageRecordingId: nil,


### PR DESCRIPTION
## Summary
- Featured Collections rail now shuffles with a session-stable seed (Android: `kotlin.random.Random(seed)`; iOS: existing `SeededGenerator`).
- Adds a "Show more" header action that bumps the seed to re-roll order without a re-fetch — same pattern as Fan Favorites.
- Extends Android `HorizontalCollection` with an optional trailing action so we don't fork the component.
- Mirrors Fan Favorites analytics: `feature_use` / `collections_show_more`.

## Test plan
- [ ] Android: open Home, confirm collections appear shuffled and order stays stable while scrolling; tap "Show more" → order changes.
- [ ] Android: with ≤1 featured collection, "Show more" is hidden.
- [ ] iOS: same checks on Home; confirm `collections_show_more` event fires.
- [ ] No regression to Fan Favorites or Trending sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)