### PR TITLE
fix(mobile/connect): background keepalive + external track-skip sync

### DIFF
--- a/PLANS/connect-background-keepalive.md
+++ b/PLANS/connect-background-keepalive.md
@@ -1,0 +1,147 @@
+# Connect — keep the WS alive while backgrounded during playback
+
+Stop tearing down the Connect WebSocket when the app backgrounds, so the
+**active, still-playing** device stays in the session while the screen is locked.
+Client-only, both platforms. No server changes.
+
+Bound by [ADR-0007](../docs/adr/0007-connect-background-socket-lifecycle.md)
+(socket lifetime follows playback/process, not the Activity/scene; #2 server
+grace and reconnect-reclaim deliberately deferred).
+
+## Status (2026-06-07)
+
+- 🔲 **Not started.** Diagnosis complete and empirically reproduced (client +
+  server logs, Android + iOS). Design agreed: ship **#1 (client keep-alive)
+  only**; explicitly **defer** server grace + reconnect-reclaim (see "Out of
+  scope").
+
+## Problem
+
+While listening with the app backgrounded (locked screen), the Connect session
+falls apart:
+
+- The **web/other devices flip to "paused" within ~4s** of locking, and the
+  scrubber freezes — even though audio keeps playing on the phone.
+- On returning to the app, the **miniplayer/player rewind to a past track**
+  (the lock screen/playlist were correct).
+
+Both are the **same root cause** and both are 100% reproducible.
+
+### Root cause — the app disconnects Connect on background
+
+The WebSocket is torn down the instant the app backgrounds:
+
+- **Android** — `MainActivity.onStop()` calls `connectService.stop()`
+  (`androidApp/app/src/main/java/com/grateful/deadly/MainActivity.kt:67`).
+- **iOS** — the `.onChange(of: scenePhase)` `.background` branch calls
+  `container.connectService.stop()`
+  (`iosApp/deadly/App/deadlyApp.swift:161-166`).
+
+Confirmed sequence (Android adb + local docker):
+
+```
+client: ConnectService: stop() called
+client: Closed: code=1000 reason=                         (clean close)
+server: unregisterDevice: iPhone[ios] / Pixel[android]
+server: mutate: playing=false activeDevice=null           → web shows paused
+```
+
+Because the device was the **active** device, the server's `unregisterDevice`
+sets `playing=false, activeDeviceId=null` and freezes `trackIndex` at its
+last-reported value. Audio keeps playing locally (Android foreground
+MediaSession service / iOS background-audio mode) and auto-advances, but
+`sendNext` is dropped on the floor (socket is gone). On foreground the client
+reconnects, the server replays its **stale** state, and the not-active branch
+syncs the local player **backward**:
+
+```
+server: State … track=10 … activeDevice=null
+client: reactToState: NOT ACTIVE — syncing track 11 -> 10   (local rewound)
+```
+
+## Fix (#1) — don't tear down on background
+
+Keep the singleton ConnectService connected when the app backgrounds. While
+audio is playing the OS keeps the process alive (Android foreground service /
+iOS background-audio), so the WS + 15s heartbeat keep running, `sendNext`/
+position reports keep flowing, and the server stays in sync. Nothing rewinds on
+return because nothing ever went stale.
+
+When playback genuinely stops and the OS suspends/kills the process, the socket
+closes on its own and the server's **existing 45s heartbeat sweep** clears the
+session. We rely on that backstop instead of an explicit background `stop()`.
+
+### Android
+- `MainActivity.onStop()` (`MainActivity.kt:63-68`): **remove the
+  `connectService.stop()` call.** Keep `mediaControllerRepository.notifyAppBackgrounded()`
+  and `analyticsService.flush()`.
+- `onStart()` still calls `connectService.startIfAuthenticated()` — already a
+  no-op when `shouldConnect` is set, so re-foregrounding won't double-connect.
+- ConnectService now stops on: explicit **logout** (existing `authService` path)
+  and **process death** (socket closes → server sweep). That's the intended
+  lifetime: the session follows playback/process, not the Activity.
+
+### iOS
+- `deadlyApp.swift:161-166`: **remove `container.connectService.stop()`** from
+  the `.background` branch. Keep `playbackRestorationService.saveNow()`.
+- `willEnterForeground` already calls `startIfAuthenticated()` (reconnect after
+  a real suspension), so the foreground path is unchanged.
+- Verify the heartbeat (`Task`/`Timer`) keeps firing during background-audio
+  execution; it should, since the app is actively running to play audio. No new
+  Info.plist capability needed (audio background mode already keeps the app
+  alive; networking is permitted while running).
+
+## Out of scope (deliberately deferred)
+
+- **Server grace period** before clearing `playing`/`activeDeviceId` on an
+  active-device socket close (#2). Only helps a **transient network drop that
+  straddles a track boundary** — rare event × narrow window × low severity (a
+  one-track rewind) — at the cost of changes to the fragile restart/transfer/
+  reclaim state machine. Build only if real-world transient-drop reports appear,
+  and prefer **client-side reconnect-reclaim** over server state then.
+- **Reconnect-reclaim loosening** (let a still-playing device re-assert forward
+  on reconnect without an epoch change). Same reasoning; the epoch gate exists
+  specifically to avoid the "was I parked or did I drop?" ambiguity.
+
+## Known residual behavior (accepted)
+
+- **iOS suspends when audio stops.** If the user pauses (or the queue ends) in
+  the background, iOS suspends within seconds and the socket dies; the server's
+  45s sweep then clears the session. → a **≤45s window** where a suspended
+  device still shows as the active owner. Cosmetic, pre-existing, tunable later
+  (shorten the sweep) if it ever matters. Not a reason to pull in #2.
+- **Transient network drop at a track boundary** still risks a one-track rewind
+  (see Out of scope).
+
+## Test matrix
+
+Reproduce against the local docker API (`make docker-up`); watch `make
+docker-logs | grep '[Connect]'` (server) + `adb logcat | grep ConnectService`
+(Android client) / Console.app subsystem `com.grateful.deadly` (iOS).
+
+- [ ] **Lock while playing (the bug):** play → lock. Web keeps `playing=true`,
+      scrubber keeps advancing. Server shows **no** `unregisterDevice` / no
+      `playing=false` on lock.
+- [ ] **Track advance while locked:** let a track end while locked → unlock.
+      Player/miniplayer show the **advanced** track (no rewind). Server
+      `trackIndex` advanced via `sendNext` while backgrounded.
+- [ ] **Foreground round-trip:** background and foreground repeatedly; no
+      double-connect, no spurious pause/play.
+- [ ] **Force-quit / swipe-away:** session clears within ~45s (heartbeat sweep);
+      web eventually shows paused. (Accepted, not instant.)
+- [ ] **Logout** still disconnects immediately.
+- [ ] **Two-device:** A active+locked keeps playing on web's view; transfer
+      A→B still works after a background round-trip.
+- [ ] iOS: confirm heartbeats keep firing while backgrounded+playing (server
+      `lastHeartbeat` stays fresh, no 45s eviction mid-playback).
+
+## Rollout
+
+Single client-only change, both platforms. Conventional commit:
+`fix(mobile/connect): keep Connect connected while backgrounded during playback`
+(`fix` + `mobile` scope → lands in both iOS and Android changelogs). No server
+deploy, no wire-format change.
+
+Relates to [[project_connect_v2_port]] and the external-media-control fix
+(`#53`, the play-intent reconciler), which assumes the active device stays
+connected while playing — this plan makes that assumption hold under lock.

--- a/androidApp/app/src/main/java/com/grateful/deadly/MainActivity.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/MainActivity.kt
@@ -64,7 +64,13 @@ class MainActivity : ComponentActivity() {
         super.onStop()
         mediaControllerRepository.notifyAppBackgrounded()
         analyticsService.flush()
-        connectService.stop()
+        // Intentionally do NOT stop Connect here. The active, still-playing device
+        // must stay in the session while backgrounded/locked (the foreground media
+        // service keeps the process — and thus the WS + heartbeat — alive). Tearing
+        // it down made the server clear the session ~4s after lock, flipping every
+        // viewer to "paused" and rewinding the player on return. The socket closes
+        // on logout or process death; the server's 45s heartbeat sweep is the
+        // backstop. See docs/adr/0007-connect-background-socket-lifecycle.md.
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
+++ b/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
@@ -223,7 +223,15 @@ class ConnectServiceImpl @Inject constructor(
         val token = authService.getAuthToken()
         Log.d(TAG, "startIfAuthenticated: token=${if (token != null) "present" else "null"}, shouldConnect=$shouldConnect")
         if (token == null) return
-        if (shouldConnect) return
+        if (shouldConnect) {
+            // Already meant to be connected. Since we no longer stop() on
+            // background, a socket that died while backgrounded (network drop)
+            // leaves shouldConnect=true; reconnect now that we're foreground
+            // instead of no-opping. handleNetworkRestored is a no-op if still
+            // connected.
+            if (!_isConnected.value) handleNetworkRestored()
+            return
+        }
         shouldConnect = true
         reconnectAttempt = 0
         connect()

--- a/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
+++ b/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
@@ -386,7 +386,27 @@ class ConnectServiceImpl @Inject constructor(
                 delay(POSITION_REPORT_INTERVAL_MS)
                 if (isActive) {
                     val positionMs = mediaControllerRepository.currentPosition.value.toInt()
-                    sendPosition(positionMs)
+                    val localIndex = mediaControllerRepository.currentTrackIndex.value
+                    val serverIndex = _connectState.value?.trackIndex
+                    if (serverIndex != null && localIndex != serverIndex) {
+                        // The active device's track changed without going through
+                        // Connect — a lock-screen / headset / Bluetooth skip drives
+                        // ExoPlayer directly (REASON_SEEK), so no sendNext fires.
+                        // Forward it as an absolute seek so the index resyncs; a bare
+                        // position report would land the new position on the stale
+                        // server index (track looks right elsewhere, progress bar wrong).
+                        // Sent via sendCommand (not sendSeek) so this background sync
+                        // doesn't arm the transport-command spinner.
+                        val durationMs = mediaControllerRepository.duration.value.toInt()
+                        Log.d(TAG, "positionReport: local track $localIndex != server $serverIndex — seek sync (pos=$positionMs)")
+                        sendCommand("seek", mapOf(
+                            "trackIndex" to localIndex,
+                            "positionMs" to positionMs,
+                            "durationMs" to durationMs,
+                        ))
+                    } else {
+                        sendPosition(positionMs)
+                    }
                 }
             }
         }

--- a/docs/adr/0007-connect-background-socket-lifecycle.md
+++ b/docs/adr/0007-connect-background-socket-lifecycle.md
@@ -1,0 +1,105 @@
+# ADR-0007: Connect — background socket lifecycle and the active-device presence boundary
+
+## Status
+
+Accepted (2026-06-07). Extends [ADR-0006](0006-connect-v2.md) (does not
+supersede it — 0006's decisions stand). Execution plan:
+[`PLANS/connect-background-keepalive.md`](../../PLANS/connect-background-keepalive.md).
+
+## Context
+
+ADR-0006 made the server the source of truth, with a 15s heartbeat / 45s sweep
+lease (decision #4) and presence defined as "live while a device is connected"
+(cost #5). It did not pin down **when the client holds the socket open** — and
+both apps tied it to the foreground UI lifecycle:
+
+- Android `MainActivity.onStop()` → `connectService.stop()`
+- iOS `deadlyApp` `.onChange(of: scenePhase) { .background → connectService.stop() }`
+
+So the socket was torn down the instant the app backgrounded. Locking the screen
+while listening — the single most common action — therefore killed the session:
+within ~4s the server's `unregisterDevice` cleared the active device
+(`playing=false, activeDeviceId=null`) while audio kept playing locally on the OS
+audio service. Two reproducible symptoms followed: every viewer (web/other
+devices) flipped to **paused** with a frozen scrubber, and on returning the
+player **rewound to a past track** (the active device auto-advanced while
+disconnected, then the reconnect replayed the server's stale `trackIndex` and the
+not-active sync path dragged the local player backward). Both are the same root
+cause: the active, still-playing device disconnecting.
+
+This also collides with the external-media-control fix
+([#53](https://github.com/ds17f/deadly-monorepo/pull/53)), which forwards
+lock-screen/headphone pauses to the session and *assumes the active device stays
+connected while it plays*.
+
+**Hard platform limit.** You cannot guarantee staying connected. iOS grants
+background execution only while audio is actively playing; once audio stops it
+suspends within seconds and a `URLSessionWebSocketTask` dies (a `.background`
+`URLSession` does not support WebSocket tasks). Drops are therefore unavoidable —
+any design must tolerate them rather than try to defeat them.
+
+## Decision
+
+1. **The Connect socket's lifetime follows playback/process, not the
+   Activity/scene.** Remove the background `stop()` calls on both platforms.
+   While audio plays the OS keeps the process alive (Android foreground
+   MediaSession service; iOS background-audio), so the WS + heartbeat keep
+   running and the active device stays in the session under lock. The socket is
+   torn down only on **explicit logout** and **process death/suspension** (the
+   close happens for free when the process dies).
+
+2. **The 45s heartbeat sweep (ADR-0006 #4) is the sole backstop** for genuine
+   suspension/death. No new background-keepalive mechanism — no `.background`
+   `URLSession`, no silent-audio trick, no extra timers.
+
+3. **We do NOT add a server-side grace period** before clearing
+   `playing`/`activeDeviceId` on an active-device socket close, and we do **not**
+   loosen the epoch-gated reconnect-reclaim. Transient-drop robustness is
+   deferred until real-world evidence shows it matters; if it does, prefer a
+   **client-side reconnect-reclaim** over new server state.
+
+4. **Presence boundary reaffirmed and sharpened (ADR-0006 cost #5):** a device is
+   in the session **only while its socket is live**. After a real suspension or
+   quit it leaves within ≤45s. We accept a ≤45s "ghost active device" window as
+   the price of *not* clearing the session instantly-but-wrongly on every
+   transient drop.
+
+## Consequences
+
+**Gains.** Locking the screen while listening keeps the session coherent on all
+viewers; the rewind-on-return is gone; the #53 external-control fix's assumption
+holds. Client-only change — no new wire fields, no server deploy, no change to
+the v2 state machine.
+
+**Costs we accept.**
+- iOS cannot stay connected once audio *stops* (it suspends): paused-in-
+  background and force-quit drop the socket and are cleared by the 45s sweep — a
+  ≤45s window where a gone device still shows as the active owner. Cosmetic,
+  pre-existing, tunable later by shortening the sweep. Not a reason to add #3's
+  server grace.
+- A transient network drop that *straddles a track boundary* while backgrounded
+  can still cause a one-track rewind on reconnect. Out of scope by decision (rare
+  × narrow window × low severity).
+- The WS lives slightly longer while backgrounded-and-playing. Negligible — the
+  radio is already up for audio streaming.
+
+## Alternatives considered
+
+- **Server grace period before clearing the active device on socket close (#2).**
+  Rejected for now. It only helps a transient network drop that coincides with a
+  track boundary — rare event × seconds-wide window × low severity (a one-track
+  rewind) — while adding a "gone but still active for N seconds" intermediate
+  state on top of the restart/transfer/reclaim machinery (ADR-0006 #7), the most
+  regression-prone part of the system. That is precisely the kind of overloaded
+  state that produced the original desync bugs. Build only with evidence.
+- **Loosen the epoch-gated reconnect-reclaim** so a still-playing device
+  re-asserts forward on any reconnect. Rejected for now: the epoch gate exists
+  specifically to disambiguate "I was parked/stopped by another device" from "I
+  dropped and I'm still the rightful owner." Loosening it re-introduces the
+  ambiguity ADR-0006 #7 removed.
+- **Defeat iOS suspension** with a `.background` `URLSession` or a silent-audio
+  keepalive. Rejected: WebSocket tasks aren't supported on background sessions;
+  silent audio is an App Store rejection / battery-abuse risk; and it fights the
+  "presence = live while connected" model rather than honoring it.
+- **Shorten the 45s sweep** to trim the post-suspension ghost window. Possible
+  future tuning, not part of this decision.

--- a/docs/adr/0008-connect-cloud-coordination-deferred.md
+++ b/docs/adr/0008-connect-cloud-coordination-deferred.md
@@ -1,0 +1,69 @@
+# ADR-0008: Connect — cloud-coordinated ("Spotify-style") control deferred
+
+## Status
+
+Accepted (2026-06-07). Extends [ADR-0006](0006-connect-v2.md) and
+[ADR-0007](0007-connect-background-socket-lifecycle.md). Records a decision to
+**not** build cloud-coordinated Connect now, and what would gate doing so.
+
+## Context
+
+ADR-0007 accepts a limit: a device that suspends (iOS, once audio stops) leaves
+the session and can't show or be handed live state until it's foregrounded.
+"Why can Spotify do this and we can't?" is the natural question. Spotify Connect
+doesn't keep a socket open from a sleeping phone — it decomposes into:
+
+1. **Durable, server-side session state** (their "connect-state" service via a
+   pub/sub "dealer"): which devices, who's active, context/track/position — held
+   in the cloud, so it survives any device dropping or suspending.
+2. **Silent push (APNs/FCM)** to wake a suspended device to stop/hand off, so
+   coordination never depends on that device's live connection.
+3. **Background audio** for the device actually making sound — identical to us;
+   the difference is purely in *coordination*, which they route through the cloud.
+
+Ours is the opposite by deliberate choice: ADR-0006 made session state in-memory
+and "recoverable from the still-connected active device," and ADR-0007 tied the
+socket to playback/process. So a suspended device genuinely has nothing to fall
+back on — hence the accepted limit.
+
+## Decision
+
+**Do not build cloud-coordinated Connect to close the suspended-device gap.**
+Specifically:
+
+- **Defer silent push (APNs/FCM) indefinitely.** It's a new cross-platform
+  subsystem (tokens, certs, send paths, lifecycle) and iOS `content-available`
+  push is best-effort — throttled/coalesced/dropped in Low Power Mode — so even
+  fully built it would lag (e.g. double-audio on transfer to/from a slow-to-wake
+  device). Revisit only if instant control of a *sleeping* device becomes a
+  named, concrete requirement, and in the knowledge that iOS won't fully cooperate.
+- **Gate durable server-side session state on the social/presence feature.** It's
+  the contained, server-mostly half (the playback-position persistence in
+  `api/src/db/userdata` already exists to build on) and it's the foundation the
+  social "see/hear what a friend is playing" feature needs anyway — `userStates`
+  already holds per-user live state (ADR-0006), so the social *read* path is a
+  future REST endpoint + friends graph with **no wire change and no push**. Build
+  durable state as part of social, where it pays for itself; don't build it just
+  for the background-takeover cosmetic.
+
+## Consequences
+
+- The ADR-0007 suspended-device limit stands until social is built. The
+  background-takeover case (take over on web while the phone is asleep → phone
+  shows stale until foregrounded) remains accepted, not papered over.
+- When social lands, durable state comes with it; the "instant handoff to a
+  sleeping device" control path (needing push) remains separately deferrable.
+- We keep the backend small now and avoid a weeks-long push subsystem with a
+  hard iOS reliability ceiling for modest UX gain.
+
+## Alternatives considered
+
+- **Build all three pieces now (durable state + push + grace).** Rejected:
+  weeks of work dominated by push infra, best-effort on iOS, for an uncommon flow
+  already covered "well enough" by the keepalive + track-sync fixes.
+- **A heavier client / background service with its own notification player.**
+  Rejected in ADR-0007: doesn't rescue iOS (no indefinite background without
+  active audio; silent-audio keepalive is an App Store / battery risk).
+- **Durable state now, push later.** Viable, and the likely path — but only worth
+  starting when social is actually on the roadmap, so it's gated on that rather
+  than done speculatively.

--- a/iosApp/deadly/App/deadlyApp.swift
+++ b/iosApp/deadly/App/deadlyApp.swift
@@ -161,7 +161,15 @@ struct deadlyApp: App {
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .background {
                 container.playbackRestorationService.saveNow()
-                container.connectService.stop()
+                // Intentionally do NOT stop Connect here. While audio plays, iOS
+                // keeps the app alive (background-audio), so the WS + heartbeat
+                // keep running and the active device stays in the session under
+                // lock. Tearing it down made the server clear the session ~4s
+                // after lock — every viewer flipped to "paused" and the player
+                // rewound on return. When iOS suspends (audio stops) the socket
+                // dies on its own; the server's 45s heartbeat sweep is the
+                // backstop, and startIfAuthenticated reconnects on foreground.
+                // See docs/adr/0007-connect-background-socket-lifecycle.md.
             }
         }
     }

--- a/iosApp/deadly/Core/Service/ConnectService.swift
+++ b/iosApp/deadly/Core/Service/ConnectService.swift
@@ -123,7 +123,14 @@ final class ConnectService: NSObject {
         let hasToken = authService.token != nil
         logger.info("startIfAuthenticated: token=\(hasToken ? "present" : "null", privacy: .public) shouldConnect=\(self.shouldConnect, privacy: .public)")
         guard hasToken else { return }
-        guard !shouldConnect else { return }
+        if shouldConnect {
+            // Already meant to be connected. Since we no longer stop() on
+            // background, a socket iOS killed during suspension leaves
+            // shouldConnect=true; reconnect on foreground instead of no-opping.
+            // handleNetworkRestored is a no-op if still connected.
+            if !isConnected { handleNetworkRestored() }
+            return
+        }
         shouldConnect = true
         reconnectAttempt = 0
         Task { await connect() }

--- a/iosApp/deadly/Core/Service/ConnectService.swift
+++ b/iosApp/deadly/Core/Service/ConnectService.swift
@@ -669,7 +669,19 @@ final class ConnectService: NSObject {
                 try? await Task.sleep(nanoseconds: Self.positionReportInterval)
                 guard !Task.isCancelled else { break }
                 let positionMs = Int(streamPlayer.progress.currentTime * 1000)
-                sendPosition(positionMs: positionMs)
+                let localIndex = streamPlayer.queueState.currentIndex
+                if let serverIndex = connectState?.trackIndex, localIndex != serverIndex {
+                    // The active device's track changed outside Connect — a lock-
+                    // screen / headset / CarPlay skip drives StreamPlayer directly,
+                    // so no sendNext fires. Forward as an absolute seek so the index
+                    // resyncs; a bare position report would land the new position on
+                    // the stale server index. sendSeek arms no pending spinner.
+                    let durationMs = Int(streamPlayer.progress.duration * 1000)
+                    logger.info("positionReport: local track \(localIndex, privacy: .public) != server \(serverIndex, privacy: .public) — seek sync (pos=\(positionMs, privacy: .public))")
+                    sendSeek(trackIndex: localIndex, positionMs: positionMs, durationMs: durationMs)
+                } else {
+                    sendPosition(positionMs: positionMs)
+                }
             }
         }
     }


### PR DESCRIPTION
Follow-on to #53 (external media-control **play/pause** forwarding). Same theme — make the active device's local transport reach the Connect session under real-world conditions — covering **backgrounding** and **external track skips**. Both platforms; no server or wire-format change.

## 1. Keep Connect connected while backgrounded (`d12a89be`)

**Bug:** both apps tore down the WebSocket the instant they backgrounded (`MainActivity.onStop`, iOS `scenePhase .background` → `connectService.stop()`). Locking the screen while listening killed the session ~4s later: the server's `unregisterDevice` cleared the active device (`playing=false, activeDeviceId=null`) while audio kept playing. Every viewer flipped to **paused** with a frozen scrubber, and the player **rewound to a past track** on return (active device auto-advanced while disconnected → reconnect replayed the stale `trackIndex` → not-active sync dragged the player backward). Confirmed in client + server logs.

**Fix:** the socket's lifetime follows playback/process, not the Activity/scene.
- Remove the background `stop()` on both platforms — while audio plays the OS keeps the process (and the WS + 15s heartbeat) alive, so the active device stays in the session under lock.
- `startIfAuthenticated()` self-heals: when `shouldConnect` is already set but the socket died while backgrounded, it reconnects (`handleNetworkRestored`) instead of no-opping, so foreground re-entry after a real suspension/drop recovers.

The socket now closes only on logout and process death/suspension; the existing 45s heartbeat sweep is the backstop. iOS still suspends when audio stops — that case (and a transient drop straddling a track boundary) is **accepted**, documented in **ADR-0007**.

## 2. Forward external track skips (`83c29ed9`)

**Bug:** a lock-screen / headset / Bluetooth / CarPlay **next/prev** drives the local player directly (`REASON_SEEK`, not `REASON_AUTO`), so it never calls `sendNext` — the server stayed on the old `trackIndex` while position kept reporting, landing the new track's position on the stale index ("time moves but the bar is wrong; changing tracks gets it confused"). In-app next/prev and the scrubber already forward correctly (verified by a labeled test).

**Fix (minimal, Option A):** make the existing 5s position reporter **track-aware** — when the active device's local `trackIndex` differs from the server's, send an absolute `seek` (index + position + duration) instead of a bare position; otherwise report position as before. Absolute `seek` avoids the relative-`sendNext` over-advance race, reuses the reporter already running while active+playing, and never lands a position on a stale index. External skips propagate within ≤5s (accepted); in-app/auto paths are untouched.

## Why "intent / absolute", not the obvious thing
- Play/pause (#53) reconciles play **intent** (`playWhenReady`), not `isPlaying`, so buffer stalls don't fire spurious pauses.
- Track-skip uses an **absolute** seek from the reporter rather than relative `sendNext`, so it can't race the in-app/auto paths into an over-advance.

## Testing
- **Android** — built, installed, **verified on device**: lock-while-playing keeps the session live (no rewind on return); lock-screen skip resyncs the web within ~5s.
- **iOS** — compiles clean on the remote Mac; mirrors the Android logic. Recommend a device pass (and a two-device transfer regression check) before the store cut.

## Docs
- `docs/adr/0007-connect-background-socket-lifecycle.md` — socket lifetime follows playback; #2 server-grace and reconnect-reclaim deliberately deferred.
- `docs/adr/0008-connect-cloud-coordination-deferred.md` — "Spotify-style" cloud coordination deferred; durable state gated on social, silent push deferred.
- `PLANS/connect-background-keepalive.md` — plan + test matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)