### PR TITLE
fix(mobile/connect): forward external media-control pause/play to Connect

### DIFF
--- a/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
+++ b/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
@@ -175,6 +175,40 @@ class ConnectServiceImpl @Inject constructor(
             }
         }
 
+        // Forward LOCAL transport changes that bypass the in-app buttons —
+        // Bluetooth/headset media keys, the lock-screen/notification controls,
+        // Android Auto, and audio-focus pauses all drive ExoPlayer directly
+        // through the MediaSession and never call sendPause()/sendPlay(). Without
+        // this, the server keeps thinking the active device is playing, its next
+        // position broadcast arrives as playing=true, and reactToState resumes the
+        // audio a few seconds after the user paused from their headphones.
+        //
+        // We watch playWhenReady (play INTENT), not isPlaying: isPlaying drops to
+        // false on every buffering stall, which would otherwise fire a spurious
+        // pause mid-playback (and reactToState would turn that into a real pause).
+        // playWhenReady stays true through buffering and flips only on an actual
+        // pause/resume — exactly the server's `playing` semantics. We push only a
+        // DIVERGENCE from the server's view, so server-driven changes don't echo:
+        // reactToState updates _connectState before it touches the player, so by the
+        // time it flips playWhenReady the local value already equals
+        // connectState.playing and nothing is sent. A duplicate send from the in-app
+        // toggle is harmless — handlePlay/handlePause are no-ops when already in the
+        // target state.
+        scope.launch {
+            mediaControllerRepository.playWhenReady.collect { localIntendsPlay ->
+                if (!_isActiveDevice.value) return@collect
+                val serverPlaying = _connectState.value?.playing ?: return@collect
+                if (localIntendsPlay == serverPlaying) return@collect
+                if (localIntendsPlay) {
+                    Log.d(TAG, "playWhenReady reconcile: local play diverged from server (paused) — sendPlay")
+                    sendPlay()
+                } else {
+                    Log.d(TAG, "playWhenReady reconcile: local pause diverged from server (playing) — sendPause")
+                    sendPause()
+                }
+            }
+        }
+
         // When network is restored while we have a pending reconnect, cancel the
         // backoff and reconnect immediately (mirrors iOS handleNetworkRestored).
         scope.launch {

--- a/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/repository/MediaControllerRepository.kt
+++ b/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/repository/MediaControllerRepository.kt
@@ -76,6 +76,15 @@ class MediaControllerRepository @Inject constructor(
     // Playback state flows
     private val _isPlaying = MutableStateFlow(false)
     val isPlaying: StateFlow<Boolean> = _isPlaying.asStateFlow()
+
+    // Play INTENT (playWhenReady), distinct from isPlaying: this stays true through
+    // buffering stalls and flips only on an actual pause/resume — including ones
+    // driven by external surfaces (Bluetooth/headset keys, lock screen, Android
+    // Auto, audio focus) that go straight to the session. Connect reconciles
+    // against this so a headphone pause propagates without a rebuffer being
+    // mistaken for a pause.
+    private val _playWhenReady = MutableStateFlow(false)
+    val playWhenReady: StateFlow<Boolean> = _playWhenReady.asStateFlow()
     
     private val _playbackState = MutableStateFlow(PlaybackState.DEFAULT)
     val playbackState: StateFlow<PlaybackState> = _playbackState.asStateFlow()
@@ -542,7 +551,15 @@ class MediaControllerRepository @Inject constructor(
                             currentIsPlaying = isPlaying
                             updatePlaybackState()
                         }
-                        
+
+                        override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
+                            // Tracks pause/resume intent across all surfaces (UI,
+                            // headset/Bluetooth, lock screen, Android Auto, audio
+                            // focus). Connect watches this to forward external pauses.
+                            Log.d(TAG, "🕒🎵 [AUDIO] playWhenReady=$playWhenReady (reason=$reason)")
+                            _playWhenReady.value = playWhenReady
+                        }
+
                         override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {
                             _currentTrack.value = mediaMetadata
                         }
@@ -668,6 +685,7 @@ class MediaControllerRepository @Inject constructor(
                         _mediaItemCount.value = controller.mediaItemCount
                         _isPlaying.value = controller.isPlaying
                         currentIsPlaying = controller.isPlaying
+                        _playWhenReady.value = controller.playWhenReady
                         currentExoPlayerState = controller.playbackState
                         _duration.value = controller.duration.coerceAtLeast(0L)
                         _currentPosition.value = controller.currentPosition.coerceAtLeast(0L)

--- a/iosApp/Packages/SwiftAudioStreamEx/Sources/SwiftAudioStreamEx/StreamPlayer.swift
+++ b/iosApp/Packages/SwiftAudioStreamEx/Sources/SwiftAudioStreamEx/StreamPlayer.swift
@@ -56,6 +56,19 @@ public final class StreamPlayer {
     /// uses this so the active device broadcasts the new track index to the session.
     public var onTrackComplete: (() -> Void)?
 
+    /// Called when play INTENT changes — true when the player wants to be playing
+    /// (`.playing`/`.buffering`), false when it has stopped (`.paused`/`.ended`/
+    /// `.idle`). Distinct from `playbackState.isPlaying`, which is false during
+    /// buffering stalls; intent stays true through a rebuffer and flips only on a
+    /// real pause/resume. Fires for EVERY pause source — including the lock screen,
+    /// Bluetooth/headset keys, and audio-session interruptions that drive the
+    /// engine directly — so Connect can forward those to the session. Transitional
+    /// states (`.loading`/`.error`) leave intent unchanged.
+    public var onPlayIntentChange: ((Bool) -> Void)?
+
+    /// Backing value for `onPlayIntentChange`; nil until the first definite state.
+    private var playIntent: Bool?
+
     /// Player output volume (0.0–1.0). Does not affect system volume.
     public var volume: Float {
         get { engine.volume }
@@ -438,6 +451,7 @@ public final class StreamPlayer {
             Task { @MainActor in
                 guard let self else { return }
                 self.playbackState = state
+                self.updatePlayIntent(for: state)
                 self.updateNowPlaying()
             }
         }
@@ -549,6 +563,22 @@ public final class StreamPlayer {
     }
 
     // MARK: - Private: state sync
+
+    /// Map an engine state to play intent and fire `onPlayIntentChange` on change.
+    /// `.buffering` counts as intending-to-play (a stall, not a pause), so a
+    /// rebuffer never reads as a pause. `.loading`/`.error` are transitional and
+    /// leave the last intent untouched.
+    private func updatePlayIntent(for state: PlaybackState) {
+        let intent: Bool
+        switch state {
+        case .playing, .buffering: intent = true
+        case .paused, .ended, .idle: intent = false
+        case .loading, .error: return
+        }
+        guard intent != playIntent else { return }
+        playIntent = intent
+        onPlayIntentChange?(intent)
+    }
 
     private func syncTrackFromEngine() {
         let index = engine.currentIndex

--- a/iosApp/deadly/Core/Service/ConnectService.swift
+++ b/iosApp/deadly/Core/Service/ConnectService.swift
@@ -86,6 +86,35 @@ final class ConnectService: NSObject {
         self.authService = authService
         self.streamPlayer = streamPlayer
         super.init()
+
+        // Forward LOCAL play/pause that bypassed the in-app buttons — the lock
+        // screen, Bluetooth/headset keys, CarPlay, and audio-session interruptions
+        // all drive StreamPlayer directly and never call sendPlay()/sendPause().
+        // Without this the server keeps thinking the active device is playing, its
+        // next position broadcast arrives as playing=true, and reactToState resumes
+        // the audio seconds after the user paused from their headphones.
+        streamPlayer.onPlayIntentChange = { [weak self] intent in
+            self?.reconcileLocalPlayIntent(intent)
+        }
+    }
+
+    /// Push a divergence between local play intent and the server's `playing` to
+    /// the session, but only while we're the active device. We send only on a
+    /// MISMATCH so server-driven changes don't echo: reactToState sets
+    /// `connectState` before it touches the player, so by the time the engine
+    /// reports the resulting intent the local value already equals the server's
+    /// and nothing is sent. A duplicate from the in-app toggle is harmless —
+    /// handlePlay/handlePause are no-ops when already in the target state.
+    private func reconcileLocalPlayIntent(_ localIntendsPlay: Bool) {
+        guard isActiveDevice, let serverPlaying = connectState?.playing else { return }
+        guard localIntendsPlay != serverPlaying else { return }
+        if localIntendsPlay {
+            logger.info("playIntent reconcile: local play diverged from server (paused) — sendPlay")
+            sendPlay()
+        } else {
+            logger.info("playIntent reconcile: local pause diverged from server (playing) — sendPause")
+            sendPause()
+        }
     }
 
     // MARK: - Public Interface


### PR DESCRIPTION
## Problem

On the **active** Connect device, pausing from **external OS media controls** (Bluetooth/headset keys, lock screen, CarPlay, Android Auto, audio-focus) paused local audio but then **auto-resumed ~5 seconds later**. Pausing from the in-app button held correctly.

### Root cause
External transport controls drive the local player directly — `MediaSession → ExoPlayer` (Android), `MPRemoteCommandCenter → StreamPlayer` (iOS) — and never call `sendPause()`/`sendPlay()`, which were wired **only** to the in-app toggle buttons. So the Connect server never learned of the pause, kept broadcasting `playing=true` via the active device's 5s position reports, and `reactToState`'s `server.playing && !localPlaying → play()` resumed the audio.

Confirmed against prod `[Connect]` server logs: a headphone pause produced **no** server mutation, while the active device's `playing=true` position reports continued uninterrupted.

**Web was already correct** — `navigator.mediaSession` handlers route through `togglePlayPause → sendCommand`.

## Fix

`ConnectService` now watches local **play intent** and, while this device is the active player, forwards any divergence from the server's `playing` to the session. Intent is used deliberately rather than `isPlaying`/`.playing`, which drop to false on buffering stalls and would fire spurious pauses (that `reactToState` would turn into real ones).

- **Android** — `MediaControllerRepository` exposes `playWhenReady` (`onPlayWhenReadyChanged`); reconciler collector in `ConnectServiceImpl.init`.
- **iOS** — `StreamPlayer.onPlayIntentChange`, derived from engine state (`.playing`/`.buffering` → intent true; `.paused`/`.ended`/`.idle` → false; `.loading`/`.error` unchanged); reconciler `reconcileLocalPlayIntent` wired in `ConnectService.init`.

No echo of server-driven changes: `handleMessage` sets `connectState` **before** `reactToState` touches the player, so a server pause already matches by the time the engine reports the resulting intent.

## Testing

- **Android** — built, installed on device, **verified**: headphone/lock-screen pause now holds; server goes `playing=false` and stays.
- **iOS** — compiles clean on the remote Mac; mirrors the Android logic. Recommend a real-device pass before shipping, particularly the `.buffering`-counts-as-intent path (confirm a rebuffer alone never pauses the session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)