### PR TITLE
fix(web): secure-context-safe UUID so login works over plain-HTTP LAN

### DIFF
--- a/ui/src/components/connect/ConnectProvider.tsx
+++ b/ui/src/components/connect/ConnectProvider.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { ConnectContext } from "@/contexts/ConnectContext";
 import type { ConnectDevice, ConnectState } from "@/types/connect";
+import { randomUUID } from "@/lib/uuid";
 
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const RECONNECT_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 30_000];
@@ -18,7 +19,7 @@ const warn = (...args: unknown[]) => console.warn("[Connect]", ...args);
 function getOrCreateDeviceId(): string {
   let id = localStorage.getItem(DEVICE_ID_KEY);
   if (!id) {
-    id = crypto.randomUUID();
+    id = randomUUID();
     localStorage.setItem(DEVICE_ID_KEY, id);
   }
   return id;

--- a/ui/src/lib/analytics.ts
+++ b/ui/src/lib/analytics.ts
@@ -10,6 +10,8 @@
 // (a bundle can't keep a secret) — Caddy injects X-Analytics-Key on
 // /api/analytics in production; in dev the API accepts keyless.
 
+import { randomUUID } from "@/lib/uuid";
+
 const IID_KEY = "deadly_iid";
 const OPT_OUT_KEY = "deadly_analytics_off";
 const ENDPOINT = "/api/analytics";
@@ -36,10 +38,7 @@ let sessionId = "";
 let buffer: AnalyticsEvent[] = [];
 let wired = false;
 
-function uuid(): string {
-  if (typeof crypto !== "undefined" && crypto.randomUUID) return crypto.randomUUID();
-  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-}
+const uuid = randomUUID;
 
 // Stable per-browser anonymous id. Distinct from mobile IIDs by design — a
 // web-only listener is a real, separate user (just not an app install).

--- a/ui/src/lib/uuid.ts
+++ b/ui/src/lib/uuid.ts
@@ -1,0 +1,26 @@
+/**
+ * Generate a UUID that works outside secure contexts.
+ *
+ * `crypto.randomUUID()` only exists in a *secure context* — HTTPS or
+ * `localhost`. Over a plain-HTTP LAN origin (e.g. `http://192.168.x.x:8080`,
+ * used when reaching the dev/beta web app from another device) it is
+ * `undefined`, which previously crashed login: `ConnectProvider` called
+ * `crypto.randomUUID()` to mint its device id and threw
+ * `TypeError: crypto.randomUUID is not a function`.
+ *
+ * Falls back to a `getRandomValues`-based UUIDv4, then to a non-crypto string
+ * as a last resort (only ids, never secrets).
+ */
+export function randomUUID(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+    const b = crypto.getRandomValues(new Uint8Array(16));
+    b[6] = (b[6] & 0x0f) | 0x40; // version 4
+    b[8] = (b[8] & 0x3f) | 0x80; // variant 10
+    const hex = Array.from(b, (x) => x.toString(16).padStart(2, "0")).join("");
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}-${Math.random().toString(16).slice(2)}`;
+}


### PR DESCRIPTION
## Problem
Reaching the web app from another device over the LAN IP (`http://192.168.x.x:8080`) and logging in throws `TypeError: crypto.randomUUID is not a function` and lands in a failed state.

## Cause
`crypto.randomUUID()` only exists in a **secure context** (HTTPS or `localhost`). A plain-HTTP LAN origin isn't one, so `crypto.randomUUID` is `undefined`. `ConnectProvider.getOrCreateDeviceId()` called it unguarded when starting Connect right after authentication.

## Fix
Add a shared `randomUUID()` helper (`crypto.randomUUID` → `getRandomValues`-based UUIDv4 → non-crypto fallback) and use it in `ConnectProvider`; refactor `analytics.ts` to reuse it (it already had its own guarded copy).

## Test
Over `http://<LAN-IP>:8080` (hard-refresh past the PWA service worker): sign in succeeds, Connect starts. `localhost`/HTTPS unchanged. `make ui-build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)