### PR TITLE
fix(web): dependabot patches, analytics scoping + reorder, Firefox scroll fix

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -25,7 +25,7 @@
         "@types/ws": "^8.18.1",
         "tsx": "^4.0.0",
         "typescript": "^5.5.0",
-        "vitest": "^3.1.0"
+        "vitest": "^4.1.0"
       }
     },
     "node_modules/@auth/core": {
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@auth/core/node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -75,6 +75,40 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -822,6 +856,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
@@ -837,24 +900,10 @@
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
-      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
-      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -863,12 +912,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
-      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -877,12 +929,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
-      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -891,26 +946,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
-      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
-      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -919,12 +963,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
-      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -933,194 +980,135 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
-      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
-      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
-      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
-      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
-      "cpu": [
-        "loong64"
+      "libc": [
+        "musl"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
-      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
-      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
-      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
-      "cpu": [
-        "ppc64"
+      "libc": [
+        "glibc"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
-      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
-      "cpu": [
-        "riscv64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
-      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
-      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
-      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
-      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
-      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -1129,12 +1117,34 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
-      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -1143,26 +1153,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
-      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -1171,21 +1170,35 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
-      "cpu": [
-        "x64"
       ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "win32"
-      ]
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
@@ -1222,9 +1235,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1249,39 +1262,40 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "4.1.8",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -1293,42 +1307,42 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^2.0.0"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "magic-string": "^0.30.17",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1336,28 +1350,25 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -1537,41 +1548,14 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
       }
     },
     "node_modules/chownr": {
@@ -1602,18 +1586,12 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1645,16 +1623,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/deep-extend": {
@@ -1724,9 +1692,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2115,13 +2083,6 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json-schema-ref-resolver": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
@@ -2185,6 +2146,15 @@
         "set-cookie-parser": "^2.6.0"
       }
     },
+    "node_modules/light-my-request/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/light-my-request/node_modules/process-warning": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
@@ -2201,6 +2171,279 @@
       ],
       "license": "MIT"
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -2211,13 +2454,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-      "license": "MIT"
-    },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -2318,9 +2554,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -2369,6 +2605,20 @@
       "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -2415,16 +2665,6 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2484,9 +2724,9 @@
       "license": "MIT"
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -2504,7 +2744,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2702,49 +2942,38 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
     },
-    "node_modules/rollup": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
-      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.2",
-        "@rollup/rollup-android-arm64": "4.60.2",
-        "@rollup/rollup-darwin-arm64": "4.60.2",
-        "@rollup/rollup-darwin-x64": "4.60.2",
-        "@rollup/rollup-freebsd-arm64": "4.60.2",
-        "@rollup/rollup-freebsd-x64": "4.60.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
-        "@rollup/rollup-linux-arm64-musl": "4.60.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
-        "@rollup/rollup-linux-loong64-musl": "4.60.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-musl": "4.60.2",
-        "@rollup/rollup-openbsd-x64": "4.60.2",
-        "@rollup/rollup-openharmony-arm64": "4.60.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
-        "@rollup/rollup-win32-x64-gnu": "4.60.2",
-        "@rollup/rollup-win32-x64-msvc": "4.60.2",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/safe-buffer": {
@@ -2941,9 +3170,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2969,19 +3198,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-literal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/tar-fs": {
@@ -3032,16 +3248,19 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3055,30 +3274,10 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
     "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3102,6 +3301,14 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -3163,18 +3370,17 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -3190,9 +3396,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -3205,13 +3412,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -3237,89 +3447,80 @@
         }
       }
     },
-    "node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@types/debug": {
+        "@opentelemetry/api": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {
@@ -3330,6 +3531,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
@@ -3357,9 +3561,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/api/package.json
+++ b/api/package.json
@@ -29,6 +29,9 @@
     "@types/ws": "^8.18.1",
     "tsx": "^4.0.0",
     "typescript": "^5.5.0",
-    "vitest": "^3.1.0"
+    "vitest": "^4.1.0"
+  },
+  "overrides": {
+    "cookie": "^0.7.0"
   }
 }

--- a/api/src/db/__tests__/platform-filter.test.ts
+++ b/api/src/db/__tests__/platform-filter.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+
+// Point the analytics module at a temp DB before importing it so its
+// module-level singleton opens our test file, not data/analytics.db.
+const TMP_DB = path.join(
+  os.tmpdir(),
+  `platform-filter-test-${process.pid}-${Date.now()}.db`,
+);
+process.env.ANALYTICS_DB_PATH = TMP_DB;
+
+const {
+  getAnalyticsDb,
+  insertEvents,
+  getSummary,
+  getTimeseries,
+  getDetail,
+  getGrowthByPlatform,
+  platformClause,
+  closeAnalyticsDb,
+} = await import("../analytics.js");
+
+const DAY_MS = 24 * 3600 * 1000;
+
+function open(iid: string, platform: string, ts: number) {
+  return {
+    event: "app_open",
+    ts,
+    iid,
+    sid: `${iid}-s`,
+    platform,
+    app_version: "2.30.0",
+    props: {},
+  };
+}
+
+beforeEach(() => {
+  const db = getAnalyticsDb();
+  db.exec(`DELETE FROM analytics_events;`);
+});
+
+afterAll(() => {
+  closeAnalyticsDb();
+  if (fs.existsSync(TMP_DB)) fs.unlinkSync(TMP_DB);
+});
+
+describe("platformClause", () => {
+  it("is a no-op for absent / empty / all-invalid filters", () => {
+    expect(platformClause(undefined)).toBe("");
+    expect(platformClause([])).toBe("");
+    expect(platformClause(["nonsense"])).toBe("");
+  });
+
+  it("is a no-op when every known platform is selected", () => {
+    expect(platformClause(["ios", "android", "web"])).toBe("");
+  });
+
+  it("builds an IN clause for a subset, dropping unknown tokens", () => {
+    expect(platformClause(["ios", "android"])).toBe(
+      " AND platform IN ('ios', 'android')",
+    );
+    expect(platformClause(["web", "bogus"])).toBe(" AND platform IN ('web')");
+  });
+
+  it("respects a custom column alias", () => {
+    expect(platformClause(["ios"], "s.platform")).toBe(
+      " AND s.platform IN ('ios')",
+    );
+  });
+});
+
+describe("install counts exclude web when filtered", () => {
+  beforeEach(() => {
+    const now = Date.now();
+    insertEvents([
+      open("ios-1", "ios", now - 1 * DAY_MS),
+      open("ios-2", "ios", now - 2 * DAY_MS),
+      open("and-1", "android", now - 1 * DAY_MS),
+      open("web-1", "web", now - 1 * DAY_MS),
+      open("web-2", "web", now - 3 * DAY_MS),
+      open("web-3", "web", now - 5 * DAY_MS),
+    ]);
+  });
+
+  it("getSummary native-only drops web from install + active counts", () => {
+    const all = getSummary();
+    const native = getSummary(["ios", "android"]);
+
+    expect(all.total_installs).toBe(6);
+    expect(native.total_installs).toBe(3); // 2 ios + 1 android, no web
+
+    expect(all.mau).toBe(6);
+    expect(native.mau).toBe(3);
+
+    // platform_split is keyed by platform; web disappears entirely when
+    // the filter excludes it.
+    expect(all.platform_split).toMatchObject({ ios: 2, android: 1, web: 3 });
+    expect(native.platform_split.web).toBeUndefined();
+    expect(native.platform_split).toMatchObject({ ios: 2, android: 1 });
+  });
+
+  it("total == native + web (the filter partitions the install base)", () => {
+    const all = getSummary();
+    const native = getSummary(["ios", "android"]);
+    const web = getSummary(["web"]);
+    expect(native.total_installs + web.total_installs).toBe(all.total_installs);
+  });
+
+  it("getDetail total_installs returns only native rows when filtered", () => {
+    const rows = getDetail("total_installs", undefined, ["ios", "android"]);
+    expect(rows).toHaveLength(3);
+    expect(rows.every((r) => r.platform !== "web")).toBe(true);
+  });
+
+  it("getTimeseries dau honors the platform filter", () => {
+    const all = getTimeseries("dau", 7);
+    const native = getTimeseries("dau", 7, ["ios", "android"]);
+    const sum = (pts: Array<{ value: number }>) =>
+      pts.reduce((s, p) => s + p.value, 0);
+    expect(sum(all)).toBe(6);
+    expect(sum(native)).toBe(3);
+  });
+
+  it("getGrowthByPlatform drops web from per-day series and totals", () => {
+    const sum = (rows: ReturnType<typeof getGrowthByPlatform>, k: string) =>
+      rows.reduce(
+        (s, d) =>
+          s + (((d as unknown as Record<string, unknown>)[k] as number) ?? 0),
+        0,
+      );
+    const all = getGrowthByPlatform(30);
+    const native = getGrowthByPlatform(30, ["ios", "android"]);
+    expect(sum(all, "total")).toBe(6);
+    expect(sum(native, "total")).toBe(3);
+    expect(sum(native, "web")).toBe(0);
+  });
+});

--- a/api/src/db/analytics.ts
+++ b/api/src/db/analytics.ts
@@ -7,6 +7,36 @@ const DB_PATH =
 
 let db: Database.Database | null = null;
 
+/** Platforms the analytics pipeline recognizes. `web` is browser usage —
+ *  not an installed app — so the admin dashboard defaults to filtering it
+ *  out of install/active-user counts (see platformClause + the dashboard
+ *  platform toggles). */
+export const KNOWN_PLATFORMS = ["ios", "android", "web"] as const;
+
+/**
+ * Build a safe ` AND <col> IN ('ios','android')` SQL fragment from an
+ * admin-supplied platform allowlist. Each value is validated against
+ * {@link KNOWN_PLATFORMS}, so inlining them carries no injection risk and
+ * callers can splice the fragment into any WHERE without binding extra
+ * params.
+ *
+ * Returns "" (a no-op) when the filter is absent, empty/all-invalid, or
+ * selects every known platform — so an unfiltered call behaves exactly as
+ * it did before platform filtering existed. `col` lets aliased queries
+ * target e.g. `s.platform`.
+ */
+export function platformClause(
+  platforms: string[] | undefined,
+  col = "platform",
+): string {
+  if (!platforms || platforms.length === 0) return "";
+  const valid = [...new Set(platforms)].filter((p) =>
+    (KNOWN_PLATFORMS as readonly string[]).includes(p),
+  );
+  if (valid.length === 0 || valid.length === KNOWN_PLATFORMS.length) return "";
+  return ` AND ${col} IN (${valid.map((p) => `'${p}'`).join(", ")})`;
+}
+
 export function getAnalyticsDb(): Database.Database {
   if (db) return db;
 
@@ -354,19 +384,24 @@ export interface AnalyticsSummary {
   events_today: number;
 }
 
-export function getSummary(): AnalyticsSummary {
+export function getSummary(platforms?: string[]): AnalyticsSummary {
   const db = getAnalyticsDb();
   const now = Date.now();
   const dayAgo = now - 24 * 3600 * 1000;
   const weekAgo = now - 7 * 24 * 3600 * 1000;
   const monthAgo = now - 30 * 24 * 3600 * 1000;
+  // Platform filter spliced into each WHERE. `pc` targets the bare
+  // `platform` column; `pcS` targets the `s.`-aliased playback_start rows
+  // in the top_shows CTE.
+  const pc = platformClause(platforms);
+  const pcS = platformClause(platforms, "s.platform");
 
   // DAU/WAU/MAU from app_open events
   const dau =
     (
       db
         .prepare(
-          `SELECT COUNT(DISTINCT iid) AS c FROM analytics_events WHERE event = 'app_open' AND ts > ?`,
+          `SELECT COUNT(DISTINCT iid) AS c FROM analytics_events WHERE event = 'app_open' AND ts > ?${pc}`,
         )
         .get(dayAgo) as { c: number }
     )?.c ?? 0;
@@ -375,7 +410,7 @@ export function getSummary(): AnalyticsSummary {
     (
       db
         .prepare(
-          `SELECT COUNT(DISTINCT iid) AS c FROM analytics_events WHERE event = 'app_open' AND ts > ?`,
+          `SELECT COUNT(DISTINCT iid) AS c FROM analytics_events WHERE event = 'app_open' AND ts > ?${pc}`,
         )
         .get(weekAgo) as { c: number }
     )?.c ?? 0;
@@ -384,7 +419,7 @@ export function getSummary(): AnalyticsSummary {
     (
       db
         .prepare(
-          `SELECT COUNT(DISTINCT iid) AS c FROM analytics_events WHERE event = 'app_open' AND ts > ?`,
+          `SELECT COUNT(DISTINCT iid) AS c FROM analytics_events WHERE event = 'app_open' AND ts > ?${pc}`,
         )
         .get(monthAgo) as { c: number }
     )?.c ?? 0;
@@ -393,17 +428,18 @@ export function getSummary(): AnalyticsSummary {
   const total_installs =
     (
       db
-        .prepare(`SELECT COUNT(DISTINCT iid) AS c FROM analytics_events`)
+        .prepare(`SELECT COUNT(DISTINCT iid) AS c FROM analytics_events WHERE 1=1${pc}`)
         .get() as { c: number }
     )?.c ?? 0;
 
-  // Stale installs: seen ever but not in last 30 days
+  // Stale installs: seen ever but not in last 30 days (both bounds honor
+  // the platform filter, so "stale" means stale on the selected platforms).
   const stale_installs_30d =
     (
       db
         .prepare(
           `SELECT COUNT(DISTINCT iid) AS c FROM analytics_events
-       WHERE iid NOT IN (SELECT DISTINCT iid FROM analytics_events WHERE ts > ?)`,
+       WHERE iid NOT IN (SELECT DISTINCT iid FROM analytics_events WHERE ts > ?${pc})${pc}`,
         )
         .get(monthAgo) as { c: number }
     )?.c ?? 0;
@@ -412,7 +448,7 @@ export function getSummary(): AnalyticsSummary {
   const platformRows = db
     .prepare(
       `SELECT platform, COUNT(DISTINCT iid) AS c FROM analytics_events
-     WHERE event = 'app_open' AND ts > ? GROUP BY platform`,
+     WHERE event = 'app_open' AND ts > ?${pc} GROUP BY platform`,
     )
     .all(monthAgo) as Array<{ platform: string; c: number }>;
   const platform_split: Record<string, number> = {};
@@ -443,14 +479,14 @@ export function getSummary(): AnalyticsSummary {
            AND json_extract(e.props, '$.show_id') = json_extract(s.props, '$.show_id')
            AND e.ts BETWEEN s.ts AND s.ts + ?
            AND CAST(json_extract(e.props, '$.listened_ms') AS REAL) >= ?
-         WHERE s.event = 'playback_start' AND s.ts > ?
+         WHERE s.event = 'playback_start' AND s.ts > ?${pcS}
        ),
        track_plays AS (
          SELECT
            json_extract(props, '$.show_id') AS show_id,
            COUNT(*) AS track_plays
          FROM analytics_events
-         WHERE event = 'playback_start' AND ts > ?
+         WHERE event = 'playback_start' AND ts > ?${pc}
          GROUP BY show_id
        ),
        completions AS (
@@ -465,7 +501,7 @@ export function getSummary(): AnalyticsSummary {
            SUM(CAST(json_extract(props, '$.duration_ms') AS REAL)) AS sum_duration,
            COUNT(*) AS end_count
          FROM analytics_events
-         WHERE event = 'playback_end' AND ts > ?
+         WHERE event = 'playback_end' AND ts > ?${pc}
            AND CAST(json_extract(props, '$.duration_ms') AS REAL) > 0
          GROUP BY show_id
        )
@@ -507,7 +543,7 @@ export function getSummary(): AnalyticsSummary {
        json_extract(props, '$.category') AS category,
        COUNT(*) AS uses
      FROM analytics_events
-     WHERE event = 'feature_use' AND ts > ?
+     WHERE event = 'feature_use' AND ts > ?${pc}
      GROUP BY feature, category ORDER BY uses DESC`,
     )
     .all(monthAgo) as Array<{
@@ -545,7 +581,7 @@ export function getSummary(): AnalyticsSummary {
            COUNT(DISTINCT iid) AS users
          FROM analytics_events
          WHERE event = 'feature_use'
-           AND ts > ?
+           AND ts > ?${pc}
            AND json_extract(props, '$.feature') IN (${placeholders})
            AND COALESCE(json_extract(props, '$.target_id'), json_extract(props, '$.show_id')) IS NOT NULL
          GROUP BY show_id
@@ -584,7 +620,7 @@ export function getSummary(): AnalyticsSummary {
          COUNT(*) AS sample_count
        FROM analytics_events
        WHERE event = 'playback_end'
-         AND ts > ?
+         AND ts > ?${pc}
          AND CAST(json_extract(props, '$.listened_ms') AS REAL) >= ?
          AND CAST(json_extract(props, '$.duration_ms') AS REAL) >= ?`,
     )
@@ -607,7 +643,7 @@ export function getSummary(): AnalyticsSummary {
          COUNT(*) AS plays,
          COUNT(DISTINCT iid) AS distinct_listeners
        FROM analytics_events
-       WHERE event = 'playback_start' AND ts > ?
+       WHERE event = 'playback_start' AND ts > ?${pc}
        GROUP BY source
        ORDER BY plays DESC`,
     )
@@ -624,7 +660,7 @@ export function getSummary(): AnalyticsSummary {
     (
       db
         .prepare(
-          `SELECT COUNT(*) AS c FROM analytics_events WHERE ts >= ?`,
+          `SELECT COUNT(*) AS c FROM analytics_events WHERE ts >= ?${pc}`,
         )
         .get(todayStart) as { c: number }
     )?.c ?? 0;
@@ -669,10 +705,14 @@ export interface RetentionCohort {
  * report null for that bucket so the UI can render a hatched / "—" cell
  * instead of misleading 0%. Defaults to the last 12 weeks of cohorts.
  */
-export function getRetentionCohorts(weeks = 12): RetentionCohort[] {
+export function getRetentionCohorts(
+  weeks = 12,
+  platforms?: string[],
+): RetentionCohort[] {
   const db = getAnalyticsDb();
   const oldestWeekStart = Date.now() - weeks * 7 * 24 * 3600 * 1000;
   const todayDay = new Date().toISOString().slice(0, 10);
+  const pc = platformClause(platforms);
 
   return db
     .prepare(
@@ -681,14 +721,14 @@ export function getRetentionCohorts(weeks = 12): RetentionCohort[] {
                 MIN(ts) AS install_ts,
                 date(MIN(ts) / 1000, 'unixepoch') AS install_day
          FROM analytics_events
-         WHERE event = 'app_open'
+         WHERE event = 'app_open'${pc}
          GROUP BY iid
          HAVING install_ts >= ?
        ),
        active AS (
          SELECT DISTINCT iid, date(ts / 1000, 'unixepoch') AS active_day
          FROM analytics_events
-         WHERE event = 'app_open'
+         WHERE event = 'app_open'${pc}
        )
        SELECT
          strftime('%Y-W%W', f.install_day) AS cohort_week,
@@ -733,9 +773,15 @@ const TOP_SHOWS_COMPLETION_MIN_ENDS_PARAM = 5;
  * Limits to top 20 (UI may render fewer) and filters tiny-sample shows
  * out of the completion column the same way the summary does.
  */
-export function getTopShows(days: number, limit = 20): TopShowRow[] {
+export function getTopShows(
+  days: number,
+  limit = 20,
+  platforms?: string[],
+): TopShowRow[] {
   const db = getAnalyticsDb();
   const cutoff = Date.now() - days * 24 * 3600 * 1000;
+  const pc = platformClause(platforms);
+  const pcS = platformClause(platforms, "s.platform");
   return db
     .prepare(
       `WITH listens AS (
@@ -750,14 +796,14 @@ export function getTopShows(days: number, limit = 20): TopShowRow[] {
            AND json_extract(e.props, '$.show_id') = json_extract(s.props, '$.show_id')
            AND e.ts BETWEEN s.ts AND s.ts + ?
            AND CAST(json_extract(e.props, '$.listened_ms') AS REAL) >= ?
-         WHERE s.event = 'playback_start' AND s.ts > ?
+         WHERE s.event = 'playback_start' AND s.ts > ?${pcS}
        ),
        track_plays AS (
          SELECT
            json_extract(props, '$.show_id') AS show_id,
            COUNT(*) AS track_plays
          FROM analytics_events
-         WHERE event = 'playback_start' AND ts > ?
+         WHERE event = 'playback_start' AND ts > ?${pc}
          GROUP BY show_id
        ),
        completions AS (
@@ -772,7 +818,7 @@ export function getTopShows(days: number, limit = 20): TopShowRow[] {
            SUM(CAST(json_extract(props, '$.duration_ms') AS REAL)) AS sum_duration,
            COUNT(*) AS end_count
          FROM analytics_events
-         WHERE event = 'playback_end' AND ts > ?
+         WHERE event = 'playback_end' AND ts > ?${pc}
            AND CAST(json_extract(props, '$.duration_ms') AS REAL) > 0
          GROUP BY show_id
        )
@@ -851,12 +897,13 @@ const LIVE_END_WINDOW_MS = 2 * 60 * 1000;
  *  window. */
 const NON_TERMINAL_END_REASONS_SQL = `('app_backgrounded')`;
 
-export function getLiveListeners(): LiveListener[] {
+export function getLiveListeners(platforms?: string[]): LiveListener[] {
   const db = getAnalyticsDb();
   const now = Date.now();
   const startWindowStart = now - LIVE_START_WINDOW_MS;
   const endWindowStart = now - LIVE_END_WINDOW_MS;
   const lookbackStart = now - 6 * 3600 * 1000;
+  const pc = platformClause(platforms);
 
   // Pick the latest playback event per iid (start or end), then keep
   // only those whose latest event qualifies under the dual-window rule.
@@ -880,7 +927,7 @@ export function getLiveListeners(): LiveListener[] {
            ROW_NUMBER() OVER (PARTITION BY iid ORDER BY ts DESC) AS rn
          FROM analytics_events
          WHERE event IN ('playback_start', 'playback_end')
-           AND ts >= ?
+           AND ts >= ?${pc}
            AND json_extract(props, '$.show_id') IS NOT NULL
            AND NOT (
              event = 'playback_end'
@@ -961,9 +1008,13 @@ export interface SearchQuality {
   top_successful: Array<{ query: string; count: number }>;
 }
 
-export function getSearchQuality(days = 30): SearchQuality {
+export function getSearchQuality(
+  days = 30,
+  platforms?: string[],
+): SearchQuality {
   const db = getAnalyticsDb();
   const cutoff = Date.now() - days * 24 * 3600 * 1000;
+  const pc = platformClause(platforms);
 
   const overview = db
     .prepare(
@@ -972,7 +1023,7 @@ export function getSearchQuality(days = 30): SearchQuality {
          COUNT(CASE WHEN json_extract(props, '$.result_count') = 0 THEN 1 END) AS zero_result_count,
          COUNT(CASE WHEN json_extract(props, '$.selected_index') IS NULL THEN 1 END) AS abandon_count
        FROM analytics_events
-       WHERE event = 'search' AND ts > ?`,
+       WHERE event = 'search' AND ts > ?${pc}`,
     )
     .get(cutoff) as {
     total_searches: number;
@@ -987,7 +1038,7 @@ export function getSearchQuality(days = 30): SearchQuality {
     .prepare(
       `SELECT CAST(json_extract(props, '$.selected_index') AS INTEGER) AS si
        FROM analytics_events
-       WHERE event = 'search' AND ts > ?
+       WHERE event = 'search' AND ts > ?${pc}
          AND json_extract(props, '$.selected_index') IS NOT NULL`,
     )
     .all(cutoff) as Array<{ si: number }>;
@@ -1010,7 +1061,7 @@ export function getSearchQuality(days = 30): SearchQuality {
     .prepare(
       `SELECT json_extract(props, '$.query') AS query, COUNT(*) AS count
        FROM analytics_events
-       WHERE event = 'search' AND ts > ?
+       WHERE event = 'search' AND ts > ?${pc}
          AND json_extract(props, '$.result_count') = 0
          AND length(TRIM(json_extract(props, '$.query'))) >= 3
        GROUP BY query
@@ -1023,7 +1074,7 @@ export function getSearchQuality(days = 30): SearchQuality {
     .prepare(
       `SELECT json_extract(props, '$.query') AS query, COUNT(*) AS count
        FROM analytics_events
-       WHERE event = 'search' AND ts > ?
+       WHERE event = 'search' AND ts > ?${pc}
          AND CAST(json_extract(props, '$.result_count') AS INTEGER) > 0
          AND length(TRIM(json_extract(props, '$.query'))) >= 3
        GROUP BY query
@@ -1057,9 +1108,23 @@ export interface GrowthDay {
  * the platform of its first event. Window is the last `days` days
  * inclusive.
  */
-export function getGrowthByPlatform(days = 60): GrowthDay[] {
+export function getGrowthByPlatform(
+  days = 60,
+  platforms?: string[],
+): GrowthDay[] {
   const db = getAnalyticsDb();
   const cutoff = Date.now() - days * 24 * 3600 * 1000;
+  // Each iid is attributed to its first event's platform, so the platform
+  // filter is applied after that attribution: a deselected platform is
+  // dropped from both its own series and the daily total. null = show all.
+  const selected =
+    platforms && platforms.length
+      ? new Set(
+          platforms.filter((p) =>
+            (KNOWN_PLATFORMS as readonly string[]).includes(p),
+          ),
+        )
+      : null;
 
   const rows = db
     .prepare(
@@ -1079,6 +1144,7 @@ export function getGrowthByPlatform(days = 60): GrowthDay[] {
 
   const byDay = new Map<string, GrowthDay>();
   for (const r of rows) {
+    if (selected && !selected.has(r.platform)) continue;
     const slot =
       byDay.get(r.day) ??
       ({ day: r.day, ios: 0, android: 0, web: 0, total: 0 } as GrowthDay);
@@ -1102,29 +1168,34 @@ export interface TimeseriesPoint {
   value: number;
 }
 
-export function getTimeseries(metric: TimeseriesMetric, days: number): TimeseriesPoint[] {
+export function getTimeseries(
+  metric: TimeseriesMetric,
+  days: number,
+  platforms?: string[],
+): TimeseriesPoint[] {
   const db = getAnalyticsDb();
   const cutoff = Date.now() - days * 24 * 3600 * 1000;
+  const pc = platformClause(platforms);
 
   switch (metric) {
     case "dau":
       return db.prepare(`
         SELECT date(ts / 1000, 'unixepoch') AS day, COUNT(DISTINCT iid) AS value
-        FROM analytics_events WHERE event = 'app_open' AND ts > ?
+        FROM analytics_events WHERE event = 'app_open' AND ts > ?${pc}
         GROUP BY day ORDER BY day ASC
       `).all(cutoff) as TimeseriesPoint[];
 
     case "events":
       return db.prepare(`
         SELECT date(ts / 1000, 'unixepoch') AS day, COUNT(*) AS value
-        FROM analytics_events WHERE ts > ?
+        FROM analytics_events WHERE ts > ?${pc}
         GROUP BY day ORDER BY day ASC
       `).all(cutoff) as TimeseriesPoint[];
 
     case "playback_starts":
       return db.prepare(`
         SELECT date(ts / 1000, 'unixepoch') AS day, COUNT(*) AS value
-        FROM analytics_events WHERE event = 'playback_start' AND ts > ?
+        FROM analytics_events WHERE event = 'playback_start' AND ts > ?${pc}
         GROUP BY day ORDER BY day ASC
       `).all(cutoff) as TimeseriesPoint[];
 
@@ -1137,6 +1208,7 @@ export function getTimeseries(metric: TimeseriesMetric, days: number): Timeserie
         WITH first_seen AS (
           SELECT iid, MIN(ts) AS first_ts
           FROM analytics_events
+          WHERE 1=1${pc}
           GROUP BY iid
         )
         SELECT date(first_ts / 1000, 'unixepoch') AS day,
@@ -1286,12 +1358,14 @@ export interface RecentListeningSession {
 export function getRecentListening(
   hours = 24,
   limit = 100,
+  platforms?: string[],
 ): RecentListeningSession[] {
   const db = getAnalyticsDb();
   const now = Date.now();
   const windowStart = now - hours * 3600 * 1000;
   const liveStartWindow = now - LIVE_START_WINDOW_MS;
   const liveEndWindow = now - LIVE_END_WINDOW_MS;
+  const pc = platformClause(platforms);
   // Inner lookback for "what's this iid's most recent event overall" —
   // must be at least as wide as the longer of the two live windows.
   const liveLookbackStart = liveStartWindow;
@@ -1312,7 +1386,7 @@ export function getRecentListening(
            json_extract(props, '$.source') AS source
          FROM analytics_events
          WHERE event IN ('playback_start', 'playback_end')
-           AND ts >= ?
+           AND ts >= ?${pc}
            AND json_extract(props, '$.show_id') IS NOT NULL
        ),
        agg AS (
@@ -1574,9 +1648,13 @@ export function getNetworkErrorOutcomes(
   };
 }
 
-export function getShowPlaybackSummary(days: number): ShowPlaybackSummary {
+export function getShowPlaybackSummary(
+  days: number,
+  platforms?: string[],
+): ShowPlaybackSummary {
   const db = getAnalyticsDb();
   const cutoff = Date.now() - days * 24 * 3600 * 1000;
+  const pc = platformClause(platforms);
 
   // Pull every playback_start / playback_end in the window. Track outcomes
   // require both sides — playback_end carries the reason, playback_start is
@@ -1592,7 +1670,7 @@ export function getShowPlaybackSummary(days: number): ShowPlaybackSummary {
       json_extract(props, '$.reason') AS reason
     FROM analytics_events
     WHERE event IN ('playback_start', 'playback_end')
-      AND ts > ?
+      AND ts > ?${pc}
       AND json_extract(props, '$.show_id') IS NOT NULL
     ORDER BY ts ASC
   `).all(cutoff) as Array<{
@@ -1693,13 +1771,18 @@ export interface DetailRow {
   detail?: string;
 }
 
-export function getDetail(metric: DetailMetric, filter?: string): DetailRow[] {
+export function getDetail(
+  metric: DetailMetric,
+  filter?: string,
+  platforms?: string[],
+): DetailRow[] {
   const db = getAnalyticsDb();
   const now = Date.now();
   const dayAgo = now - 24 * 3600 * 1000;
   const weekAgo = now - 7 * 24 * 3600 * 1000;
   const monthAgo = now - 30 * 24 * 3600 * 1000;
   const todayStart = new Date(new Date().toISOString().slice(0, 10)).getTime();
+  const pc = platformClause(platforms);
 
   switch (metric) {
     case "dau":
@@ -1707,7 +1790,7 @@ export function getDetail(metric: DetailMetric, filter?: string): DetailRow[] {
         SELECT iid, platform, app_version,
           datetime(MAX(ts)/1000, 'unixepoch') AS last_seen,
           COUNT(*) AS event_count
-        FROM analytics_events WHERE event = 'app_open' AND ts > ?
+        FROM analytics_events WHERE event = 'app_open' AND ts > ?${pc}
         GROUP BY iid ORDER BY MAX(ts) DESC
       `).all(dayAgo) as DetailRow[];
 
@@ -1716,7 +1799,7 @@ export function getDetail(metric: DetailMetric, filter?: string): DetailRow[] {
         SELECT iid, platform, app_version,
           datetime(MAX(ts)/1000, 'unixepoch') AS last_seen,
           COUNT(*) AS event_count
-        FROM analytics_events WHERE event = 'app_open' AND ts > ?
+        FROM analytics_events WHERE event = 'app_open' AND ts > ?${pc}
         GROUP BY iid ORDER BY MAX(ts) DESC
       `).all(weekAgo) as DetailRow[];
 
@@ -1725,7 +1808,7 @@ export function getDetail(metric: DetailMetric, filter?: string): DetailRow[] {
         SELECT iid, platform, app_version,
           datetime(MAX(ts)/1000, 'unixepoch') AS last_seen,
           COUNT(*) AS event_count
-        FROM analytics_events WHERE event = 'app_open' AND ts > ?
+        FROM analytics_events WHERE event = 'app_open' AND ts > ?${pc}
         GROUP BY iid ORDER BY MAX(ts) DESC
       `).all(monthAgo) as DetailRow[];
 
@@ -1735,6 +1818,7 @@ export function getDetail(metric: DetailMetric, filter?: string): DetailRow[] {
           datetime(MAX(ts)/1000, 'unixepoch') AS last_seen,
           COUNT(*) AS event_count
         FROM analytics_events
+        WHERE 1=1${pc}
         GROUP BY iid ORDER BY MAX(ts) DESC
       `).all() as DetailRow[];
 
@@ -1744,7 +1828,7 @@ export function getDetail(metric: DetailMetric, filter?: string): DetailRow[] {
           datetime(MAX(ts)/1000, 'unixepoch') AS last_seen,
           COUNT(*) AS event_count
         FROM analytics_events
-        WHERE iid NOT IN (SELECT DISTINCT iid FROM analytics_events WHERE ts > ?)
+        WHERE iid NOT IN (SELECT DISTINCT iid FROM analytics_events WHERE ts > ?${pc})${pc}
         GROUP BY iid ORDER BY MAX(ts) DESC
       `).all(monthAgo) as DetailRow[];
 
@@ -1754,7 +1838,7 @@ export function getDetail(metric: DetailMetric, filter?: string): DetailRow[] {
           iid,
           datetime(ts/1000, 'unixepoch') AS last_seen,
           1 AS event_count
-        FROM analytics_events WHERE ts >= ?
+        FROM analytics_events WHERE ts >= ?${pc}
         ORDER BY ts DESC LIMIT 500
       `).all(todayStart) as DetailRow[];
 
@@ -1765,7 +1849,7 @@ export function getDetail(metric: DetailMetric, filter?: string): DetailRow[] {
       if (filter) {
         return db.prepare(`
           WITH first_seen AS (
-            SELECT iid, MIN(ts) AS first_ts FROM analytics_events GROUP BY iid
+            SELECT iid, MIN(ts) AS first_ts FROM analytics_events WHERE 1=1${pc} GROUP BY iid
           )
           SELECT
             f.iid,
@@ -1781,7 +1865,7 @@ export function getDetail(metric: DetailMetric, filter?: string): DetailRow[] {
       }
       return db.prepare(`
         WITH first_seen AS (
-          SELECT iid, MIN(ts) AS first_ts FROM analytics_events GROUP BY iid
+          SELECT iid, MIN(ts) AS first_ts FROM analytics_events WHERE 1=1${pc} GROUP BY iid
         )
         SELECT
           f.iid,
@@ -1810,7 +1894,7 @@ export function getDetail(metric: DetailMetric, filter?: string): DetailRow[] {
             datetime(ts/1000, 'unixepoch') AS last_seen,
             1 AS event_count
           FROM analytics_events
-          WHERE event = 'playback_start' AND ts > ? AND ${filterClause}
+          WHERE event = 'playback_start' AND ts > ?${pc} AND ${filterClause}
           ORDER BY ts DESC LIMIT 500
         `).all(...params) as DetailRow[];
       }
@@ -1821,7 +1905,7 @@ export function getDetail(metric: DetailMetric, filter?: string): DetailRow[] {
           datetime(ts/1000, 'unixepoch') AS last_seen,
           1 AS event_count
         FROM analytics_events
-        WHERE event = 'playback_start' AND ts > ?
+        WHERE event = 'playback_start' AND ts > ?${pc}
         ORDER BY ts DESC LIMIT 500
       `).all(monthAgo) as DetailRow[];
 
@@ -1833,7 +1917,7 @@ export function getDetail(metric: DetailMetric, filter?: string): DetailRow[] {
             datetime(ts/1000, 'unixepoch') AS last_seen,
             1 AS event_count
           FROM analytics_events
-          WHERE event = 'playback_start' AND ts > ? AND json_extract(props, '$.show_id') = ?
+          WHERE event = 'playback_start' AND ts > ?${pc} AND json_extract(props, '$.show_id') = ?
           ORDER BY ts DESC LIMIT 500
         `).all(monthAgo, filter) as DetailRow[];
       }
@@ -1843,7 +1927,7 @@ export function getDetail(metric: DetailMetric, filter?: string): DetailRow[] {
           datetime(ts/1000, 'unixepoch') AS last_seen,
           1 AS event_count
         FROM analytics_events
-        WHERE event = 'playback_start' AND ts > ?
+        WHERE event = 'playback_start' AND ts > ?${pc}
         ORDER BY ts DESC LIMIT 500
       `).all(monthAgo) as DetailRow[];
 
@@ -1862,7 +1946,7 @@ export function getDetail(metric: DetailMetric, filter?: string): DetailRow[] {
             datetime(ts/1000, 'unixepoch') AS last_seen,
             1 AS event_count
           FROM analytics_events
-          WHERE event = 'feature_use' AND ts > ? AND json_extract(props, '$.feature') = ?
+          WHERE event = 'feature_use' AND ts > ?${pc} AND json_extract(props, '$.feature') = ?
           ORDER BY ts DESC LIMIT 500
         `).all(monthAgo, filter) as DetailRow[];
       }
@@ -1872,7 +1956,7 @@ export function getDetail(metric: DetailMetric, filter?: string): DetailRow[] {
           datetime(ts/1000, 'unixepoch') AS last_seen,
           1 AS event_count
         FROM analytics_events
-        WHERE event = 'feature_use' AND ts > ?
+        WHERE event = 'feature_use' AND ts > ?${pc}
         ORDER BY ts DESC LIMIT 500
       `).all(monthAgo) as DetailRow[];
 
@@ -1882,7 +1966,7 @@ export function getDetail(metric: DetailMetric, filter?: string): DetailRow[] {
           SELECT platform, iid, app_version,
             datetime(MAX(ts)/1000, 'unixepoch') AS last_seen,
             COUNT(*) AS event_count
-          FROM analytics_events WHERE event = 'app_open' AND ts > ? AND platform = ?
+          FROM analytics_events WHERE event = 'app_open' AND ts > ?${pc} AND platform = ?
           GROUP BY iid ORDER BY MAX(ts) DESC
         `).all(monthAgo, filter) as DetailRow[];
       }
@@ -1890,7 +1974,7 @@ export function getDetail(metric: DetailMetric, filter?: string): DetailRow[] {
         SELECT platform, iid, app_version,
           datetime(MAX(ts)/1000, 'unixepoch') AS last_seen,
           COUNT(*) AS event_count
-        FROM analytics_events WHERE event = 'app_open' AND ts > ?
+        FROM analytics_events WHERE event = 'app_open' AND ts > ?${pc}
         GROUP BY iid ORDER BY platform, MAX(ts) DESC
       `).all(monthAgo) as DetailRow[];
 
@@ -1901,7 +1985,7 @@ export function getDetail(metric: DetailMetric, filter?: string): DetailRow[] {
           datetime(ts/1000, 'unixepoch') AS last_seen,
           CAST(json_extract(props, '$.listened_ms') AS INTEGER) AS event_count
         FROM analytics_events
-        WHERE event = 'playback_end' AND ts > ?
+        WHERE event = 'playback_end' AND ts > ?${pc}
         ORDER BY ts DESC LIMIT 500
       `).all(monthAgo) as DetailRow[];
 

--- a/api/src/routes/analytics.ts
+++ b/api/src/routes/analytics.ts
@@ -28,6 +28,22 @@ import { requireAdmin } from "../auth/middleware.js";
 import { ANALYTICS_WATERSHED } from "../analytics-watershed.js";
 
 const VALID_PLATFORMS = new Set(["ios", "android", "web"]);
+
+/**
+ * Parse the admin dashboard's `?platforms=ios,android` filter into a
+ * validated allowlist. Returns undefined when the param is absent or
+ * resolves to no known platforms — the db layer treats that as "all
+ * platforms" (no filter). Unknown tokens are dropped silently.
+ */
+function parsePlatforms(raw: unknown): string[] | undefined {
+  if (typeof raw !== "string" || raw.trim() === "") return undefined;
+  const list = raw
+    .split(",")
+    .map((p) => p.trim())
+    .filter((p) => VALID_PLATFORMS.has(p));
+  return list.length > 0 ? list : undefined;
+}
+
 const MAX_EVENTS_PER_BATCH = 100;
 const MAX_PROP_STRING_LENGTH = 500;
 
@@ -223,7 +239,13 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
         tags: ["analytics"],
         summary: "Analytics summary (admin)",
         description:
-          "Returns key metrics: DAU/WAU/MAU, top shows, platform split, feature adoption.",
+          "Returns key metrics: DAU/WAU/MAU, top shows, platform split, feature adoption. Optional `platforms` (comma-separated) restricts every metric to the selected platforms.",
+        querystring: {
+          type: "object",
+          properties: {
+            platforms: { type: "string" },
+          },
+        },
         response: {
           200: {
             type: "object",
@@ -359,8 +381,9 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
       },
       preHandler: requireAdmin,
     },
-    async () => {
-      return getSummary();
+    async (request) => {
+      const { platforms } = request.query as { platforms?: string };
+      return getSummary(parsePlatforms(platforms));
     },
   );
 
@@ -383,6 +406,7 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
           properties: {
             metric: { type: "string" },
             filter: { type: "string" },
+            platforms: { type: "string" },
           },
         },
         response: {
@@ -409,11 +433,15 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
       preHandler: requireAdmin,
     },
     async (request, reply) => {
-      const { metric, filter } = request.query as { metric: string; filter?: string };
+      const { metric, filter, platforms } = request.query as {
+        metric: string;
+        filter?: string;
+        platforms?: string;
+      };
       if (!VALID_METRICS.has(metric)) {
         return reply.code(400).send({ error: `Invalid metric: ${metric}` });
       }
-      return getDetail(metric as DetailMetric, filter);
+      return getDetail(metric as DetailMetric, filter, parsePlatforms(platforms));
     },
   );
 
@@ -487,15 +515,19 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
           type: "object",
           properties: {
             days: { type: "number", default: 30 },
+            platforms: { type: "string" },
           },
         },
       },
       preHandler: requireAdmin,
     },
     async (request) => {
-      const { days } = request.query as { days?: number };
+      const { days, platforms } = request.query as {
+        days?: number;
+        platforms?: string;
+      };
       const clampedDays = Math.min(Math.max(days ?? 30, 1), 90);
-      return getShowPlaybackSummary(clampedDays);
+      return getShowPlaybackSummary(clampedDays, parsePlatforms(platforms));
     },
   );
 
@@ -516,6 +548,7 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
           properties: {
             metric: { type: "string" },
             days: { type: "number", default: 14 },
+            platforms: { type: "string" },
           },
         },
         response: {
@@ -538,12 +571,16 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
       preHandler: requireAdmin,
     },
     async (request, reply) => {
-      const { metric, days } = request.query as { metric: string; days?: number };
+      const { metric, days, platforms } = request.query as {
+        metric: string;
+        days?: number;
+        platforms?: string;
+      };
       if (!VALID_TS_METRICS.has(metric)) {
         return reply.code(400).send({ error: `Invalid metric: ${metric}` });
       }
       const clampedDays = Math.min(Math.max(days ?? 14, 1), 90);
-      return getTimeseries(metric as TimeseriesMetric, clampedDays);
+      return getTimeseries(metric as TimeseriesMetric, clampedDays, parsePlatforms(platforms));
     },
   );
 
@@ -559,6 +596,7 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
           properties: {
             days: { type: "number", default: 30 },
             limit: { type: "number", default: 20 },
+            platforms: { type: "string" },
           },
         },
         response: {
@@ -584,10 +622,16 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
       preHandler: requireAdmin,
     },
     async (request) => {
-      const { days, limit } = request.query as { days?: number; limit?: number };
+      const { days, limit, platforms } = request.query as {
+        days?: number;
+        limit?: number;
+        platforms?: string;
+      };
       const clampedDays = Math.min(Math.max(days ?? 30, 1), 365);
       const clampedLimit = Math.min(Math.max(limit ?? 20, 1), 100);
-      return { shows: getTopShows(clampedDays, clampedLimit) };
+      return {
+        shows: getTopShows(clampedDays, clampedLimit, parsePlatforms(platforms)),
+      };
     },
   );
 
@@ -600,7 +644,10 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
         summary: "New installs per day by platform (admin)",
         querystring: {
           type: "object",
-          properties: { days: { type: "number", default: 60 } },
+          properties: {
+            days: { type: "number", default: 60 },
+            platforms: { type: "string" },
+          },
         },
         response: {
           200: {
@@ -626,9 +673,12 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
       preHandler: requireAdmin,
     },
     async (request) => {
-      const { days } = request.query as { days?: number };
+      const { days, platforms } = request.query as {
+        days?: number;
+        platforms?: string;
+      };
       const clamped = Math.min(Math.max(days ?? 60, 1), 365);
-      return { days: getGrowthByPlatform(clamped) };
+      return { days: getGrowthByPlatform(clamped, parsePlatforms(platforms)) };
     },
   );
 
@@ -639,6 +689,12 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
       schema: {
         tags: ["analytics"],
         summary: "Currently listening (admin)",
+        querystring: {
+          type: "object",
+          properties: {
+            platforms: { type: "string" },
+          },
+        },
         response: {
           200: {
             type: "object",
@@ -675,7 +731,10 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
       },
       preHandler: requireAdmin,
     },
-    async () => ({ listeners: getLiveListeners() }),
+    async (request) => {
+      const { platforms } = request.query as { platforms?: string };
+      return { listeners: getLiveListeners(parsePlatforms(platforms)) };
+    },
   );
 
   // GET /api/analytics/recent-listening — finished sessions in the last N hours.
@@ -690,6 +749,7 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
           properties: {
             hours: { type: "number", default: 24 },
             limit: { type: "number", default: 100 },
+            platforms: { type: "string" },
           },
         },
         response: {
@@ -732,14 +792,19 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
       preHandler: requireAdmin,
     },
     async (request) => {
-      const { hours, limit } = request.query as {
+      const { hours, limit, platforms } = request.query as {
         hours?: number;
         limit?: number;
+        platforms?: string;
       };
       const clampedHours = Math.min(Math.max(hours ?? 24, 1), 168);
       const clampedLimit = Math.min(Math.max(limit ?? 100, 1), 500);
       return {
-        sessions: getRecentListening(clampedHours, clampedLimit),
+        sessions: getRecentListening(
+          clampedHours,
+          clampedLimit,
+          parsePlatforms(platforms),
+        ),
       };
     },
   );
@@ -787,7 +852,10 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
         summary: "Search quality metrics (admin)",
         querystring: {
           type: "object",
-          properties: { days: { type: "number", default: 30 } },
+          properties: {
+            days: { type: "number", default: 30 },
+            platforms: { type: "string" },
+          },
         },
         response: {
           200: {
@@ -824,9 +892,12 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
       preHandler: requireAdmin,
     },
     async (request) => {
-      const { days } = request.query as { days?: number };
+      const { days, platforms } = request.query as {
+        days?: number;
+        platforms?: string;
+      };
       const clamped = Math.min(Math.max(days ?? 30, 1), 90);
-      return getSearchQuality(clamped);
+      return getSearchQuality(clamped, parsePlatforms(platforms));
     },
   );
 
@@ -841,6 +912,7 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
           type: "object",
           properties: {
             weeks: { type: "number", default: 12 },
+            platforms: { type: "string" },
           },
         },
         response: {
@@ -867,9 +939,12 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
       preHandler: requireAdmin,
     },
     async (request) => {
-      const { weeks } = request.query as { weeks?: number };
+      const { weeks, platforms } = request.query as {
+        weeks?: number;
+        platforms?: string;
+      };
       const clamped = Math.min(Math.max(weeks ?? 12, 1), 52);
-      return { cohorts: getRetentionCohorts(clamped) };
+      return { cohorts: getRetentionCohorts(clamped, parsePlatforms(platforms)) };
     },
   );
 

--- a/ui/src/app/admin/analytics/AnalyticsDashboard.tsx
+++ b/ui/src/app/admin/analytics/AnalyticsDashboard.tsx
@@ -20,6 +20,11 @@ import CollapsibleSection from "./components/CollapsibleSection";
 import ShowEngagement, { TopShowsByAction } from "./components/ShowEngagement";
 import { WatchedInstallsProvider } from "./components/WatchedInstallsContext";
 import WatchedInstallsPanel from "./components/WatchedInstallsPanel";
+import {
+  PlatformFilterProvider,
+  usePlatformFilter,
+} from "./components/PlatformFilterContext";
+import PlatformToggles from "./components/PlatformToggles";
 
 interface FeatureAdoptionEntry {
   feature: string;
@@ -113,9 +118,11 @@ const DASH_SCROLL_KEY = "__analytics_dashboard_scroll";
 
 export default function AnalyticsDashboard(props: { showNames: ShowName[] }) {
   return (
-    <WatchedInstallsProvider>
-      <AnalyticsDashboardInner {...props} />
-    </WatchedInstallsProvider>
+    <PlatformFilterProvider>
+      <WatchedInstallsProvider>
+        <AnalyticsDashboardInner {...props} />
+      </WatchedInstallsProvider>
+    </PlatformFilterProvider>
   );
 }
 
@@ -123,6 +130,7 @@ function AnalyticsDashboardInner({ showNames }: { showNames: ShowName[] }) {
   const { user, isLoading: authLoading } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { withParam } = usePlatformFilter();
   const [data, setData] = useState<AnalyticsSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -171,7 +179,7 @@ function AnalyticsDashboardInner({ showNames }: { showNames: ShowName[] }) {
 
   const fetchSummary = useCallback(async () => {
     try {
-      const res = await fetch("/api/analytics/summary", { credentials: "include" });
+      const res = await fetch(withParam("/api/analytics/summary"), { credentials: "include" });
       if (res.status === 403) {
         setError("Forbidden");
         return;
@@ -185,20 +193,20 @@ function AnalyticsDashboardInner({ showNames }: { showNames: ShowName[] }) {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [withParam]);
 
   const fetchTimeseries = useCallback(async () => {
     try {
       const [dau, events] = await Promise.all([
-        fetch("/api/analytics/timeseries?metric=dau&days=14", { credentials: "include" }).then((r) => r.json()),
-        fetch("/api/analytics/timeseries?metric=events&days=14", { credentials: "include" }).then((r) => r.json()),
+        fetch(withParam("/api/analytics/timeseries?metric=dau&days=14"), { credentials: "include" }).then((r) => r.json()),
+        fetch(withParam("/api/analytics/timeseries?metric=events&days=14"), { credentials: "include" }).then((r) => r.json()),
       ]);
       setDauTs(dau);
       setEventsTs(events);
     } catch {
       // non-critical
     }
-  }, []);
+  }, [withParam]);
 
   // Auth + initial load
   useEffect(() => {
@@ -306,6 +314,7 @@ function AnalyticsDashboardInner({ showNames }: { showNames: ShowName[] }) {
           <a href="/admin/beta" className="text-sm text-zinc-500 hover:text-zinc-300">Beta &rarr;</a>
         </div>
         <div className="flex items-center gap-3 flex-wrap">
+          <PlatformToggles />
           <button
             onClick={() => setWatchedOnly((v) => !v)}
             className={`text-xs px-2 py-1 rounded border transition-colors ${
@@ -428,14 +437,14 @@ function AnalyticsDashboardInner({ showNames }: { showNames: ShowName[] }) {
             label="Total Installs"
             value={data.total_installs}
             unit="install"
-            hint="Distinct iids ever seen"
+            hint="Distinct installs ever seen on the selected platforms (web is off by default — it's browser usage, not an installed app)"
             onClick={() => openDetail("total_installs")}
           />
           <MetricCard
             label="Stale (30d)"
             value={data.stale_installs_30d}
             unit="install"
-            hint="Seen ever, not seen in last 30 days"
+            hint="Seen ever on the selected platforms, not seen in last 30 days"
             onClick={() => openDetail("stale_installs")}
           />
           <MetricCard

--- a/ui/src/app/admin/analytics/AnalyticsDashboard.tsx
+++ b/ui/src/app/admin/analytics/AnalyticsDashboard.tsx
@@ -347,8 +347,8 @@ function AnalyticsDashboardInner({ showNames }: { showNames: ShowName[] }) {
         </div>
       </div>
 
-      {/* Watched installs */}
-      <CollapsibleSection title="Watched installs" forceOpen={forceOpen}>
+      {/* Watched installs — collapsed by default; a power-user drill-down */}
+      <CollapsibleSection title="Watched installs" defaultOpen={false} forceOpen={forceOpen}>
         <WatchedInstallsPanel onOpenInstall={openInstall} />
       </CollapsibleSection>
 
@@ -361,8 +361,8 @@ function AnalyticsDashboardInner({ showNames }: { showNames: ShowName[] }) {
         />
       </CollapsibleSection>
 
-      {/* Recent Listening (finished sessions, last 24h) */}
-      <CollapsibleSection title="Recent Listening (24h)" forceOpen={forceOpen}>
+      {/* Recent Listening (finished sessions, last 24h) — collapsed by default */}
+      <CollapsibleSection title="Recent Listening (24h)" defaultOpen={false} forceOpen={forceOpen}>
         <RecentListening
           showMap={showMap}
           onOpenInstall={openInstall}
@@ -370,34 +370,22 @@ function AnalyticsDashboardInner({ showNames }: { showNames: ShowName[] }) {
         />
       </CollapsibleSection>
 
-      {/* Network error recovery */}
-      <CollapsibleSection
-        title="Network error recovery"
-        forceOpen={forceOpen}
-      >
-        <NetworkErrorOutcomes showMap={showMap} onOpenInstall={openInstall} />
-      </CollapsibleSection>
-
       {watchedOnly ? null : <>
-      {/* Most-listened shows */}
-      <CollapsibleSection
-        title="Most-listened shows"
-        forceOpen={forceOpen}
-        onDetail={() => openDetail("top_shows")}
-      >
-        <TopShowsList
-          showMap={showMap}
-          onShowClick={(id) => openDetail("top_shows", id)}
-        />
-      </CollapsibleSection>
-
-      {/* Growth */}
+      {/* Growth — lead the aggregates with the headline trend */}
       <CollapsibleSection
         title="Growth (60d)"
         forceOpen={forceOpen}
         onDetail={() => openDetail("new_installs")}
       >
         <GrowthChart onDayClick={(day) => openDetail("new_installs", day)} />
+      </CollapsibleSection>
+
+      {/* Installs by platform */}
+      <CollapsibleSection title="Active installs by platform (30d)" forceOpen={forceOpen} onDetail={() => openDetail("platform_split")}>
+        <PlatformChart
+          data={data.platform_split}
+          onPlatformClick={(p) => openDetail("platform_split", p)}
+        />
       </CollapsibleSection>
 
       {/* Active Users */}
@@ -466,11 +454,15 @@ function AnalyticsDashboardInner({ showNames }: { showNames: ShowName[] }) {
         </div>
       </CollapsibleSection>
 
-      {/* Platform Split */}
-      <CollapsibleSection title="Active installs by platform (30d)" forceOpen={forceOpen} onDetail={() => openDetail("platform_split")}>
-        <PlatformChart
-          data={data.platform_split}
-          onPlatformClick={(p) => openDetail("platform_split", p)}
+      {/* Most-listened shows */}
+      <CollapsibleSection
+        title="Most-listened shows"
+        forceOpen={forceOpen}
+        onDetail={() => openDetail("top_shows")}
+      >
+        <TopShowsList
+          showMap={showMap}
+          onShowClick={(id) => openDetail("top_shows", id)}
         />
       </CollapsibleSection>
 
@@ -513,6 +505,14 @@ function AnalyticsDashboardInner({ showNames }: { showNames: ShowName[] }) {
         />
       </CollapsibleSection>
       </>}
+
+      {/* Network error recovery — diagnostic, kept at the bottom */}
+      <CollapsibleSection
+        title="Network error recovery"
+        forceOpen={forceOpen}
+      >
+        <NetworkErrorOutcomes showMap={showMap} onOpenInstall={openInstall} />
+      </CollapsibleSection>
 
     </div>
   );

--- a/ui/src/app/admin/analytics/components/GrowthChart.tsx
+++ b/ui/src/app/admin/analytics/components/GrowthChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { usePlatformFilter } from "./PlatformFilterContext";
 
 interface GrowthDay {
   day: string;
@@ -30,6 +31,7 @@ export default function GrowthChart({
 }: {
   onDayClick?: (day: string) => void;
 }) {
+  const { withParam, param } = usePlatformFilter();
   const [days, setDays] = useState<number>(7);
   const [data, setData] = useState<GrowthDay[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -37,7 +39,7 @@ export default function GrowthChart({
 
   useEffect(() => {
     setData(null);
-    fetch(`/api/analytics/growth?days=${days}`, { credentials: "include" })
+    fetch(withParam(`/api/analytics/growth?days=${days}`), { credentials: "include" })
       .then(async (res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const body = (await res.json()) as { days: GrowthDay[] };
@@ -48,7 +50,7 @@ export default function GrowthChart({
       .catch((e: unknown) =>
         setError(e instanceof Error ? e.message : "Failed to load"),
       );
-  }, [days]);
+  }, [days, withParam, param]);
 
   const windowPicker = (
     <div className="flex items-center gap-1 ml-auto">

--- a/ui/src/app/admin/analytics/components/ListeningNow.tsx
+++ b/ui/src/app/admin/analytics/components/ListeningNow.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { ListeningRow, type TrackPlay } from "./listeningRow";
 import { useWatchedInstalls } from "./WatchedInstallsContext";
+import { usePlatformFilter } from "./PlatformFilterContext";
 
 interface LiveListener {
   iid: string;
@@ -37,12 +38,13 @@ export default function ListeningNow({
   watchedOnly?: boolean;
 } = {}) {
   const { isWatched } = useWatchedInstalls();
+  const { withParam, param } = usePlatformFilter();
   const [listeners, setListeners] = useState<LiveListener[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const fetchData = async () => {
     try {
-      const res = await fetch("/api/analytics/live", { credentials: "include" });
+      const res = await fetch(withParam("/api/analytics/live"), { credentials: "include" });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const body = (await res.json()) as { listeners: LiveListener[] };
       setListeners(body.listeners);
@@ -56,7 +58,8 @@ export default function ListeningNow({
     fetchData();
     const id = setInterval(fetchData, POLL_INTERVAL_MS);
     return () => clearInterval(id);
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [param]);
 
   if (error)
     return <p className="text-sm text-red-400">Listening Now error: {error}</p>;

--- a/ui/src/app/admin/analytics/components/MetricDetailView.tsx
+++ b/ui/src/app/admin/analytics/components/MetricDetailView.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { emojiForId } from "./emojiId";
 import { useWatchedInstalls } from "./WatchedInstallsContext";
+import { usePlatformFilter } from "./PlatformFilterContext";
 
 const SHOW_ID_RE = /^\d{4}-\d{2}-\d{2}(-[\w-]+)?$/;
 function isShowId(value: string): boolean {
@@ -68,6 +69,7 @@ interface Props {
 export default function MetricDetailView({ metric, filter, backHref }: Props) {
   const router = useRouter();
   const { isWatched, nameFor, setWatched, unwatch } = useWatchedInstalls();
+  const { withParam, param } = usePlatformFilter();
   const [rows, setRows] = useState<DetailRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [sortKey, setSortKey] = useState<SortKey>("last_seen");
@@ -82,7 +84,7 @@ export default function MetricDetailView({ metric, filter, backHref }: Props) {
     setLoading(true);
     const params = new URLSearchParams({ metric });
     if (filter) params.set("filter", filter);
-    fetch(`/api/analytics/detail?${params}`, { credentials: "include" })
+    fetch(withParam(`/api/analytics/detail?${params}`), { credentials: "include" })
       .then((r) => (r.ok ? r.json() : []))
       .then((data: DetailRow[]) => {
         if (!cancelled) setRows(data);
@@ -96,7 +98,7 @@ export default function MetricDetailView({ metric, filter, backHref }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [metric, filter]);
+  }, [metric, filter, withParam, param]);
 
   const sortedRows = useMemo(() => {
     const sorted = [...rows];

--- a/ui/src/app/admin/analytics/components/PlatformFilterContext.tsx
+++ b/ui/src/app/admin/analytics/components/PlatformFilterContext.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+/** Platforms the analytics pipeline emits, with display labels for the
+ *  toggle chips. Keep in sync with KNOWN_PLATFORMS in api/src/db/analytics.ts. */
+export const PLATFORMS = [
+  { id: "ios", label: "iOS" },
+  { id: "android", label: "Android" },
+  { id: "web", label: "Web" },
+] as const;
+
+export type PlatformId = (typeof PLATFORMS)[number]["id"];
+
+const ALL_IDS = PLATFORMS.map((p) => p.id) as PlatformId[];
+
+// `web` is browser usage, not an installed app, so the dashboard opens with
+// it filtered out of every install/active-user count. Admins can flip it on.
+const DEFAULT: PlatformId[] = ["ios", "android"];
+
+const STORAGE_KEY = "analytics:platform-filter";
+
+interface PlatformFilterValue {
+  /** Currently selected platforms (always ≥1). */
+  platforms: PlatformId[];
+  isSelected: (p: PlatformId) => boolean;
+  /** Toggle one platform on/off. Refuses to clear the last selected one so
+   *  there is always at least one platform in view. */
+  toggle: (p: PlatformId) => void;
+  /**
+   * Query value to send to the API, or "" when every platform is selected
+   * (the server treats an absent/full filter as "all", so we omit it to keep
+   * URLs clean and the request indistinguishable from the legacy unfiltered
+   * call). Use this as a fetch dependency so panels refetch on change.
+   */
+  param: string;
+  /** Append `?platforms=…` / `&platforms=…` to a URL when a filter is active. */
+  withParam: (url: string) => string;
+}
+
+const PlatformFilterContext = createContext<PlatformFilterValue | null>(null);
+
+function loadInitial(): PlatformId[] {
+  if (typeof window === "undefined") return DEFAULT;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return DEFAULT;
+    const valid = parsed.filter((p): p is PlatformId =>
+      (ALL_IDS as string[]).includes(p as string),
+    );
+    return valid.length > 0 ? valid : DEFAULT;
+  } catch {
+    return DEFAULT;
+  }
+}
+
+export function PlatformFilterProvider({ children }: { children: ReactNode }) {
+  const [platforms, setPlatforms] = useState<PlatformId[]>(loadInitial);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(platforms));
+    } catch {
+      /* ignore quota / privacy-mode errors */
+    }
+  }, [platforms]);
+
+  const toggle = useCallback((p: PlatformId) => {
+    setPlatforms((prev) => {
+      if (prev.includes(p)) {
+        // Never let the selection become empty.
+        if (prev.length === 1) return prev;
+        return prev.filter((x) => x !== p);
+      }
+      // Preserve canonical order so the param string is stable.
+      return ALL_IDS.filter((x) => prev.includes(x) || x === p);
+    });
+  }, []);
+
+  const isSelected = useCallback(
+    (p: PlatformId) => platforms.includes(p),
+    [platforms],
+  );
+
+  const param = useMemo(() => {
+    if (platforms.length >= ALL_IDS.length) return "";
+    return platforms.join(",");
+  }, [platforms]);
+
+  const withParam = useCallback(
+    (url: string) => {
+      if (!param) return url;
+      const sep = url.includes("?") ? "&" : "?";
+      return `${url}${sep}platforms=${encodeURIComponent(param)}`;
+    },
+    [param],
+  );
+
+  const value = useMemo<PlatformFilterValue>(
+    () => ({ platforms, isSelected, toggle, param, withParam }),
+    [platforms, isSelected, toggle, param, withParam],
+  );
+
+  return (
+    <PlatformFilterContext.Provider value={value}>
+      {children}
+    </PlatformFilterContext.Provider>
+  );
+}
+
+export function usePlatformFilter(): PlatformFilterValue {
+  const ctx = useContext(PlatformFilterContext);
+  if (!ctx) {
+    throw new Error(
+      "usePlatformFilter must be used inside <PlatformFilterProvider>",
+    );
+  }
+  return ctx;
+}

--- a/ui/src/app/admin/analytics/components/PlatformToggles.tsx
+++ b/ui/src/app/admin/analytics/components/PlatformToggles.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { PLATFORMS, usePlatformFilter } from "./PlatformFilterContext";
+
+/**
+ * Header chips that scope the entire dashboard to a set of platforms.
+ * Defaults to native-only (iOS + Android) so install/active-user counts
+ * exclude web browser usage; flip Web on to fold it back in.
+ */
+export default function PlatformToggles() {
+  const { isSelected, toggle } = usePlatformFilter();
+
+  return (
+    <div
+      className="flex items-center gap-1"
+      role="group"
+      aria-label="Filter analytics by platform"
+    >
+      {PLATFORMS.map((p) => {
+        const on = isSelected(p.id);
+        return (
+          <button
+            key={p.id}
+            type="button"
+            onClick={() => toggle(p.id)}
+            aria-pressed={on}
+            title={
+              on
+                ? `${p.label} included — click to exclude`
+                : `${p.label} excluded — click to include`
+            }
+            className={`text-xs px-2 py-1 rounded border transition-colors ${
+              on
+                ? "border-deadly-blue/60 bg-deadly-blue/10 text-deadly-blue"
+                : "border-zinc-700 text-zinc-500 hover:bg-zinc-800"
+            }`}
+          >
+            {p.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/ui/src/app/admin/analytics/components/RecentListening.tsx
+++ b/ui/src/app/admin/analytics/components/RecentListening.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { ListeningRow, type TrackPlay } from "./listeningRow";
 import { useWatchedInstalls } from "./WatchedInstallsContext";
+import { usePlatformFilter } from "./PlatformFilterContext";
 
 const INITIAL_VISIBLE = 10;
 
@@ -42,6 +43,7 @@ export default function RecentListening({
   watchedOnly?: boolean;
 } = {}) {
   const { isWatched } = useWatchedInstalls();
+  const { withParam, param } = usePlatformFilter();
   const [sessions, setSessions] = useState<RecentSession[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState(false);
@@ -49,7 +51,7 @@ export default function RecentListening({
   const fetchData = async () => {
     try {
       const res = await fetch(
-        "/api/analytics/recent-listening?hours=24",
+        withParam("/api/analytics/recent-listening?hours=24"),
         { credentials: "include" },
       );
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -65,7 +67,8 @@ export default function RecentListening({
     fetchData();
     const id = setInterval(fetchData, POLL_INTERVAL_MS);
     return () => clearInterval(id);
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [param]);
 
   if (error)
     return (

--- a/ui/src/app/admin/analytics/components/RetentionCohorts.tsx
+++ b/ui/src/app/admin/analytics/components/RetentionCohorts.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { usePlatformFilter } from "./PlatformFilterContext";
 
 interface Cohort {
   cohort_week: string;
@@ -45,11 +46,12 @@ function CellRate({
 }
 
 export default function RetentionCohorts() {
+  const { withParam, param } = usePlatformFilter();
   const [cohorts, setCohorts] = useState<Cohort[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch("/api/analytics/retention?weeks=12", { credentials: "include" })
+    fetch(withParam("/api/analytics/retention?weeks=12"), { credentials: "include" })
       .then(async (res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = (await res.json()) as { cohorts: Cohort[] };
@@ -59,7 +61,7 @@ export default function RetentionCohorts() {
       .catch((e: unknown) =>
         setError(e instanceof Error ? e.message : "Failed to load"),
       );
-  }, []);
+  }, [withParam, param]);
 
   if (error) {
     return <p className="text-sm text-red-400">Retention error: {error}</p>;

--- a/ui/src/app/admin/analytics/components/SearchQuality.tsx
+++ b/ui/src/app/admin/analytics/components/SearchQuality.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { usePlatformFilter } from "./PlatformFilterContext";
 
 interface SearchQuality {
   total_searches: number;
@@ -65,11 +66,12 @@ function QueryList({
 }
 
 export default function SearchQuality() {
+  const { withParam, param } = usePlatformFilter();
   const [data, setData] = useState<SearchQuality | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch("/api/analytics/search-quality?days=30", { credentials: "include" })
+    fetch(withParam("/api/analytics/search-quality?days=30"), { credentials: "include" })
       .then(async (res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const body = (await res.json()) as SearchQuality;
@@ -79,7 +81,7 @@ export default function SearchQuality() {
       .catch((e: unknown) =>
         setError(e instanceof Error ? e.message : "Failed to load"),
       );
-  }, []);
+  }, [withParam, param]);
 
   if (error)
     return <p className="text-sm text-red-400">Search quality error: {error}</p>;

--- a/ui/src/app/admin/analytics/components/TopShowsList.tsx
+++ b/ui/src/app/admin/analytics/components/TopShowsList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { usePlatformFilter } from "./PlatformFilterContext";
 
 interface ShowInfo {
   id: string;
@@ -39,13 +40,14 @@ function formatDate(d: string): string {
 }
 
 export default function TopShowsList({ showMap, onShowClick }: TopShowsListProps) {
+  const { withParam, param } = usePlatformFilter();
   const [days, setDays] = useState(30);
   const [shows, setShows] = useState<TopShow[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     setShows(null);
-    fetch(`/api/analytics/top-shows?days=${days}`, { credentials: "include" })
+    fetch(withParam(`/api/analytics/top-shows?days=${days}`), { credentials: "include" })
       .then(async (res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const body = (await res.json()) as { shows: TopShow[] };
@@ -55,7 +57,7 @@ export default function TopShowsList({ showMap, onShowClick }: TopShowsListProps
       .catch((e: unknown) =>
         setError(e instanceof Error ? e.message : "Failed to load"),
       );
-  }, [days]);
+  }, [days, withParam, param]);
 
   return (
     <div className="space-y-2">

--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -14,11 +14,14 @@
 
 html,
 body {
-  /* App-like, not web-page-like: kill the rubber-band bounce and the
-     pull-to-refresh / horizontal pan that make an installed PWA feel "floaty"
-     and draggable. No axis of the document overscrolls or scrolls sideways. */
+  /* App-like, not web-page-like: kill the rubber-band bounce and pull-to-refresh
+     that make an installed PWA feel "floaty". Note: do NOT set `overflow-x:
+     hidden` on the root here — in Firefox that disables APZ wheel/touchpad
+     scrolling of the document (scrollbar + keys still work, wheel doesn't),
+     which breaks the bare admin/auth pages. Horizontal pan is already contained
+     by the shell itself (its fixed container is overflow-hidden, and the shell
+     locks `html { overflow: hidden }` on non-bare routes via JS). */
   overscroll-behavior: none;
-  overflow-x: hidden;
 }
 
 body {

--- a/ui/src/components/shell/AppShell.tsx
+++ b/ui/src/components/shell/AppShell.tsx
@@ -130,14 +130,19 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
 
   // The shell owns a fixed h-[100dvh] viewport — the document must NOT scroll,
   // or wheeling over the pinned header/transport pages it (the body is
-  // min-h-screen). Bare routes keep normal document scroll.
+  // min-h-screen). Bare routes (admin/auth) are full document-scroll pages, so
+  // we must actively *clear* the lock when entering one — early-returning would
+  // leave a stale `overflow: hidden` from the prior shell render stuck on the
+  // document, which silently kills scrolling on e.g. the analytics dashboard.
   useEffect(() => {
-    if (bare) return;
     const html = document.documentElement;
-    const prev = html.style.overflow;
+    if (bare) {
+      html.style.overflow = "";
+      return;
+    }
     html.style.overflow = "hidden";
     return () => {
-      html.style.overflow = prev;
+      html.style.overflow = "";
     };
   }, [bare]);
 


### PR DESCRIPTION
## Summary

Several web-side fixes batched on one branch:

- **Dependabot (`b1a89ab8`)** — patch the 3 open alerts on `api/package-lock.json` (ws, cookie, vitest); 0 vulnerabilities, API tests green on vitest 4.
- **Analytics platform scoping (`041ab7eb`)** — per-platform toggles (iOS/Android/Web) that re-scope the whole dashboard; default native-only so install/active-user counts exclude web. Server-side `platformClause()` threaded through every dashboard read; new test suite proving total = native + web.
- **Firefox touchpad scroll (`590ca56d`)** — root `overflow-x: hidden` was disabling Firefox APZ wheel/touchpad scrolling on bare admin/auth pages (scrollbar + keys worked, wheel didn't). Removed it; horizontal pan is already contained by the shell.
- **Analytics reorder (`894a7f41`)** — collapse Watched installs / Recent Listening by default, surface Growth + platform split above Active Users, push Network error recovery to the bottom.

## Verification

- API: 133/133 tests pass, `tsc` clean, `npm audit` clean.
- UI: `make ui-build` clean; reorder + scroll fix verified live on the local Docker stack (8080), touchpad scroll confirmed working in real Firefox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)