### PR TITLE
chore(player): end-of-show detection signal (ADR-0010 chunk 1)

### DIFF
--- a/PLANS/ROADMAP.md
+++ b/PLANS/ROADMAP.md
@@ -56,17 +56,25 @@ web-launch threads, 2026-06).
 
 ## What remains
 
-### 1. Playback queue + autoplay + shuffle (community's top ask)
-The loudest, most-aligned cluster of requests, all client-side (no backend),
-and the just-rebuilt Connect-v2 player surfaces are the right foundation.
-- **Queue of shows** — a transient "play next" list, separate from Favorites
+### 1. Playback auto-advance + show queue + shuffle (community's top ask)
+The loudest, most-aligned cluster of requests. **Now in build (v2 design):**
+[`docs/adr/0010-playback-auto-advance-and-show-queue.md`](../docs/adr/0010-playback-auto-advance-and-show-queue.md),
+plan [`show-queue-v2.md`](show-queue-v2.md), branch `show-queue-v2`. A first
+attempt (abandoned `show-queue` branch) entangled the queue with auto-advance
+and fought Connect-v2's transport authority — the v2 design fixes that by making
+advance an independent coordinator off a positive `onShowCompleted` event,
+keeping the queue local-first (synced like Favorites), and adding one
+informational Connect "park" primitive. Built chunk-by-chunk, proven on all
+three platforms.
+- **Auto-advance / Go-to-next-show** — the foundational, highest-risk piece;
+  built first (chronological, then queue-fed). *(OP idea #3; MazelTov.)*
+- **Queue of shows** — a local-first "play next" list, separate from Favorites
   (which never clear and pollute Fan-Favorites stats). Shows leave the queue
-  once played; can be reordered. *(OP idea #1.)*
-- **Autoplay / Go-to-next-show** — when a show ends, roll into the next. A
-  user-proposed setting shape: `OFF` / `ON (queues + collections only)` /
-  `ON (individual shows, queues, collections)`. *(OP idea #3; MazelTov.)*
+  once played; reorderable; syncs as a whole-list snapshot when signed in
+  (absorbs the old `show-queue-sync` effort). *(OP idea #1.)*
 - **Shuffle** — both *tracks* and *shows*, with the ability to curate which
-  collections feed the shuffle pool. *(MuffDiving — "greedy, I want both".)*
+  collections feed the shuffle pool. Layers on the queue. *(MuffDiving — "greedy,
+  I want both".)*
 
 ### 2. Connect-v2 — finish the remaining edges
 MVP shipped (see Shipped). Open:

--- a/PLANS/show-queue-v2.md
+++ b/PLANS/show-queue-v2.md
@@ -80,6 +80,38 @@ Genuinely good, framework-level pieces (re-introduce in Chunk 3+):
 Leave behind: the advance coordinator's transport-state interrogation, the
 Connect guards, the end-of-show settings matrix, the interrupt snackbar.
 
+## Gotcha: wipe stale DB on devices that ran the abandoned branch
+The old `show-queue` branch bumped the schema (Android Room **v26** +
+`MIGRATION_25_26`; iOS GRDB `v15-play-queue`). `show-queue-v2` is off `main`, so
+its schema is **lower** — a device still holding the v26 DB crashes on launch
+(`IllegalStateException: A migration from 26 to 25 was required but not found`;
+Room can't downgrade). Fix: clear app data —
+`adb shell pm clear com.grateful.deadly.debug` (Android) / delete+reinstall the
+iOS app — before installing a `show-queue-v2` build on such a device.
+
 ## Status
-2026-06-10: **Design accepted (ADR-0010), branch created, no code yet.** Next:
-Chunk 1 — `onShowCompleted` detection across the three platforms.
+2026-06-10: **Chunk 1 (`onShowCompleted` detection) — code complete, proven on
+web + Android; iOS verification in progress.**
+- **Web ✓** — `🏁 SHOW-COMPLETE` fires on natural end-of-show, silent on
+  pause/stop/skip (browser console; needs a hard-refresh past the PWA service
+  worker after each redeploy).
+- **Android ✓** — fires on `READY → ENDED`; silent on pause, stop (`→ IDLE`),
+  show-switch, and **force-quit + cold relaunch** (the `hasPlayedThisSession`
+  guard — the exact false-positive the old build tripped on).
+- **iOS ✓** — verified in Console.app (`PlaylistService` category): fires on
+  natural end-of-show, silent on the negatives.
+
+**Chunk 1 COMPLETE on all three platforms.** Next: Chunk 2 — chronological
+auto-advance + the Connect "park" primitive (verify the original
+Android-under-Connect bug is dead).
+
+### Known pre-existing bug to fix *during* Chunk 2 (not a Chunk 1 regression)
+iOS miniplayer play/pause icon **sometimes** sticks on "play" after
+`ended → tap a song in the same show` — the full-player button + track highlight
+stay correct. Both icons read `service.isPlaying` (= `playbackState == .playing`,
+false during `.buffering`); the miniplayer-only divergence is a SwiftUI
+re-render timing gap in `MiniPlayerOverlay` as the engine settles
+`buffering → playing`. Fix in Chunk 2 by driving the icon off **play-intent**
+(`StreamPlayer.onPlayIntentChange`, true through buffering) rather than the
+knife-edge `.playing` state — Chunk 2 reworks this exact `ended → play next`
+transition anyway.

--- a/PLANS/show-queue-v2.md
+++ b/PLANS/show-queue-v2.md
@@ -1,0 +1,85 @@
+# Show Queue v2 — auto-advance + queue (build plan)
+
+Branch `show-queue-v2` (fresh off `main`; the old `show-queue` branch is
+**abandoned**, not merged). Design spec: [`docs/adr/0010-playback-auto-advance-and-show-queue.md`](../docs/adr/0010-playback-auto-advance-and-show-queue.md).
+Roadmap: §1 in [`ROADMAP.md`](ROADMAP.md).
+
+## The shape (one paragraph)
+
+Auto-advance is an **independent coordinator** that listens for one positive
+event — **`onShowCompleted(showId)`**, "the final track played to its natural
+end" — and on it (optionally counts down, then) calls `playShow(next)`, which is
+an ordinary play. It reads **no** transport/Connect state, so there is no fight
+and no patch layer. To keep Connect from dragging the device back, the active
+device sends a **park** ("I'm done") command at completion so the server stops
+believing it's playing. The **queue is local-first** (works signed-out;
+authoritative locally) and **syncs as a whole-list snapshot** for signed-in
+users, like Favorites. The advance target is **queue head, else next show by
+date** (client-resolved — the server has no catalog).
+
+## Why this replaces the first attempt
+
+The abandoned `show-queue` branch made advancing a client decision that
+interrogated transport state and fought the server's `playing=true` (the
+"advance immediately / no countdown in Connect" patch, the guessed
+`isActiveDevice` gate, `isAutoAdvancing`, `hasBeenPlaying`). Root cause +
+corrected model are in ADR-0010 ("Why the first model was wrong"). **Do not
+reintroduce those patterns.** If you find yourself reading `playing` /
+`activeDeviceId` to decide whether to advance, stop — that's the old trap.
+
+## Build order — each chunk proven on iOS + Android + web before the next
+
+### Chunk 1 — reliable `onShowCompleted` on all three platforms
+The riskiest atom; prove it in isolation. **No advance, no park, no queue.**
+- Each platform's player adapter emits/logs `onShowCompleted(showId)` only on
+  natural end of the **last** track.
+- Verify on-device that it fires on natural show-end and does **NOT** fire on:
+  pause, user-stop, error/skip, transfer (Connect), or cold-start restored state.
+- Per-platform mapping:
+  - **Android (Media3):** `STATE_ENDED` + "played this session" guard.
+  - **iOS (AVQueuePlayer):** `AVPlayerItemDidPlayToEndTime` on the last item.
+  - **Web:** `ended` on the last track.
+- Proof = a log/toast. Web audio verified on beta / another machine (the
+  primary dev box may not output web audio — unverified note from a prior
+  session; confirm by testing).
+
+### Chunk 2 — chronological auto-advance + the park primitive
+On top of Chunk 1's signal. Still no queue.
+- Advance coordinator: `onShowCompleted` → (cancelable countdown) → `playShow`
+  of the **next show by date** (client-resolved from catalog).
+- Active device sends **park** at completion (first cut may reuse `stop`; add a
+  dedicated park action only if the ~1s remote "stopped" flicker bothers us).
+- **Verify the original bug is dead:** auto-advance works under a Connect session
+  on Android (and iOS/web) — countdown holds, no restart/drag-back, advances on
+  exactly the audio-producing device.
+- If "next" fails even on *immediate* advance, suspect a background-socket
+  gremlin (ADR-0007), not this logic.
+
+### Chunk 3 — local queue feeding the advance
+- Local `play_queue` store (Room / GRDB) + domain model. *(Salvageable from the
+  abandoned branch — re-introduce deliberately, not wholesale.)*
+- Surfaces: add-to-queue entry points, a view/reorder/remove list, tap-to-play.
+- Advance target becomes **queue head, else chronological**. Works signed-out.
+
+### Chunk 4 — whole-list snapshot sync (signed-in)
+- Debounced PUT of the full queue to the userdata layer
+  (`api/src/db/userdata`); last-writer-wins; first-pull on sign-in/foreground.
+- Refresh queue when a device becomes active (covers transfer-mid-queue).
+- Absorbs the old `show-queue-sync` project.
+
+### Settings cleanup (independent, anytime)
+The settings screen is overloaded — regroup and improve findability. Not
+coupled to the queue. Keep any end-of-show options here **minimal** until the
+core advance is proven (the first model over-built this matrix).
+
+## Salvage from the abandoned `show-queue` branch (reference, don't cargo-cult)
+Genuinely good, framework-level pieces (re-introduce in Chunk 3+):
+- `play_queue` table + DAO/entity (Room) and GRDB record/DAO + migration.
+- Domain model (`QueuedShow` / `QueuedShowItem`).
+- Add-to-queue UI entry points and the Favorites "Queue" segment list rows.
+Leave behind: the advance coordinator's transport-state interrogation, the
+Connect guards, the end-of-show settings matrix, the interrupt snackbar.
+
+## Status
+2026-06-10: **Design accepted (ADR-0010), branch created, no code yet.** Next:
+Chunk 1 — `onShowCompleted` detection across the three platforms.

--- a/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/repository/MediaControllerRepository.kt
+++ b/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/repository/MediaControllerRepository.kt
@@ -124,6 +124,24 @@ class MediaControllerRepository @Inject constructor(
     private val _trackAutoAdvanced = MutableSharedFlow<Int>(extraBufferCapacity = 1)
     val trackAutoAdvanced: SharedFlow<Int> = _trackAutoAdvanced.asSharedFlow()
 
+    // ADR-0010 Chunk 1: the show-completion signal for auto-advance. Emits the
+    // showId of the show that just finished — and *only* on natural end of the
+    // last track. This is the positive "final track played to its natural end"
+    // event, NOT a generic "playback stopped": ExoPlayer reaches STATE_ENDED only
+    // after running off the end of the media-item list (user-stop is STATE_IDLE,
+    // pause stays STATE_READY, errors go through onPlayerError). The
+    // `hasPlayedThisSession` guard suppresses the cold-start / restored-ENDED case
+    // (a session restored into ENDED must not fire). Disambiguation lives here, in
+    // the player adapter, so the advance coordinator can subscribe to one clean
+    // event and read no transport state.
+    private val _showCompleted = MutableSharedFlow<String>(extraBufferCapacity = 1)
+    val showCompleted: SharedFlow<String> = _showCompleted.asSharedFlow()
+
+    // True once real playback has occurred since the last completion/load. Set on
+    // the first onIsPlayingChanged(true); cleared when we emit showCompleted so a
+    // single end-of-show fires exactly once.
+    @Volatile private var hasPlayedThisSession: Boolean = false
+
     // Analytics: tracks the currently playing item for playback_end
     private var analyticsPlaybackInfo: Triple<String, String, Int>? = null // showId, recordingId, trackNumber
 
@@ -524,6 +542,10 @@ class MediaControllerRepository @Inject constructor(
                         override fun onIsPlayingChanged(isPlaying: Boolean) {
                             if (isPlaying) {
                                 Log.d(TAG, "🕒🎵 [AUDIO] MediaController detected AUDIO STARTED at ${System.currentTimeMillis()}")
+                                // ADR-0010 Chunk 1: real playback has occurred, so a
+                                // subsequent STATE_ENDED is a genuine end-of-show (not a
+                                // cold-start restored ENDED).
+                                hasPlayedThisSession = true
                                 // If no playback_start has been emitted for the current item
                                 // (restore loaded items with playWhenReady=false), emit now
                                 // that playback has actually begun.
@@ -620,6 +642,25 @@ class MediaControllerRepository @Inject constructor(
 
                             currentExoPlayerState = playbackState
                             updatePlaybackState()
+
+                            // ADR-0010 Chunk 1: emit onShowCompleted on the natural end
+                            // of the last track. STATE_ENDED is reached only after the
+                            // media-item list runs off the end; the session guard rejects
+                            // a restored-into-ENDED cold start; the prevState check makes
+                            // it fire exactly once.
+                            if (playbackState == Player.STATE_ENDED &&
+                                prevState != Player.STATE_ENDED &&
+                                hasPlayedThisSession
+                            ) {
+                                hasPlayedThisSession = false
+                                val completedShowId = controller.currentMediaItem
+                                    ?.let { extractShowIdFromMediaItem(it) }
+                                    ?: _currentShowId.value
+                                if (completedShowId != null) {
+                                    Log.d(TAG, "🏁 [SHOW-COMPLETE] onShowCompleted(showId=$completedShowId)")
+                                    _showCompleted.tryEmit(completedShowId)
+                                }
+                            }
 
                             // Stall detection: only count BUFFERING as a stall if we were
                             // already READY (i.e. mid-playback rebuffer). Initial load

--- a/docs/adr/0010-playback-auto-advance-and-show-queue.md
+++ b/docs/adr/0010-playback-auto-advance-and-show-queue.md
@@ -1,0 +1,191 @@
+# ADR-0010: Playback auto-advance + show queue (local-first, transport-decoupled)
+
+## Status
+
+Accepted (2026-06-10). Implementation on `show-queue-v2`, built and verified
+chunk-by-chunk across iOS, Android, and web simultaneously.
+
+**Supersedes an earlier, abandoned design** (the `show-queue` branch, never
+merged). That branch shipped the queue and auto-advance as one entangled change
+and accreted a layer of patches around Connect — the "advance immediately, no
+countdown, because the server keeps dragging us back" workaround, a client-
+guessed `isActiveDevice` gate, an `isAutoAdvancing` suppression flag, and a
+cold-start `hasBeenPlaying` guard. Those patches were the symptom; the root
+cause is recorded under "Why the first model was wrong" below. This ADR records
+the corrected model.
+
+Related: [ADR-0006](0006-connect-v2.md) (Connect-v2, server is transport SoT),
+[ADR-0007](0007-connect-background-socket-lifecycle.md) (background socket
+lifecycle), [ADR-0008](0008-connect-cloud-coordination-deferred.md) (durable
+server-side session state deferred).
+
+## Context
+
+The community's top ask (ROADMAP §1) is a playback queue + autoplay. Two facts
+shape the design:
+
+1. **Connect-v2 makes the server the single source of truth for transport.**
+   Clients send commands; the server owns `playing` / `activeDeviceId` / position
+   and broadcasts a full snapshot (ADR-0006). The server is deliberately
+   **transport-only and has no catalog** — display metadata and "what's next" are
+   client-resolved (Amendments #1, #4); a server-side track cache was built and
+   reverted.
+2. **There is no per-show resume.** A single global `last_played_track` exists
+   only for app-relaunch restoration; shows otherwise start from the beginning.
+
+### Why the first model was wrong
+
+Auto-advance is a **transport transition** — "stop playing A, start playing B."
+In Connect-v2, transport is the server's job. The abandoned design made advancing
+a **client decision executed locally while interrogating transport state**: the
+client decided there was a next show, guessed whether it was the device that
+should act, and tried to drive a paused countdown — while the server still
+believed A was `playing` and broadcast that, dragging the device back. The two
+authorities fought. Every patch on that branch was a concession to the fight.
+A single-source-of-truth model cannot tolerate a second, local authority over the
+same state; the exceptions become whack-a-mole.
+
+## Decision
+
+### 1. The advance signal is "the final track completed," never "playback stopped"
+
+"Playback stopped" is ambiguous — it conflates end-of-show with user-stop, pause,
+error, transfer-park, and the cold-start restored-state case. The signal is
+instead **positive and specific**: the *last track of the current show reached
+its natural end of content*. Stop/pause/error/transfer do not produce it; a
+cold-start restore does not produce it (no track completed in this session). So
+we never disambiguate a generic stop — we never listen for one.
+
+Disambiguation lives **inside each platform's player adapter** and each emits the
+same semantic event:
+
+> **`onShowCompleted(showId)`** — fired only when the final track of `showId`
+> reaches natural end-of-content.
+
+Per-platform mapping:
+- **Android (Media3/ExoPlayer):** `STATE_ENDED` (reached only after running off
+  the end of the media-item list; user-stop is `STATE_IDLE`, pause stays `READY`)
+  **+ a "played in this session" guard** for the cold-start restored-ENDED case.
+- **iOS (AVQueuePlayer):** `AVPlayerItemDidPlayToEndTime` on the **last** item
+  (not a mid-show item).
+- **Web (HTML5 audio):** the `ended` event on the **last** track.
+
+### 2. Auto-advance is an independent coordinator that reads no transport state
+
+The advance coordinator subscribes to `onShowCompleted` and **nothing else**. It
+does not read `playing` / `activeDeviceId` / "are we parked" to decide anything —
+that interrogation *was* the bug. On the event it (optionally) runs a cancelable
+countdown, then calls `playShow(next)`.
+
+- **Input-decoupled:** decided purely from the completion event + the queue +
+  the timer.
+- **Output-normal:** its only interaction with transport is the final
+  `playShow(next)` — byte-for-byte identical to a user tapping a show. The server
+  cannot tell an auto-advance from a manual play, and does not need to.
+
+Gating falls out for free: **only the device producing audio reaches
+`onShowCompleted`.** A remote-control device isn't playing the show locally, so
+its player never completes — no `isActiveDevice` guess required.
+
+### 3. Connect gains one informational primitive: "I'm done" / park
+
+When a show completes, the active device sends a new **park** command so the
+server stops believing it is `playing` (transitions to parked / `playing=false`).
+This is what kills the v1 fight: once the server is out of `playing=true`, the
+device can hold a countdown and advance without being dragged back.
+
+- Park is a **transport fact**, not a command to the local player — at
+  end-of-show the audio has already stopped on its own. It informs Connect; it
+  drives nothing.
+- Park carries **no queue state and no catalog data.** The server gains no
+  knowledge of the queue and makes no advance decision (consistent with
+  ADR-0006: server owns transport, clients resolve shows).
+- The wire change is **additive** (ADR-0006 §8): a new optional command old
+  clients ignore. First implementation may reuse the existing `stop` command if
+  the ~1s "stopped" flicker on remote devices is acceptable; a dedicated park
+  action that holds device ownership is the seamless upgrade if it isn't.
+
+### 4. The queue is local-first; the server is a synced mirror, never an authority
+
+**You can build a queue without an account, so the queue must live locally.**
+Connect-v2 is per-user — no account means no Connect session, so a signed-out
+user is always single-device and never has the fight or a transfer.
+
+- The **local queue is authoritative** for every operation; the advance logic
+  reads the local copy. Works fully signed-out.
+- For **signed-in** users the queue **syncs as a whole-list snapshot** (debounced
+  PUT, last-writer-wins) through the existing userdata layer
+  (`api/src/db/userdata`), exactly like Favorites and playback position. A
+  dropped or out-of-order snapshot just means the next one wins; a per-op delta
+  log would need ordering/conflict guarantees the tiny list doesn't justify.
+- Sync makes the queue **travel** with the user; it is **not** on the advance
+  critical path. The transfer-mid-queue edge (active device moves, queue must
+  follow) is covered because each signed-in device holds a synced copy; staleness
+  at the moment of transfer is handled by refreshing the queue when a device
+  becomes active.
+
+This places the server-side queue firmly in **durable user data** (no push, no
+live-session coordination), so it is compatible with ADR-0008's deferral of
+durable *session* state — it is the "server-mostly easy half" that ADR named.
+
+### 5. Advance target resolution
+
+The advance coordinator computes the next show as: **queue head if present, else
+the next show chronologically** (later date), resolved client-side from the
+catalog. The server never resolves a show — it has no catalog. Chronological
+auto-advance is therefore just "advance with an empty queue."
+
+### 6. Build order: prove each piece on all three platforms before the next
+
+Built chunk-by-chunk; each chunk is one capability, contract-defined once,
+implemented **and verified on iOS, Android, and web** before the next. (Web audio
+is verified on beta / another machine, not the primary dev box.) This is the
+deliberate antidote to the first model's "one big change, many small problems."
+
+## Consequences
+
+**Gained:**
+- No second authority over transport, so no fight and no patch layer. The advance
+  is a pure function of a specific event; its output is an ordinary play.
+- End-of-show is detected by a specific positive event, eliminating the whole
+  class of "stopped-for-the-wrong-reason" false advances.
+- The queue works signed-out (local-first) and travels signed-in (snapshot sync),
+  absorbing what was the separate `show-queue-sync` project — at no critical-path
+  cost.
+- One wire addition (park), additive and small.
+
+**Accepted / given up:**
+- **Parallel per-platform implementations** kept at contract parity by
+  discipline (no KMM shared module). The shared contract is the `onShowCompleted`
+  event, the park command, and the snapshot sync shape.
+- **Reuse-`stop`-for-park** may flicker remote devices through a "stopped" state
+  for ~1s before the next show loads, until/unless a dedicated park action lands.
+- **Resume-on-interrupt and the end-of-show settings matrix are deferred**, not
+  designed here — the first model over-built settings. Revisit minimally once the
+  core advance + queue are proven.
+- **Sync staleness at transfer** is best-effort (refresh-on-active), consistent
+  with userdata being focus/foreground-refresh rather than realtime.
+
+## Alternatives considered
+
+**Server-authoritative queue + server-arbitrated advance** (server owns the
+ordered list and directs the active device to advance). Rejected: it fails the
+no-account case (no server identity → no queue), pulls forward durable
+server-side state that ADR-0008 deferred, and is unnecessary — once advance is
+input-decoupled (Decision #2) and park kills the fight (Decision #3), the server
+does not need to decide or store anything for advance to be correct. The local-
+first mirror (Decision #4) gets cross-device for free without making the server
+an authority.
+
+**Key advance off a generic "playback stopped" signal.** Rejected (Decision #1):
+ambiguous on every platform; it is the source of the cold-start and
+stopped-for-the-wrong-reason false advances.
+
+**Client-side advance that interrogates transport state to self-gate** (the
+abandoned model). Rejected: that interrogation is the whack-a-mole; the
+audio-producing device is intrinsically the only one that completes a show, so no
+self-gate is needed.
+
+**Per-op delta sync (outbox) for the queue.** Rejected in favor of whole-list
+snapshot (Decision #4): the list is tiny and reorder/remove/pop deltas need
+ordering and conflict resolution that a snapshot makes moot.

--- a/iosApp/Packages/SwiftAudioStreamEx/Sources/SwiftAudioStreamEx/Internal/AudioStreamEngine.swift
+++ b/iosApp/Packages/SwiftAudioStreamEx/Sources/SwiftAudioStreamEx/Internal/AudioStreamEngine.swift
@@ -118,6 +118,11 @@ final class AudioStreamEngine: NSObject, AudioEngineProtocol, @unchecked Sendabl
     // MARK: - AudioEngineProtocol callbacks
     nonisolated(unsafe) var onStateChange: ((PlaybackState) -> Void)?
     nonisolated(unsafe) var onTrackComplete: (() -> Void)?
+    /// Fired when the *last* track of the queue reaches its natural end of file
+    /// (the positive "show completed" signal — see ADR-0010 Chunk 1). Distinct
+    /// from onTrackComplete (mid-queue auto-advance) and from a user stop/pause
+    /// or an error (which never reach this `.eof && isLastTrack` path).
+    nonisolated(unsafe) var onQueueComplete: (() -> Void)?
     nonisolated(unsafe) var onProgressUpdate: ((PlaybackProgress) -> Void)?
     /// Fired when the engine surfaces a user-visible playback failure.
     /// The second parameter, when non-nil, is the playback position at the
@@ -815,6 +820,7 @@ extension AudioStreamEngine: AudioPlayerDelegate {
         if stopReason == .eof && isLastTrack {
             logger.notice("[PB] final track finished, queue ended")
             onStateChange?(.ended)
+            onQueueComplete?()
         }
     }
 

--- a/iosApp/Packages/SwiftAudioStreamEx/Sources/SwiftAudioStreamEx/StreamPlayer.swift
+++ b/iosApp/Packages/SwiftAudioStreamEx/Sources/SwiftAudioStreamEx/StreamPlayer.swift
@@ -56,6 +56,13 @@ public final class StreamPlayer {
     /// uses this so the active device broadcasts the new track index to the session.
     public var onTrackComplete: (() -> Void)?
 
+    /// Called when the *last* track of the queue reaches its natural end of file —
+    /// the positive "show completed" signal (ADR-0010 Chunk 1). Fires only on
+    /// `.eof && isLastTrack`, so a user stop/pause, an error, or a mid-queue
+    /// transition never trigger it. The package stays show-agnostic; the app
+    /// layer translates this into `onShowCompleted(showId)`.
+    public var onQueueComplete: (() -> Void)?
+
     /// Called when play INTENT changes — true when the player wants to be playing
     /// (`.playing`/`.buffering`), false when it has stopped (`.paused`/`.ended`/
     /// `.idle`). Distinct from `playbackState.isPlaying`, which is false during
@@ -464,6 +471,14 @@ public final class StreamPlayer {
                 let newTitle = self.currentTrack?.title ?? "(none)"
                 self.logger.notice("[PB] onTrackComplete prev=\(previousTitle, privacy: .public) → newIdx=\(self.engine.currentIndex, privacy: .public) new=\(newTitle, privacy: .public)")
                 self.onTrackComplete?()
+            }
+        }
+
+        engine.onQueueComplete = { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                self.logger.notice("[PB] onQueueComplete — final track finished naturally")
+                self.onQueueComplete?()
             }
         }
 

--- a/iosApp/deadly/Core/Service/PlaylistServiceImpl.swift
+++ b/iosApp/deadly/Core/Service/PlaylistServiceImpl.swift
@@ -1,8 +1,11 @@
 import Foundation
 import SwiftAudioStreamEx
+import os.log
 #if canImport(UIKit)
 import UIKit
 #endif
+
+private let logger = Logger(subsystem: "com.grateful.deadly", category: "PlaylistService")
 
 @Observable
 @MainActor
@@ -27,6 +30,15 @@ final class PlaylistServiceImpl: PlaylistService {
     var connectService: ConnectService?
     /// When true, playTrack() skips notifying Connect to avoid Connect→load→sendLoad loops.
     var suppressConnectNotify = false
+
+    /// ADR-0010 Chunk 1: the show-completion signal for auto-advance. Fired with
+    /// the showId of the show that just finished — and *only* on the natural end
+    /// of its last track (the package's `onQueueComplete`, which is `.eof &&
+    /// isLastTrack`). A user stop/pause, an error, or a mid-show track transition
+    /// never reach it, and a cold-start restore never plays to EOF, so no session
+    /// guard is needed on iOS. The advance coordinator subscribes to this and
+    /// reads no transport state.
+    var onShowCompleted: ((String) -> Void)?
 
     /// Tracks the currently playing item for playback_end analytics.
     private var playbackStartInfo: (showId: String, recordingId: String, trackNumber: Int)?
@@ -108,6 +120,13 @@ final class PlaylistServiceImpl: PlaylistService {
         MainActor.assumeIsolated {
             self.startProgressObservation()
             self.startPlaybackStateObservation()
+            // ADR-0010 Chunk 1: translate the package's show-agnostic
+            // "queue completed naturally" into onShowCompleted(showId).
+            self.streamPlayer.onQueueComplete = { [weak self] in
+                guard let self, let showId = self.currentShow?.id else { return }
+                logger.notice("🏁 [SHOW-COMPLETE] onShowCompleted(showId=\(showId, privacy: .public))")
+                self.onShowCompleted?(showId)
+            }
             self.willResignActiveObserver = NotificationCenter.default.addObserver(
                 forName: UIApplication.willResignActiveNotification,
                 object: nil,

--- a/ui/src/components/player/PlayerProvider.tsx
+++ b/ui/src/components/player/PlayerProvider.tsx
@@ -281,6 +281,13 @@ export default function PlayerProvider({
           sendCommandRef.current("next");
         } else {
           setStatus("paused");
+          // ADR-0010 Chunk 1: the final track finished on its own — the positive
+          // "show completed" signal. `ended` only fires on natural EOF (a user
+          // stop/pause doesn't fire it; load errors go to the "error" listener),
+          // and this is the last-track branch — so this is end-of-show, not a
+          // generic stop. The advance coordinator will hang off this point.
+          const completedShowId = activeShowRef.current?.showId ?? "";
+          console.info(`🏁 [SHOW-COMPLETE] onShowCompleted(showId=${completedShowId})`);
           // Last track finished on its own — no track change will drive the
           // playback_end, so emit the completed end here.
           const c = committedPlaybackRef.current;


### PR DESCRIPTION
First increment of the show-queue / auto-advance work (ADR-0010). **Foundation only — no user-facing behavior change.**

## What this adds
A positive **`onShowCompleted`** signal — "the final track of the current show played to its natural end" — surfaced from each platform's player adapter. Nothing consumes it yet (auto-advance is Chunk 2); it only logs `🏁 SHOW-COMPLETE`. Purely additive, zero behavior change.

- **Android** — `MediaControllerRepository.showCompleted: SharedFlow<String>`, emitted on `STATE_ENDED` (only reached after running off the media-item list), guarded by `hasPlayedThisSession` to suppress the cold-start restored-ENDED case.
- **iOS** — `SwiftAudioStreamEx` gains a show-agnostic `onQueueComplete` (fired only on `stopReason == .eof && isLastTrack`); `PlaylistServiceImpl` translates it to `onShowCompleted(showId)`.
- **Web** — `PlayerProvider`'s `ended` last-track branch (`ended` doesn't fire on stop/pause; errors go to the error listener).

Plus the design docs: `docs/adr/0010-playback-auto-advance-and-show-queue.md`, `PLANS/show-queue-v2.md`, ROADMAP §1.

## Why it's the right shape
The disambiguation lives *inside* each player adapter, so the future advance coordinator subscribes to one clean event and reads no transport state — the structural fix for the abandoned `show-queue` branch's Connect whack-a-mole (see the ADR's "Why the first model was wrong").

## Verification (device-tested)
Proven on **web + Android + iOS**: fires on natural end-of-show, and stays silent on pause, manual stop, skip-past-last-track, show-switch, and **force-quit + cold relaunch** (the false-positive that broke the old build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)