### PR TITLE
feat(all/notifications): track engagement funnel + per-notification admin stats

### DIFF
--- a/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
@@ -115,6 +115,7 @@ fun MainNavigation(
         notificationViewModel.newArrivals.collect { arrival ->
             if (lastToastKey.value == arrival.key) return@collect
             lastToastKey.value = arrival.key
+            notificationViewModel.onToastShown(arrival)
             val msg = if (arrival.count > 1) "${arrival.count} new messages" else "New: ${arrival.title}"
             val result = snackbarHostState.showSnackbar(
                 message = msg,
@@ -122,6 +123,7 @@ fun MainNavigation(
                 duration = SnackbarDuration.Short,
             )
             if (result == SnackbarResult.ActionPerformed) {
+                notificationViewModel.onToastTap(arrival)
                 navController.navigate("notifications")
             }
         }

--- a/androidApp/app/src/main/java/com/grateful/deadly/notifications/NotificationBody.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/notifications/NotificationBody.kt
@@ -3,6 +3,7 @@ package com.grateful.deadly.notifications
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.LinkInteractionListener
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.buildAnnotatedString
@@ -22,10 +23,22 @@ private val TOKEN =
 
 private val TRAILING = Regex("""[).,!?;:]+$""")
 
-fun notificationBody(body: String, linkColor: Color): AnnotatedString =
+// [onLinkClick] fully handles a tapped link (track + open): supplying a
+// LinkInteractionListener overrides Compose's default browser launch, so the
+// caller is responsible for opening the URL (see NotificationDetail).
+fun notificationBody(
+    body: String,
+    linkColor: Color,
+    onLinkClick: (String) -> Unit,
+): AnnotatedString =
     buildAnnotatedString {
         val styles = TextLinkStyles(
             style = SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline),
+        )
+        fun urlLink(url: String) = LinkAnnotation.Url(
+            url,
+            styles,
+            LinkInteractionListener { onLinkClick(url) },
         )
         var last = 0
         for (match in TOKEN.findAll(body)) {
@@ -35,12 +48,12 @@ fun notificationBody(body: String, linkColor: Color): AnnotatedString =
             val bareUrl = match.groupValues[3]
             when {
                 mdUrl.isNotEmpty() -> {
-                    withLink(LinkAnnotation.Url(mdUrl, styles)) { append(mdLabel) }
+                    withLink(urlLink(mdUrl)) { append(mdLabel) }
                 }
                 bareUrl.isNotEmpty() -> {
                     val trailing = TRAILING.find(bareUrl)?.value ?: ""
                     val url = bareUrl.dropLast(trailing.length)
-                    withLink(LinkAnnotation.Url(url, styles)) { append(url) }
+                    withLink(urlLink(url)) { append(url) }
                     if (trailing.isNotEmpty()) append(trailing)
                 }
                 else -> append(match.value)

--- a/androidApp/app/src/main/java/com/grateful/deadly/notifications/NotificationViewModel.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/notifications/NotificationViewModel.kt
@@ -2,12 +2,23 @@ package com.grateful.deadly.notifications
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.grateful.deadly.core.database.AnalyticsService
 import com.grateful.deadly.core.notifications.CachedNotification
 import com.grateful.deadly.core.notifications.NewArrival
 import com.grateful.deadly.core.notifications.NotificationApiService
 import com.grateful.deadly.core.notifications.NotificationStore
 import com.grateful.deadly.core.notifications.active
 import com.grateful.deadly.core.notifications.dismissed
+import com.grateful.deadly.core.notifications.trackNotificationArchive
+import com.grateful.deadly.core.notifications.trackNotificationArchiveAll
+import com.grateful.deadly.core.notifications.trackNotificationCommunityTap
+import com.grateful.deadly.core.notifications.trackNotificationImpression
+import com.grateful.deadly.core.notifications.trackNotificationLinkTap
+import com.grateful.deadly.core.notifications.trackNotificationMarkAllRead
+import com.grateful.deadly.core.notifications.trackNotificationOpen
+import com.grateful.deadly.core.notifications.trackNotificationReceived
+import com.grateful.deadly.core.notifications.trackNotificationToastShown
+import com.grateful.deadly.core.notifications.trackNotificationToastTap
 import com.grateful.deadly.core.notifications.unreadCount
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,9 +39,13 @@ import javax.inject.Inject
 class NotificationViewModel @Inject constructor(
     private val store: NotificationStore,
     private val apiService: NotificationApiService,
+    private val analytics: AnalyticsService,
 ) : ViewModel() {
 
     private val version = store.appVersion
+
+    /** Ids already counted as an impression this session, to dedupe re-scrolls. */
+    private val impressed = mutableSetOf<Long>()
 
     private val _refreshing = MutableStateFlow(false)
     /** Drives the pull-to-refresh spinner on the inbox screen. */
@@ -59,19 +74,47 @@ class NotificationViewModel @Inject constructor(
         if (_refreshing.value) return
         viewModelScope.launch {
             _refreshing.value = true
-            apiService.fetch(store.cursor).onSuccess { store.merge(it) }
+            apiService.fetch(store.cursor).onSuccess { result ->
+                store.merge(result).forEach { analytics.trackNotificationReceived(it, "refresh") }
+            }
             _refreshing.value = false
         }
     }
 
+    /** A message row became visible in the inbox — count one impression per id. */
+    fun onImpression(message: CachedNotification) {
+        if (impressed.add(message.id)) analytics.trackNotificationImpression(message)
+    }
+
     /** "Tap to read" — opening a message's detail marks just that one read. */
-    fun markRead(id: Long) = store.markRead(id)
+    fun open(message: CachedNotification) {
+        analytics.trackNotificationOpen(message)
+        if (message.seenAt == null) store.markRead(message.id)
+    }
 
     /** Bulk "Mark all read". */
-    fun markAllSeen() = store.markAllSeen()
+    fun markAllSeen() {
+        analytics.trackNotificationMarkAllRead(active.value.count { it.seenAt == null })
+        store.markAllSeen()
+    }
 
-    fun dismiss(id: Long) = store.dismiss(id)
+    /** Archive a single message (row swipe / detail button). */
+    fun archive(message: CachedNotification) {
+        analytics.trackNotificationArchive(message)
+        store.dismiss(message.id)
+    }
 
     /** Bulk "Archive all". */
-    fun archiveAll() = store.archiveAll()
+    fun archiveAll() {
+        analytics.trackNotificationArchiveAll(active.value.size)
+        store.archiveAll()
+    }
+
+    fun onLinkTap(id: Long, url: String) = analytics.trackNotificationLinkTap(id, url)
+
+    fun onCommunityTap() = analytics.trackNotificationCommunityTap()
+
+    fun onToastShown(arrival: NewArrival) = analytics.trackNotificationToastShown(arrival)
+
+    fun onToastTap(arrival: NewArrival) = analytics.trackNotificationToastTap(arrival)
 }

--- a/androidApp/app/src/main/java/com/grateful/deadly/notifications/NotificationsScreen.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/notifications/NotificationsScreen.kt
@@ -82,9 +82,10 @@ fun NotificationsScreen(
                     message = selected,
                     archived = showArchive,
                     onArchive = {
-                        viewModel.dismiss(selected.id)
+                        viewModel.archive(selected)
                         selectedId = null
                     },
+                    onLinkTap = { url -> viewModel.onLinkTap(selected.id, url) },
                 )
             } else {
                 PullToRefreshBox(
@@ -120,19 +121,23 @@ fun NotificationsScreen(
                                 }
                             } else {
                                 items(list, key = { it.id }) { m ->
+                                    // First time this row renders, count one impression.
+                                    LaunchedEffect(m.id) { viewModel.onImpression(m) }
                                     NotificationRow(
                                         message = m,
                                         unread = !showArchive && m.seenAt == null,
                                         onClick = {
-                                            if (!showArchive && m.seenAt == null) viewModel.markRead(m.id)
+                                            viewModel.open(m)
                                             selectedId = m.id
                                         },
                                     )
                                     HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
                                 }
-                                item { CommunityFooter() }
                             }
                         }
+
+                        // Always present (empty inbox + archive too), matching iOS.
+                        CommunityFooter(onTap = { viewModel.onCommunityTap() })
                     }
                 }
             }
@@ -200,7 +205,9 @@ private fun NotificationDetail(
     message: CachedNotification,
     archived: Boolean,
     onArchive: () -> Unit,
+    onLinkTap: (String) -> Unit,
 ) {
+    val uriHandler = LocalUriHandler.current
     Column(
         Modifier
             .fillMaxSize()
@@ -231,7 +238,10 @@ private fun NotificationDetail(
         )
         // Body renders newlines as-is and turns links tappable.
         Text(
-            text = notificationBody(message.body, MaterialTheme.colorScheme.primary),
+            text = notificationBody(message.body, MaterialTheme.colorScheme.primary) { url ->
+                onLinkTap(url)
+                uriHandler.openUri(url)
+            },
             style = MaterialTheme.typography.bodyLarge,
         )
         if (!archived) {
@@ -241,10 +251,13 @@ private fun NotificationDetail(
 }
 
 @Composable
-private fun CommunityFooter() {
+private fun CommunityFooter(onTap: () -> Unit) {
     val uriHandler = LocalUriHandler.current
     Box(Modifier.fillMaxWidth().padding(24.dp), contentAlignment = Alignment.Center) {
-        TextButton(onClick = { uriHandler.openUri(Community.SUBREDDIT_URL) }) {
+        TextButton(onClick = {
+            onTap()
+            uriHandler.openUri(Community.SUBREDDIT_URL)
+        }) {
             Text("More at ${Community.SUBREDDIT_HANDLE} →")
         }
     }

--- a/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/NotificationAnalytics.kt
+++ b/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/NotificationAnalytics.kt
@@ -1,0 +1,57 @@
+package com.grateful.deadly.core.notifications
+
+import com.grateful.deadly.core.database.AnalyticsService
+
+/**
+ * The notifications analytics vocabulary in one place. Extension functions on
+ * [AnalyticsService] so call sites (coordinator, view model, screen) stay terse
+ * and every `notification_*` event name/prop is defined once. Mirrors the
+ * server allowlist in api/src/db/analytics.ts and the iOS/web equivalents.
+ *
+ * Every message-scoped event carries `id` so the admin dashboard can aggregate
+ * engagement per notification.
+ */
+
+fun AnalyticsService.trackNotificationReceived(m: CachedNotification, reason: String) =
+    track(
+        "notification_received",
+        mapOf("id" to m.id, "category" to m.category, "level" to m.level, "reason" to reason),
+    )
+
+fun AnalyticsService.trackNotificationImpression(m: CachedNotification) =
+    track(
+        "notification_impression",
+        mapOf("id" to m.id, "category" to m.category, "level" to m.level),
+    )
+
+fun AnalyticsService.trackNotificationOpen(m: CachedNotification) =
+    track(
+        "notification_open",
+        mapOf(
+            "id" to m.id,
+            "category" to m.category,
+            "level" to m.level,
+            "was_unread" to (m.seenAt == null),
+        ),
+    )
+
+fun AnalyticsService.trackNotificationLinkTap(id: Long, url: String) =
+    track("notification_link_tap", mapOf("id" to id, "url" to url))
+
+fun AnalyticsService.trackNotificationArchive(m: CachedNotification) =
+    track("notification_archive", mapOf("id" to m.id, "category" to m.category))
+
+fun AnalyticsService.trackNotificationToastShown(arrival: NewArrival) =
+    track("notification_toast_shown", mapOf("id" to arrival.key, "count" to arrival.count))
+
+fun AnalyticsService.trackNotificationToastTap(arrival: NewArrival) =
+    track("notification_toast_tap", mapOf("id" to arrival.key))
+
+fun AnalyticsService.trackNotificationMarkAllRead(count: Int) =
+    track("notification_mark_all_read", mapOf("count" to count))
+
+fun AnalyticsService.trackNotificationArchiveAll(count: Int) =
+    track("notification_archive_all", mapOf("count" to count))
+
+fun AnalyticsService.trackNotificationCommunityTap() =
+    track("notification_community_tap")

--- a/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/NotificationCoordinator.kt
+++ b/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/NotificationCoordinator.kt
@@ -1,6 +1,7 @@
 package com.grateful.deadly.core.notifications
 
 import android.util.Log
+import com.grateful.deadly.core.database.AnalyticsService
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
@@ -28,6 +29,7 @@ import javax.inject.Singleton
 class NotificationCoordinator @Inject constructor(
     private val apiService: NotificationApiService,
     private val store: NotificationStore,
+    private val analytics: AnalyticsService,
 ) {
     companion object {
         private const val TAG = "NotificationCoord"
@@ -58,7 +60,8 @@ class NotificationCoordinator @Inject constructor(
         scope.launch {
             apiService.fetch(store.cursor).fold(
                 onSuccess = {
-                    store.merge(it)
+                    val fresh = store.merge(it)
+                    fresh.forEach { m -> analytics.trackNotificationReceived(m, reason) }
                     Log.d(TAG, "pull[$reason] ok: +${it.messages.size} (cursor=${store.cursor})")
                 },
                 onFailure = { Log.w(TAG, "pull[$reason] failed: ${it.message}") },

--- a/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/NotificationStore.kt
+++ b/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/NotificationStore.kt
@@ -86,8 +86,12 @@ class NotificationStore @Inject constructor(
      * expiry keep the backlog relevant and "Mark all read" handles volume.
      * A non-cold delta that adds eligible unread messages emits [newArrivals]
      * so the UI can toast.
+     *
+     * Returns the genuinely-new, eligible messages added by this merge (for any
+     * reason, including cold start) so the caller can emit per-message
+     * `notification_received` analytics. Empty when nothing new arrived.
      */
-    fun merge(result: NotificationFetchResult) {
+    fun merge(result: NotificationFetchResult): List<CachedNotification> {
         val coldStart = persisted.cursor == 0L
         val now = System.currentTimeMillis()
         val knownIds = persisted.messages.mapTo(HashSet()) { it.id }
@@ -121,19 +125,22 @@ class NotificationStore @Inject constructor(
 
         commit(Persisted(cursor = maxOf(persisted.cursor, result.cursor), messages = pruned))
 
-        // Toast signal: genuinely new, eligible, unread messages from a delta.
-        if (!coldStart) {
-            val fresh = result.messages
-                .filter { it.id !in knownIds }
-                .map { byId.getValue(it.id) }
-                .filter { it.isEligible(appVersion) && it.dismissedAt == null }
-                .sortedByDescending { it.createdAt }
-            if (fresh.isNotEmpty()) {
-                _newArrivals.tryEmit(
-                    NewArrival(title = fresh.first().title, count = fresh.size, key = fresh.first().id),
-                )
-            }
+        // Genuinely new, eligible messages added by this merge — the basis for
+        // both the toast (delta only) and `notification_received` analytics (any).
+        val fresh = result.messages
+            .filter { it.id !in knownIds }
+            .mapNotNull { byId[it.id] }
+            .filter { it.isEligible(appVersion) && it.dismissedAt == null }
+            .sortedByDescending { it.createdAt }
+
+        // Toast signal: only on a delta (never the cold-start backlog).
+        if (!coldStart && fresh.isNotEmpty()) {
+            _newArrivals.tryEmit(
+                NewArrival(title = fresh.first().title, count = fresh.size, key = fresh.first().id),
+            )
         }
+
+        return fresh
     }
 
     /** Mark a single message read ("tap to read" — opening its detail). */

--- a/api/src/db/__tests__/notifications-engagement.test.ts
+++ b/api/src/db/__tests__/notifications-engagement.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+
+// Point the analytics module at a temp DB before importing it so its
+// module-level singleton opens our test file, not data/analytics.db.
+const TMP_DB = path.join(
+  os.tmpdir(),
+  `notif-engagement-test-${process.pid}-${Date.now()}.db`,
+);
+process.env.ANALYTICS_DB_PATH = TMP_DB;
+
+const { getAnalyticsDb, insertEvents, getNotificationEngagement, closeAnalyticsDb } =
+  await import("../analytics.js");
+
+function evt(
+  event: string,
+  iid: string,
+  props: Record<string, unknown>,
+  platform = "ios",
+) {
+  return {
+    event,
+    ts: Date.now(),
+    iid,
+    sid: `${iid}-s`,
+    platform,
+    app_version: "2.34.0",
+    props,
+  };
+}
+
+beforeEach(() => {
+  getAnalyticsDb().exec(`DELETE FROM analytics_events;`);
+});
+
+afterAll(() => {
+  closeAnalyticsDb();
+  if (fs.existsSync(TMP_DB)) fs.unlinkSync(TMP_DB);
+});
+
+describe("getNotificationEngagement", () => {
+  it("counts distinct installs per notification id across the funnel", () => {
+    insertEvents([
+      // Notification 1: delivered to 2 clients, both displayed, one opened,
+      // one archived, one link click. Duplicate received from iid-a must not
+      // double-count delivered.
+      evt("notification_received", "iid-a", { id: 1, category: "release", level: "info", reason: "cold_start" }),
+      evt("notification_received", "iid-a", { id: 1, category: "release", level: "info", reason: "foreground" }),
+      evt("notification_received", "iid-b", { id: 1, category: "release", level: "info", reason: "cold_start" }),
+      evt("notification_impression", "iid-a", { id: 1, category: "release", level: "info" }),
+      evt("notification_impression", "iid-b", { id: 1, category: "release", level: "info" }),
+      evt("notification_open", "iid-a", { id: 1, category: "release", level: "info", was_unread: true }),
+      evt("notification_archive", "iid-b", { id: 1, category: "release" }),
+      evt("notification_link_tap", "iid-a", { id: 1, url: "https://example.com" }),
+
+      // Notification 2: delivered to 1 client; "displayed" unions impression
+      // and toast_shown, but the same iid seeing both counts once.
+      evt("notification_received", "iid-c", { id: 2, category: "feature", level: "info", reason: "refresh" }),
+      evt("notification_impression", "iid-c", { id: 2, category: "feature", level: "info" }),
+      evt("notification_toast_shown", "iid-c", { id: 2, count: 1 }),
+    ]);
+
+    const rows = getNotificationEngagement();
+    const byId = Object.fromEntries(rows.map((r) => [r.id, r]));
+
+    expect(byId[1]).toMatchObject({
+      delivered: 2,
+      displayed: 2,
+      opened: 1,
+      archived: 1,
+      link_clicks: 1,
+    });
+    expect(byId[2]).toMatchObject({
+      delivered: 1,
+      displayed: 1, // impression + toast_shown from the same install = 1
+      opened: 0,
+      archived: 0,
+      link_clicks: 0,
+    });
+  });
+
+  it("honors the platform filter", () => {
+    insertEvents([
+      evt("notification_received", "ios-1", { id: 5, category: "general", level: "info", reason: "cold_start" }, "ios"),
+      evt("notification_received", "web-1", { id: 5, category: "general", level: "info", reason: "cold_start" }, "web"),
+    ]);
+
+    expect(getNotificationEngagement(90)[0].delivered).toBe(2);
+    expect(getNotificationEngagement(90, ["ios"])[0].delivered).toBe(1);
+  });
+});

--- a/api/src/db/analytics.ts
+++ b/api/src/db/analytics.ts
@@ -249,6 +249,19 @@ const EVENT_SCHEMAS: Record<string, Set<string>> = {
   ]),
   error: new Set(["source", "message", "is_fatal"]),
   cold_start: new Set(["duration_ms"]),
+  // In-app notifications funnel. `id` is the notification id (number) — every
+  // message-scoped event carries it so engagement aggregates per notification
+  // via json_extract(props,'$.id'). See getNotificationEngagement.
+  notification_received: new Set(["id", "category", "level", "reason"]),
+  notification_impression: new Set(["id", "category", "level"]),
+  notification_open: new Set(["id", "category", "level", "was_unread"]),
+  notification_link_tap: new Set(["id", "url"]),
+  notification_archive: new Set(["id", "category"]),
+  notification_toast_shown: new Set(["id", "count"]),
+  notification_toast_tap: new Set(["id"]),
+  notification_mark_all_read: new Set(["count"]),
+  notification_archive_all: new Set(["count"]),
+  notification_community_tap: new Set<string>([]),
 };
 
 export const VALID_EVENTS = new Set(Object.keys(EVENT_SCHEMAS));
@@ -1340,6 +1353,54 @@ export type TrackOutcome = "complete" | "skipped" | "error" | "partial";
 export interface TrackPlay {
   index: number;
   outcome: TrackOutcome;
+}
+
+export interface NotificationEngagement {
+  id: number;
+  delivered: number;
+  displayed: number;
+  opened: number;
+  archived: number;
+  link_clicks: number;
+}
+
+/**
+ * Per-notification engagement funnel, keyed by notification id. Each metric is
+ * a distinct-install count (`COUNT(DISTINCT iid)`) so it reads as "N clients".
+ * Aggregated from the `notification_*` events via `json_extract(props,'$.id')`,
+ * mirroring the show_id grouping in getShowPlaybackSummary. "Displayed" unions
+ * inbox impressions and toasts — both mean a human saw the message.
+ */
+export function getNotificationEngagement(
+  days = 90,
+  platforms?: string[],
+): NotificationEngagement[] {
+  const db = getAnalyticsDb();
+  const cutoff = Date.now() - days * 24 * 3600 * 1000;
+  const pc = platformClause(platforms);
+
+  return db
+    .prepare(
+      `SELECT
+         CAST(json_extract(props, '$.id') AS INTEGER) AS id,
+         COUNT(DISTINCT CASE WHEN event = 'notification_received' THEN iid END) AS delivered,
+         COUNT(DISTINCT CASE WHEN event IN ('notification_impression', 'notification_toast_shown') THEN iid END) AS displayed,
+         COUNT(DISTINCT CASE WHEN event = 'notification_open' THEN iid END) AS opened,
+         COUNT(DISTINCT CASE WHEN event = 'notification_archive' THEN iid END) AS archived,
+         COUNT(DISTINCT CASE WHEN event = 'notification_link_tap' THEN iid END) AS link_clicks
+       FROM analytics_events
+       WHERE event IN (
+           'notification_received', 'notification_impression', 'notification_toast_shown',
+           'notification_open', 'notification_archive', 'notification_link_tap'
+         )
+         AND ts > ?${pc}
+         AND json_extract(props, '$.id') IS NOT NULL
+       -- GROUP/ORDER by the expression, not the alias: the table has its own
+       -- 'id' PK column that would otherwise shadow the aliased notification id.
+       GROUP BY json_extract(props, '$.id')
+       ORDER BY json_extract(props, '$.id') DESC`,
+    )
+    .all(cutoff) as NotificationEngagement[];
 }
 
 export interface ShowPlaybackSummary {

--- a/api/src/routes/analytics.ts
+++ b/api/src/routes/analytics.ts
@@ -21,6 +21,7 @@ import {
   getGrowthByPlatform,
   getVersionDistribution,
   getVersionTimeseries,
+  getNotificationEngagement,
   getTopShows,
   getWatchedInstalls,
   setWatchedInstall,
@@ -633,6 +634,57 @@ export async function analyticsRoutes(app: FastifyInstance): Promise<void> {
       const clampedLimit = Math.min(Math.max(limit ?? 20, 1), 100);
       return {
         shows: getTopShows(clampedDays, clampedLimit, parsePlatforms(platforms)),
+      };
+    },
+  );
+
+  // GET /api/analytics/notifications — per-notification engagement funnel
+  // (delivered → displayed → opened → archived), keyed by notification id.
+  app.get(
+    "/api/analytics/notifications",
+    {
+      schema: {
+        tags: ["analytics"],
+        summary: "Per-notification engagement funnel (admin)",
+        querystring: {
+          type: "object",
+          properties: {
+            days: { type: "number", default: 90 },
+            platforms: { type: "string" },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              notifications: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    id: { type: "number" },
+                    delivered: { type: "number" },
+                    displayed: { type: "number" },
+                    opened: { type: "number" },
+                    archived: { type: "number" },
+                    link_clicks: { type: "number" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      preHandler: requireAdmin,
+    },
+    async (request) => {
+      const { days, platforms } = request.query as {
+        days?: number;
+        platforms?: string;
+      };
+      const clamped = Math.min(Math.max(days ?? 90, 1), 365);
+      return {
+        notifications: getNotificationEngagement(clamped, parsePlatforms(platforms)),
       };
     },
   );

--- a/iosApp/deadly/App/AppContainer.swift
+++ b/iosApp/deadly/App/AppContainer.swift
@@ -343,7 +343,7 @@ final class AppContainer {
             let notifStore = MainActor.assumeIsolated { NotificationStore() }
             notificationStore = notifStore
             notificationService = MainActor.assumeIsolated {
-                NotificationService(appPreferences: prefs, store: notifStore)
+                NotificationService(appPreferences: prefs, store: notifStore, analytics: analytics)
             }
 
             let coldStartMs = Int((CFAbsoluteTimeGetCurrent() - initStart) * 1000)

--- a/iosApp/deadly/App/MainNavigation.swift
+++ b/iosApp/deadly/App/MainNavigation.swift
@@ -117,6 +117,7 @@ struct MainNavigation: View {
         .overlay(alignment: .bottom) {
             if let toast = notificationToast {
                 NotificationToastView(arrival: toast) {
+                    container.analyticsService.trackNotificationToastTap(toast)
                     notificationToast = nil
                     selectedTab = .home
                     homeStack.append(NotificationRoute.inbox)
@@ -128,6 +129,7 @@ struct MainNavigation: View {
         .onChange(of: container.notificationStore.lastArrival) { _, arrival in
             guard let arrival, arrival.key != lastToastKey else { return }
             lastToastKey = arrival.key
+            container.analyticsService.trackNotificationToastShown(arrival)
             withAnimation { notificationToast = arrival }
             Task {
                 try? await Task.sleep(for: .seconds(4))

--- a/iosApp/deadly/Core/Notifications/NotificationAnalytics.swift
+++ b/iosApp/deadly/Core/Notifications/NotificationAnalytics.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// The notifications analytics vocabulary in one place — extension methods on
+/// AnalyticsService so call sites stay terse and every `notification_*` event
+/// name/prop is defined once. Mirrors the server allowlist in
+/// api/src/db/analytics.ts and the Android/web equivalents.
+///
+/// Every message-scoped event carries `id` so the admin dashboard can aggregate
+/// engagement per notification.
+extension AnalyticsService {
+    func trackNotificationReceived(_ m: CachedNotification, reason: String) {
+        track("notification_received", props: [
+            "id": m.id, "category": m.category, "level": m.level, "reason": reason,
+        ])
+    }
+
+    func trackNotificationImpression(_ m: CachedNotification) {
+        track("notification_impression", props: [
+            "id": m.id, "category": m.category, "level": m.level,
+        ])
+    }
+
+    func trackNotificationOpen(_ m: CachedNotification) {
+        track("notification_open", props: [
+            "id": m.id, "category": m.category, "level": m.level,
+            "was_unread": m.seenAt == nil,
+        ])
+    }
+
+    func trackNotificationLinkTap(id: Int64, url: String) {
+        track("notification_link_tap", props: ["id": id, "url": url])
+    }
+
+    func trackNotificationArchive(_ m: CachedNotification) {
+        track("notification_archive", props: ["id": m.id, "category": m.category])
+    }
+
+    func trackNotificationToastShown(_ arrival: NewArrival) {
+        track("notification_toast_shown", props: ["id": arrival.key, "count": arrival.count])
+    }
+
+    func trackNotificationToastTap(_ arrival: NewArrival) {
+        track("notification_toast_tap", props: ["id": arrival.key])
+    }
+
+    func trackNotificationMarkAllRead(count: Int) {
+        track("notification_mark_all_read", props: ["count": count])
+    }
+
+    func trackNotificationArchiveAll(count: Int) {
+        track("notification_archive_all", props: ["count": count])
+    }
+
+    func trackNotificationCommunityTap() {
+        track("notification_community_tap")
+    }
+}

--- a/iosApp/deadly/Core/Notifications/NotificationService.swift
+++ b/iosApp/deadly/Core/Notifications/NotificationService.swift
@@ -8,10 +8,12 @@ import Foundation
 final class NotificationService {
     private let appPreferences: AppPreferences
     let store: NotificationStore
+    private let analytics: AnalyticsService
 
-    init(appPreferences: AppPreferences, store: NotificationStore) {
+    init(appPreferences: AppPreferences, store: NotificationStore, analytics: AnalyticsService) {
         self.appPreferences = appPreferences
         self.store = store
+        self.analytics = analytics
     }
 
     /// Pull a `?since=<cursor>` delta and merge it. Best-effort: failures are
@@ -27,7 +29,9 @@ final class NotificationService {
                 return
             }
             let result = try JSONDecoder().decode(NotificationFetchResult.self, from: data)
-            store.merge(result)
+            for message in store.merge(result) {
+                analytics.trackNotificationReceived(message, reason: reason)
+            }
             print("[Notifications] refresh[\(reason)] ok: +\(result.messages.count) (cursor=\(store.cursor))")
         } catch {
             print("[Notifications] refresh[\(reason)] failed: \(error)")

--- a/iosApp/deadly/Core/Notifications/NotificationStore.swift
+++ b/iosApp/deadly/Core/Notifications/NotificationStore.swift
@@ -51,11 +51,20 @@ final class NotificationStore {
         }
     }
 
+    /// Ids already counted as an inbox impression this session, to dedupe
+    /// re-renders / scrolls. Not persisted — an impression is per-session.
+    private var impressed: Set<Int64> = []
+
     /// Merge a fetch result into the store and prune. v2 (decision G): new
     /// arrivals — including the cold-start batch — start **unread**; targeting +
     /// expiry keep the backlog relevant and "Mark all read" handles volume.
     /// A non-cold delta that adds eligible unread messages sets `lastArrival`.
-    func merge(_ result: NotificationFetchResult) {
+    ///
+    /// Returns the genuinely-new, eligible messages added by this merge (for any
+    /// reason, including cold start) so the caller can emit per-message
+    /// `notification_received` analytics. Empty when nothing new arrived.
+    @discardableResult
+    func merge(_ result: NotificationFetchResult) -> [CachedNotification] {
         let coldStart = cursor == 0
         let now = NotificationClock.now()
         let knownIds = Set(notifications.map { $0.id })
@@ -91,17 +100,26 @@ final class NotificationStore {
         notifications = pruned.sorted { $0.createdAt > $1.createdAt }
         persist()
 
-        // Toast signal: genuinely new, eligible, unread messages from a delta.
-        if !coldStart {
-            let fresh = result.messages
-                .filter { !knownIds.contains($0.id) }
-                .compactMap { byId[$0.id] }
-                .filter { $0.isEligible(appVersion: appVersion) && $0.dismissedAt == nil }
-                .sorted { $0.createdAt > $1.createdAt }
-            if let newest = fresh.first {
-                lastArrival = NewArrival(title: newest.title, count: fresh.count, key: newest.id)
-            }
+        // Genuinely new, eligible messages added by this merge — the basis for
+        // both the toast (delta only) and `notification_received` analytics (any).
+        let fresh = result.messages
+            .filter { !knownIds.contains($0.id) }
+            .compactMap { byId[$0.id] }
+            .filter { $0.isEligible(appVersion: appVersion) && $0.dismissedAt == nil }
+            .sorted { $0.createdAt > $1.createdAt }
+
+        // Toast signal: only on a delta (never the cold-start backlog).
+        if !coldStart, let newest = fresh.first {
+            lastArrival = NewArrival(title: newest.title, count: fresh.count, key: newest.id)
         }
+
+        return fresh
+    }
+
+    /// Record an inbox impression for `id`; returns true the first time per
+    /// session so the caller emits exactly one `notification_impression`.
+    func registerImpression(_ id: Int64) -> Bool {
+        impressed.insert(id).inserted
     }
 
     /// Mark a single message read ("tap to read" — opening its detail).

--- a/iosApp/deadly/Feature/Notifications/NotificationsInboxScreen.swift
+++ b/iosApp/deadly/Feature/Notifications/NotificationsInboxScreen.swift
@@ -28,10 +28,17 @@ struct NotificationsInboxScreen: View {
                     EmptyView()
                 } header: {
                     HStack {
-                        Button("Mark all read") { store.markAllSeen() }
-                            .disabled(!active.contains { $0.seenAt == nil })
+                        Button("Mark all read") {
+                            container.analyticsService.trackNotificationMarkAllRead(
+                                count: active.filter { $0.seenAt == nil }.count)
+                            store.markAllSeen()
+                        }
+                        .disabled(!active.contains { $0.seenAt == nil })
                         Spacer()
-                        Button("Archive all", role: .destructive) { store.archiveAll() }
+                        Button("Archive all", role: .destructive) {
+                            container.analyticsService.trackNotificationArchiveAll(count: active.count)
+                            store.archiveAll()
+                        }
                     }
                     .font(.footnote)
                     .textCase(nil)
@@ -44,15 +51,23 @@ struct NotificationsInboxScreen: View {
             } else {
                 ForEach(list) { message in
                     Button {
+                        container.analyticsService.trackNotificationOpen(message)
                         if !showArchive && message.seenAt == nil { store.markRead(message.id) }
                         selected = message
                     } label: {
                         NotificationRowView(message: message, unread: !showArchive && message.seenAt == nil)
+                            // First time this row appears, count one impression.
+                            .onAppear {
+                                if store.registerImpression(message.id) {
+                                    container.analyticsService.trackNotificationImpression(message)
+                                }
+                            }
                     }
                     .buttonStyle(.plain)
                     .swipeActions(edge: .trailing) {
                         if !showArchive {
                             Button(role: .destructive) {
+                                container.analyticsService.trackNotificationArchive(message)
                                 store.dismiss(message.id)
                             } label: {
                                 Label("Archive", systemImage: "archivebox")
@@ -68,11 +83,17 @@ struct NotificationsInboxScreen: View {
                         .font(.footnote)
                         .frame(maxWidth: .infinity, alignment: .center)
                 }
+                // A simultaneous TapGesture swallows Link activation; intercept
+                // via openURL instead — track, then let the system open it.
+                .environment(\.openURL, OpenURLAction { _ in
+                    container.analyticsService.trackNotificationCommunityTap()
+                    return .systemAction
+                })
             }
             .listRowBackground(Color.clear)
         }
         .refreshable {
-            await container.notificationService.refresh(reason: "pull")
+            await container.notificationService.refresh(reason: "refresh")
         }
         .navigationTitle(showArchive ? "Archived" : "Notifications")
         .navigationBarTitleDisplayMode(.inline)
@@ -148,8 +169,16 @@ private struct NotificationDetailView: View {
                     .foregroundColor(.secondary)
                 Text(notificationBody(message.body, linkColor: DeadlyColors.primary))
                     .font(.body)
+                    // Links carry a `.link` attribute; intercept the tap to
+                    // track click-through, then let the system open Safari.
+                    .environment(\.openURL, OpenURLAction { url in
+                        container.analyticsService.trackNotificationLinkTap(
+                            id: message.id, url: url.absoluteString)
+                        return .systemAction
+                    })
                 if !archived {
                     Button {
+                        container.analyticsService.trackNotificationArchive(message)
                         container.notificationStore.dismiss(message.id)
                         dismiss()
                     } label: {

--- a/ui/src/app/admin/analytics/AnalyticsDashboard.tsx
+++ b/ui/src/app/admin/analytics/AnalyticsDashboard.tsx
@@ -19,6 +19,7 @@ import VersionPanel from "./components/VersionPanel";
 import FeatureAdoption from "./components/FeatureAdoption";
 import CollapsibleSection from "./components/CollapsibleSection";
 import ShowEngagement, { TopShowsByAction } from "./components/ShowEngagement";
+import NotificationEngagement from "./components/NotificationEngagement";
 import { WatchedInstallsProvider } from "./components/WatchedInstallsContext";
 import WatchedInstallsPanel from "./components/WatchedInstallsPanel";
 import {
@@ -509,6 +510,11 @@ function AnalyticsDashboardInner({ showNames }: { showNames: ShowName[] }) {
           data={data.feature_adoption}
           onFeatureClick={(f) => openDetail("feature_adoption", f)}
         />
+      </CollapsibleSection>
+
+      {/* Notification engagement (delivered → displayed → opened → archived) */}
+      <CollapsibleSection title="Notification Engagement (90d)" forceOpen={forceOpen}>
+        <NotificationEngagement />
       </CollapsibleSection>
       </>}
 

--- a/ui/src/app/admin/analytics/components/NotificationEngagement.tsx
+++ b/ui/src/app/admin/analytics/components/NotificationEngagement.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePlatformFilter } from "./PlatformFilterContext";
+
+interface Engagement {
+  id: number;
+  delivered: number;
+  displayed: number;
+  opened: number;
+  archived: number;
+  link_clicks: number;
+}
+
+interface AdminNotification {
+  id: number;
+  title: string;
+}
+
+const STAGES: Array<{ key: keyof Engagement; label: string }> = [
+  { key: "delivered", label: "Delivered" },
+  { key: "displayed", label: "Displayed" },
+  { key: "opened", label: "Opened" },
+  { key: "archived", label: "Archived" },
+];
+
+// Per-notification engagement funnel (distinct clients) for the analytics
+// dashboard. Counts come from /api/analytics/notifications; titles are joined
+// from /api/admin/notifications. "Displayed" unions inbox impressions + toasts;
+// "Opened" is deliberate tap-to-read.
+export default function NotificationEngagement() {
+  const { withParam, param } = usePlatformFilter();
+  const [rows, setRows] = useState<Engagement[] | null>(null);
+  const [titles, setTitles] = useState<Record<number, string>>({});
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setRows(null);
+    Promise.all([
+      fetch(withParam("/api/analytics/notifications?days=90"), { credentials: "include" }).then(
+        async (r) => {
+          if (!r.ok) throw new Error(`HTTP ${r.status}`);
+          return (await r.json()) as { notifications: Engagement[] };
+        },
+      ),
+      fetch("/api/admin/notifications", { credentials: "include" })
+        .then((r) => (r.ok ? r.json() : { notifications: [] }))
+        .catch(() => ({ notifications: [] })) as Promise<{ notifications: AdminNotification[] }>,
+    ])
+      .then(([eng, admin]) => {
+        setRows(eng.notifications);
+        setTitles(Object.fromEntries(admin.notifications.map((n) => [n.id, n.title])));
+        setError(null);
+      })
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : "Failed to load"));
+  }, [withParam, param]);
+
+  if (error) return <p className="text-sm text-red-400">{error}</p>;
+  if (!rows) return <p className="text-sm text-zinc-500">Loading…</p>;
+  if (rows.length === 0)
+    return <p className="text-sm text-zinc-500">No notification engagement yet.</p>;
+
+  return (
+    <div className="bg-deadly-surface rounded-lg p-4 space-y-4">
+      {rows.map((r) => {
+        // Funnel bars are relative to "delivered" — the top of the funnel.
+        const max = Math.max(r.delivered, 1);
+        return (
+          <div key={r.id} className="space-y-1.5">
+            <div className="flex items-baseline justify-between gap-2">
+              <span className="text-sm text-zinc-200 truncate">
+                {titles[r.id] ?? `Notification #${r.id}`}
+              </span>
+              {r.link_clicks > 0 && (
+                <span className="shrink-0 text-xs text-zinc-500 tabular-nums">
+                  {r.link_clicks} link {r.link_clicks === 1 ? "click" : "clicks"}
+                </span>
+              )}
+            </div>
+            <div className="grid grid-cols-[auto_1fr_auto] items-center gap-x-3 gap-y-1">
+              {STAGES.map(({ key, label }) => {
+                const value = r[key] as number;
+                return (
+                  <div key={key} className="contents">
+                    <span className="text-xs text-zinc-500 w-16">{label}</span>
+                    <div className="bg-zinc-800 rounded-full h-3 overflow-hidden">
+                      <div
+                        className="bg-deadly-accent h-full rounded-full transition-all"
+                        style={{ width: `${(value / max) * 100}%` }}
+                      />
+                    </div>
+                    <span className="text-xs text-zinc-400 w-10 text-right tabular-nums">
+                      {value}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/ui/src/app/admin/notifications/page.tsx
+++ b/ui/src/app/admin/notifications/page.tsx
@@ -12,6 +12,15 @@ const CATEGORIES: Category[] = ["general", "release", "feature", "outage"];
 type Platform = "ios" | "android" | "web";
 const PLATFORMS: Platform[] = ["ios", "android", "web"];
 
+interface NotificationEngagement {
+  id: number;
+  delivered: number;
+  displayed: number;
+  opened: number;
+  archived: number;
+  link_clicks: number;
+}
+
 interface AdminNotification {
   id: number;
   title: string;
@@ -56,6 +65,7 @@ export default function NotificationsAdminPage() {
   const { user, isLoading: authLoading } = useAuth();
   const router = useRouter();
   const [items, setItems] = useState<AdminNotification[]>([]);
+  const [stats, setStats] = useState<Record<number, NotificationEngagement>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -83,6 +93,19 @@ export default function NotificationsAdminPage() {
       const data = await res.json();
       setItems(data.notifications);
       setError(null);
+
+      // Engagement is best-effort — never block the authoring list on it.
+      try {
+        const eng = await fetch("/api/analytics/notifications", { credentials: "include" });
+        if (eng.ok) {
+          const { notifications } = (await eng.json()) as {
+            notifications: NotificationEngagement[];
+          };
+          setStats(Object.fromEntries(notifications.map((n) => [n.id, n])));
+        }
+      } catch {
+        /* leave stats empty */
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load");
     } finally {
@@ -326,6 +349,7 @@ export default function NotificationsAdminPage() {
                       </div>
                       <p className="mt-1.5 font-medium text-zinc-100 truncate">{n.title}</p>
                       <p className="mt-0.5 text-sm text-zinc-400 whitespace-pre-wrap break-words">{n.body}</p>
+                      <EngagementStrip stats={stats[n.id]} />
                     </div>
                     {!n.deleted_at && (
                       confirmDelete === n.id ? (
@@ -349,6 +373,34 @@ export default function NotificationsAdminPage() {
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Per-notification engagement funnel (distinct clients). "Displayed" unions
+ * inbox impressions and toasts; "Opened" is deliberate tap-to-read. Empty until
+ * the first analytics events land for this message.
+ */
+function EngagementStrip({ stats }: { stats?: NotificationEngagement }) {
+  if (!stats) {
+    return <p className="mt-2 text-xs text-zinc-600">No engagement yet</p>;
+  }
+  const metrics: Array<[string, number]> = [
+    ["Delivered", stats.delivered],
+    ["Displayed", stats.displayed],
+    ["Opened", stats.opened],
+    ["Archived", stats.archived],
+    ["Links", stats.link_clicks],
+  ];
+  return (
+    <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-400">
+      {metrics.map(([label, value]) => (
+        <span key={label}>
+          <span className="text-zinc-200 font-medium tabular-nums">{value}</span>{" "}
+          <span className="text-zinc-500">{label}</span>
+        </span>
+      ))}
     </div>
   );
 }

--- a/ui/src/app/notifications/page.tsx
+++ b/ui/src/app/notifications/page.tsx
@@ -1,10 +1,37 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNotifications } from "@/components/notifications/NotificationsProvider";
 import { linkify } from "@/lib/linkify";
 import { SUBREDDIT_HANDLE, SUBREDDIT_URL } from "@/lib/community";
 import type { CachedNotification, NotificationCategory } from "@/lib/notifications";
+import {
+  trackNotificationOpen,
+  trackNotificationImpression,
+  trackNotificationLinkTap,
+  trackNotificationCommunityTap,
+} from "@/lib/notificationAnalytics";
+
+// Ids already counted as an impression this session (module scope so it
+// survives re-renders), deduping re-renders/scrolls into one impression.
+const impressed = new Set<number>();
+
+/** Fires exactly one `notification_impression` the first time a row renders. */
+function Impression({ message }: { message: CachedNotification }) {
+  useEffect(() => {
+    if (!impressed.has(message.id)) {
+      impressed.add(message.id);
+      trackNotificationImpression(message);
+    }
+  }, [message.id]); // eslint-disable-line react-hooks/exhaustive-deps
+  return null;
+}
+
+/** Track a click on a link inside linkified body text (delegated). */
+function onBodyClick(id: number, e: React.MouseEvent<HTMLParagraphElement>) {
+  const anchor = (e.target as HTMLElement).closest("a");
+  if (anchor) trackNotificationLinkTap(id, anchor.getAttribute("href") ?? "");
+}
 
 // Monochrome outline glyphs (heroicons-style, currentColor) — they inherit the
 // muted row text color so they read as quiet markers, not colorful stickers.
@@ -58,6 +85,7 @@ export default function NotificationsPage() {
       setExpanded(null);
     } else {
       setExpanded(m.id);
+      trackNotificationOpen(m);
       if (!showArchive && m.seen_at == null) markRead(m.id); // tap to read
     }
   };
@@ -105,6 +133,7 @@ export default function NotificationsPage() {
             const isOpen = expanded === m.id;
             return (
               <div key={m.id} className="px-4 py-3 transition hover:bg-zinc-800/30">
+                <Impression message={m} />
                 <button
                   onClick={() => onToggle(m)}
                   className="flex w-full items-start gap-3 text-left"
@@ -131,7 +160,10 @@ export default function NotificationsPage() {
 
                 {isOpen && (
                   <div className="mt-2 pl-9">
-                    <p className="whitespace-pre-wrap break-words text-sm text-zinc-300">
+                    <p
+                      className="whitespace-pre-wrap break-words text-sm text-zinc-300"
+                      onClick={(e) => onBodyClick(m.id, e)}
+                    >
                       {linkify(m.body)}
                     </p>
                     {!showArchive && (
@@ -160,6 +192,7 @@ export default function NotificationsPage() {
           href={SUBREDDIT_URL}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={() => trackNotificationCommunityTap()}
           className="text-deadly-accent underline underline-offset-2 hover:text-white"
         >
           {SUBREDDIT_HANDLE}

--- a/ui/src/components/notifications/NotificationsProvider.tsx
+++ b/ui/src/components/notifications/NotificationsProvider.tsx
@@ -25,6 +25,14 @@ import {
   isEligible,
   type CachedNotification,
 } from "@/lib/notifications";
+import {
+  trackNotificationReceived,
+  trackNotificationToastShown,
+  trackNotificationToastTap,
+  trackNotificationMarkAllRead,
+  trackNotificationArchive,
+  trackNotificationArchiveAll,
+} from "@/lib/notificationAnalytics";
 
 // App-wide owner of the notifications store, polling, and the new-message
 // toast. The always-mounted bell and the /notifications page both read/write
@@ -67,35 +75,48 @@ export default function NotificationsProvider({
     setStore(next);
   }, []);
 
-  const refresh = useCallback(async () => {
-    lastFetch.current = Date.now();
-    const prev = storeRef.current;
-    try {
-      const res = await fetchNotifications(prev.cursor);
-      const existing = new Set(Object.keys(prev.messages).map(Number));
-      apply(mergeStore(prev, res));
+  const refresh = useCallback(
+    async (reason: string) => {
+      lastFetch.current = Date.now();
+      const prev = storeRef.current;
+      try {
+        const res = await fetchNotifications(prev.cursor);
+        const existing = new Set(Object.keys(prev.messages).map(Number));
+        const next = mergeStore(prev, res);
+        apply(next);
 
-      // Toast only for genuinely new, eligible, unread arrivals — and never on
-      // a cold start (decision C). Surfaces the newest one; tap opens the inbox.
-      if (prev.cursor > 0) {
+        // Genuinely new, eligible messages from this fetch (any reason, incl.
+        // cold start) — the basis for `notification_received` analytics.
         const fresh = res.messages
           .filter((m) => isEligible(m) && !existing.has(m.id))
-          .sort((a, b) => b.created_at - a.created_at);
-        if (fresh.length > 0) {
-          const label = fresh.length === 1 ? fresh[0].title : `${fresh.length} new messages`;
-          showToast(`New: ${label}`, () => router.push("/notifications"));
+          .sort((a, b) => b.created_at - a.created_at)
+          .map((m) => next.messages[m.id])
+          .filter((m): m is CachedNotification => m != null);
+        for (const m of fresh) trackNotificationReceived(m, reason);
+
+        // Toast only for new arrivals on a delta — never the cold-start backlog
+        // (decision C). Surfaces the newest one; tap opens the inbox.
+        if (prev.cursor > 0 && fresh.length > 0) {
+          const newest = fresh[0];
+          const label = fresh.length === 1 ? newest.title : `${fresh.length} new messages`;
+          trackNotificationToastShown(newest.id, fresh.length);
+          showToast(`New: ${label}`, () => {
+            trackNotificationToastTap(newest.id);
+            router.push("/notifications");
+          });
         }
+      } catch {
+        /* offline — keep the cache */
       }
-    } catch {
-      /* offline — keep the cache */
-    }
-  }, [apply, router, showToast]);
+    },
+    [apply, router, showToast],
+  );
 
   // Initial load + poll on focus/visibility only (decision H — no idle timer).
   useEffect(() => {
-    refresh();
+    refresh("cold_start");
     const onFocus = () => {
-      if (Date.now() - lastFetch.current > 30_000) refresh();
+      if (Date.now() - lastFetch.current > 30_000) refresh("foreground");
     };
     window.addEventListener("focus", onFocus);
     document.addEventListener("visibilitychange", onFocus);
@@ -106,15 +127,25 @@ export default function NotificationsProvider({
   }, [refresh]);
 
   const markRead = useCallback((id: number) => apply(markReadStore(storeRef.current, id)), [apply]);
-  const markAllRead = useCallback(() => apply(markAllSeen(storeRef.current)), [apply]);
-  const archive = useCallback((id: number) => apply(dismissStore(storeRef.current, id)), [apply]);
-  const archiveAll = useCallback(() => apply(archiveAllStore(storeRef.current)), [apply]);
+  const markAllRead = useCallback(() => {
+    trackNotificationMarkAllRead(unreadCount(storeRef.current));
+    apply(markAllSeen(storeRef.current));
+  }, [apply]);
+  const archive = useCallback((id: number) => {
+    const m = storeRef.current.messages[id];
+    if (m) trackNotificationArchive(m);
+    apply(dismissStore(storeRef.current, id));
+  }, [apply]);
+  const archiveAll = useCallback(() => {
+    trackNotificationArchiveAll(activeMessages(storeRef.current).length);
+    apply(archiveAllStore(storeRef.current));
+  }, [apply]);
 
   const value: NotificationsContextValue = {
     unread: unreadCount(store),
     active: activeMessages(store),
     archived: dismissedMessages(store),
-    refresh,
+    refresh: useCallback(() => refresh("refresh"), [refresh]),
     markRead,
     markAllRead,
     archive,

--- a/ui/src/lib/notificationAnalytics.ts
+++ b/ui/src/lib/notificationAnalytics.ts
@@ -1,0 +1,60 @@
+// The notifications analytics vocabulary in one place — thin wrappers over
+// track() so call sites stay terse and every `notification_*` event name/prop
+// is defined once. Mirrors the server allowlist in api/src/db/analytics.ts and
+// the iOS/Android equivalents.
+//
+// Every message-scoped event carries `id` so the admin dashboard can aggregate
+// engagement per notification.
+
+import { track } from "@/lib/analytics";
+import type { CachedNotification } from "@/lib/notifications";
+
+export function trackNotificationReceived(m: CachedNotification, reason: string): void {
+  track("notification_received", {
+    id: m.id,
+    category: m.category,
+    level: m.level,
+    reason,
+  });
+}
+
+export function trackNotificationImpression(m: CachedNotification): void {
+  track("notification_impression", { id: m.id, category: m.category, level: m.level });
+}
+
+export function trackNotificationOpen(m: CachedNotification): void {
+  track("notification_open", {
+    id: m.id,
+    category: m.category,
+    level: m.level,
+    was_unread: m.seen_at == null,
+  });
+}
+
+export function trackNotificationLinkTap(id: number, url: string): void {
+  track("notification_link_tap", { id, url });
+}
+
+export function trackNotificationArchive(m: CachedNotification): void {
+  track("notification_archive", { id: m.id, category: m.category });
+}
+
+export function trackNotificationToastShown(id: number, count: number): void {
+  track("notification_toast_shown", { id, count });
+}
+
+export function trackNotificationToastTap(id: number): void {
+  track("notification_toast_tap", { id });
+}
+
+export function trackNotificationMarkAllRead(count: number): void {
+  track("notification_mark_all_read", { count });
+}
+
+export function trackNotificationArchiveAll(count: number): void {
+  track("notification_archive_all", { count });
+}
+
+export function trackNotificationCommunityTap(): void {
+  track("notification_community_tap");
+}


### PR DESCRIPTION
Instruments the in-app notifications funnel across iOS, Android, and web, and surfaces per-notification engagement stats to admins.

## Clients
Emit a shared `notification_*` event set via the existing analytics pipeline; every message-scoped event carries the notification `id`: received, impression, open, link_tap, archive, toast_shown/tap, mark_all_read, archive_all, community_tap. `NotificationStore.merge()` now returns newly-delivered messages so each emits one `received`.

## Server
Registers the events in the `EVENT_SCHEMAS` allowlist and adds `getNotificationEngagement()` + `GET /api/analytics/notifications`, aggregating distinct-client counts per notification id (delivered, displayed, opened, archived, link_clicks).

## Admin
Per-notification stats strip on `/admin/notifications` cards and a Notification Engagement funnel section on the analytics dashboard.

## Post-build footer fixes
- iOS: community footer link ("More at r/thedeadlyapp →") now opens — replaced the analytics `simultaneousGesture` (which swallowed `Link` activation) with an `OpenURLAction` interception.
- Android: community footer now renders in all states (empty inbox + archive too), matching iOS.

Verified: API (tsc + tests), Android (compileDebugKotlin), web (tsc), iOS (built + working on device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)