### PR TITLE
feat(all/player): end-of-show auto-advance + cross-device countdown + Up Next takeover (ADR-0010)

### DIFF
--- a/PLANS/ROADMAP.md
+++ b/PLANS/ROADMAP.md
@@ -56,17 +56,25 @@ web-launch threads, 2026-06).
 
 ## What remains
 
-### 1. Playback queue + autoplay + shuffle (community's top ask)
-The loudest, most-aligned cluster of requests, all client-side (no backend),
-and the just-rebuilt Connect-v2 player surfaces are the right foundation.
-- **Queue of shows** — a transient "play next" list, separate from Favorites
+### 1. Playback auto-advance + show queue + shuffle (community's top ask)
+The loudest, most-aligned cluster of requests. **Now in build (v2 design):**
+[`docs/adr/0010-playback-auto-advance-and-show-queue.md`](../docs/adr/0010-playback-auto-advance-and-show-queue.md),
+plan [`show-queue-v2.md`](show-queue-v2.md), branch `show-queue-v2`. A first
+attempt (abandoned `show-queue` branch) entangled the queue with auto-advance
+and fought Connect-v2's transport authority — the v2 design fixes that by making
+advance an independent coordinator off a positive `onShowCompleted` event,
+keeping the queue local-first (synced like Favorites), and adding one
+informational Connect "park" primitive. Built chunk-by-chunk, proven on all
+three platforms.
+- **Auto-advance / Go-to-next-show** — the foundational, highest-risk piece;
+  built first (chronological, then queue-fed). *(OP idea #3; MazelTov.)*
+- **Queue of shows** — a local-first "play next" list, separate from Favorites
   (which never clear and pollute Fan-Favorites stats). Shows leave the queue
-  once played; can be reordered. *(OP idea #1.)*
-- **Autoplay / Go-to-next-show** — when a show ends, roll into the next. A
-  user-proposed setting shape: `OFF` / `ON (queues + collections only)` /
-  `ON (individual shows, queues, collections)`. *(OP idea #3; MazelTov.)*
+  once played; reorderable; syncs as a whole-list snapshot when signed in
+  (absorbs the old `show-queue-sync` effort). *(OP idea #1.)*
 - **Shuffle** — both *tracks* and *shows*, with the ability to curate which
-  collections feed the shuffle pool. *(MuffDiving — "greedy, I want both".)*
+  collections feed the shuffle pool. Layers on the queue. *(MuffDiving — "greedy,
+  I want both".)*
 
 ### 2. Connect-v2 — finish the remaining edges
 MVP shipped (see Shipped). Open:

--- a/PLANS/ROADMAP.md
+++ b/PLANS/ROADMAP.md
@@ -66,8 +66,12 @@ advance an independent coordinator off a positive `onShowCompleted` event,
 keeping the queue local-first (synced like Favorites), and adding one
 informational Connect "park" primitive. Built chunk-by-chunk, proven on all
 three platforms.
-- **Auto-advance / Go-to-next-show** — the foundational, highest-risk piece;
-  built first (chronological, then queue-fed). *(OP idea #3; MazelTov.)*
+- **Auto-advance / Go-to-next-show** — ✅ **mechanism complete on all three
+  platforms**, incl. cross-device end-of-show countdown over Connect and the
+  full-screen "Up Next" takeover + per-device "when a show ends" setting
+  (2026-06-11). Chronological today; queue-fed once the queue lands. Remaining:
+  the play/pause affordance fix and an intermittent iOS spurious-`next` (seen
+  once, needs a repro). *(OP idea #3; MazelTov.)*
 - **Queue of shows** — a local-first "play next" list, separate from Favorites
   (which never clear and pollute Fan-Favorites stats). Shows leave the queue
   once played; reorderable; syncs as a whole-list snapshot when signed in

--- a/PLANS/ROADMAP.md
+++ b/PLANS/ROADMAP.md
@@ -78,6 +78,17 @@ three platforms.
 
 ### 2. Connect-v2 — finish the remaining edges
 MVP shipped (see Shipped). Open:
+- **Session ownership lease + WS protocol versioning (ship ASAP).** Connect's
+  `activeDeviceId` is in-memory server state that clients rebuild via a growing
+  pile of cause-specific reclaim detectors — which miss the fresh-reconnect-after-
+  restart case (an end-of-show advance silently died this way, 2026-06-11) and the
+  disconnect-cleanup case. Replace them with one convergent **ownership lease** the
+  audio-producing device renews via heartbeat, gated on a new **`protocolVersion`**
+  primitive (monotonic int on `register`, stamped on the in-memory connection
+  record — telemetry + soft forced-update lever). **`protocolVersion` has standalone
+  value — ship it first.** Server claim-when-null already landed (`52942d45`).
+  Decisions in **ADR-0011**; plan in [`PLANS/connect-ownership-lease.md`](connect-ownership-lease.md).
+  Redis-persist stays deferred (ADR-0008); the lease covers what we need without it.
 - **Web as a first-class controllable target ("remote").** A browser tab is now
   a controller/target — control the web player from the phone. In flight,
   promised publicly. Current constraint: the controlling app can't be
@@ -161,6 +172,16 @@ blocks onboarding for affected users.
   (`MobileTabBar` is Home/Favorites/Settings; the rail is `lg:hidden`). To
   retire: add Settings to `UserMenu`, surface Recent/Reviews in mobile nav, then
   drop the strip. Until that nav exists, leave it.
+
+### 11. Settings screen reorganization (cross-platform, maintainer pain)
+The settings screens (iOS `SettingsScreen.swift`, Android `SettingsScreen.kt`,
+web `/me` SettingsTab) have grown overloaded and are increasingly hard to work in
+— findability is poor and adding a toggle means scanning a long flat list (the
+"When a show ends" / Playback section just landed into this sprawl). Regroup into
+clear sections with better findability; keep it a presentation/IA change, not new
+settings. Independent of any feature — the show-queue plan flags it as
+"Settings cleanup (independent, anytime)." Do it before the settings list grows
+again (shuffle, queue, and source-picker options are all coming).
 
 ## Deferred / explicit non-goals (sync v0)
 Cross-device deletion **tombstones**, **settings sync**, and **background sync**

--- a/PLANS/connect-ownership-lease.md
+++ b/PLANS/connect-ownership-lease.md
@@ -1,0 +1,78 @@
+# Connect — session ownership lease + WS protocol versioning (build plan)
+
+Design spec: [`docs/adr/0011-connect-session-ownership-and-protocol-versioning.md`](../docs/adr/0011-connect-session-ownership-and-protocol-versioning.md).
+Roadmap: §2 in [`ROADMAP.md`](ROADMAP.md). Extends ADR-0006/0007/0008; the failure
+that motivated it surfaced in ADR-0010 §7 (cross-device end-of-show countdown).
+
+## The shape (one paragraph)
+
+Connect's `activeDeviceId`/`playing` is in-memory server state that clients today
+re-establish only **reactively**, via a growing pile of cause-specific detectors
+(epoch-change reclaim, empty-tracks re-assert). They miss cases (a fresh reconnect
+*after* a restart never witnesses the epoch change; `handleDisconnect` nulls active
+with no restart at all). Replace them with **one convergent mechanism**: the device
+producing audio renews an **ownership lease** by piggybacking `{playing,
+recordingId, positionMs}` on the existing heartbeat; the server treats the active
+device as a lease the live player renews. Explicit commands stay the fast,
+immediately-consistent control path — the lease is the *healing* layer. Gate it on
+a new **`protocolVersion`** primitive so a mixed old/new fleet stays safe.
+
+## Ship order — protocol versioning first; it has standalone value
+
+### Chunk A — `protocolVersion` + `appVersion` on `register` (ship ASAP, standalone)
+The enabling primitive; useful before any lease work.
+- Clients send `protocolVersion` (monotonic int, new builds = `1`) and `appVersion`
+  (string) in the `register` message. Absent ⇒ `0` (legacy).
+- Server stamps both onto the **in-memory `liveDevices` connection record** (next to
+  the socket — NOT Redis; same lifetime as the connection). Every command/heartbeat
+  handler can read it.
+- **Telemetry:** log the protocol/app distribution per session so we can later see
+  when it's safe to retire legacy branches and advance `MIN_SUPPORTED`.
+- **Soft floor:** optional `MIN_SUPPORTED` → `{type:"error", code:"client_too_old"}`
+  the client renders as an "Update for Connect" nudge. Soft, not a hard reject
+  (app-store review lag). Wire the client surface but keep `MIN_SUPPORTED` at `0`
+  until there's a reason to raise it.
+- Single source of truth for version semantics: add `docs/PROTOCOL.md`.
+- Per-platform: Android `sendRegister`, iOS register payload, web WS register.
+- Proof: server logs the stamped version per device; telemetry row lands.
+
+### Chunk B — ownership lease (heartbeat-renewed), gated on `protocolVersion >= 1`
+- Heartbeat (client→server) carries `{playing, recordingId, positionMs}` for the
+  device producing audio. Additive fields; old clients omit them.
+- Server: a renewal **claims an ownerless session** (`activeDeviceId == null`) or
+  **refreshes the existing owner**. It **never preempts** a command-claimed owner
+  (the §2 conservative rule — mixed-fleet safe, no split-brain flap).
+- Ownership ≠ "playing now": a paused owner keeps the lease (renew while connected).
+- Conflict (two devices assert an ownerless session): tiebreak by most-recent
+  explicit user action, then lease timestamp. Rare — only one device makes sound
+  normally.
+- Verify the original bug is dead: play through an API restart → next heartbeat
+  reconverges `activeDeviceId` → end-of-show advance fires. Also the
+  disconnect-reconnect variant (kill the socket mid-play, reconnect).
+
+### Chunk C — delete the reclaim heuristics
+Once B is proven on all three platforms and telemetry shows the fleet on
+`protocolVersion >= 1`:
+- Remove epoch-change reclaim (`serverRestarted`/`lastEpoch`), empty-tracks
+  re-assert (`reassertingTracks`), and the `playWhenReady` reconciler's
+  `if (!isActive) return` gate — the lease subsumes them.
+- Keep the deletion gated on telemetry; each removed branch is debt paid down.
+
+## Already shipped (pre-plan)
+- **Server `handleAnnounceNext` claim-when-null** (`52942d45`, `fix(all/connect)`):
+  the announcing device claims active when `activeDeviceId == null`. Rescues
+  end-of-show auto-advance even before the lease lands; a consistent instance of
+  the §2 "claim when null" rule.
+
+## Explicitly NOT this plan
+- **Redis-persist of session state** — stays deferred (ADR-0008, gated on social);
+  it wouldn't cover the disconnect variant anyway. The lease is the fix now.
+- **Silent push to wake a sleeping device** — deferred (ADR-0008), orthogonal.
+- **Multi-instance API** — per-connection facts live in one instance's memory;
+  horizontal scaling would need sticky routing / a shared presence registry. Out of
+  scope; noted in ADR-0011 Consequences.
+
+## Status
+2026-06-11: **ADR-0011 accepted (design); server claim-when-null shipped
+(`52942d45`). Chunks A–C not started.** Ship Chunk A (protocol versioning) ASAP —
+it has standalone value (telemetry + forced-update lever) independent of the lease.

--- a/PLANS/connect-ownership-lease.md
+++ b/PLANS/connect-ownership-lease.md
@@ -56,6 +56,13 @@ Once B is proven on all three platforms and telemetry shows the fleet on
 - Remove epoch-change reclaim (`serverRestarted`/`lastEpoch`), empty-tracks
   re-assert (`reassertingTracks`), and the `playWhenReady` reconciler's
   `if (!isActive) return` gate — the lease subsumes them.
+- Collapse the **transport-authority guards** into one lease invariant. There are
+  now two "don't sync transport DOWN to stale server state because this device is
+  the real source" exceptions in `reactToState`: `if (reclaimAfterRestart) return`
+  and the `justBecameActive && pendingAdvance == null` become-active guard (added
+  while fixing the announce-park seek-back glitch, 2026-06-11). Both are the same
+  rule — *the device producing audio is the transport authority* — which the lease
+  makes first-class, so both guards go away.
 - Keep the deletion gated on telemetry; each removed branch is debt paid down.
 
 ## Already shipped (pre-plan)

--- a/PLANS/show-queue-v2.md
+++ b/PLANS/show-queue-v2.md
@@ -80,6 +80,38 @@ Genuinely good, framework-level pieces (re-introduce in Chunk 3+):
 Leave behind: the advance coordinator's transport-state interrogation, the
 Connect guards, the end-of-show settings matrix, the interrupt snackbar.
 
+## Gotcha: wipe stale DB on devices that ran the abandoned branch
+The old `show-queue` branch bumped the schema (Android Room **v26** +
+`MIGRATION_25_26`; iOS GRDB `v15-play-queue`). `show-queue-v2` is off `main`, so
+its schema is **lower** — a device still holding the v26 DB crashes on launch
+(`IllegalStateException: A migration from 26 to 25 was required but not found`;
+Room can't downgrade). Fix: clear app data —
+`adb shell pm clear com.grateful.deadly.debug` (Android) / delete+reinstall the
+iOS app — before installing a `show-queue-v2` build on such a device.
+
 ## Status
-2026-06-10: **Design accepted (ADR-0010), branch created, no code yet.** Next:
-Chunk 1 — `onShowCompleted` detection across the three platforms.
+2026-06-10: **Chunk 1 (`onShowCompleted` detection) — code complete, proven on
+web + Android; iOS verification in progress.**
+- **Web ✓** — `🏁 SHOW-COMPLETE` fires on natural end-of-show, silent on
+  pause/stop/skip (browser console; needs a hard-refresh past the PWA service
+  worker after each redeploy).
+- **Android ✓** — fires on `READY → ENDED`; silent on pause, stop (`→ IDLE`),
+  show-switch, and **force-quit + cold relaunch** (the `hasPlayedThisSession`
+  guard — the exact false-positive the old build tripped on).
+- **iOS ✓** — verified in Console.app (`PlaylistService` category): fires on
+  natural end-of-show, silent on the negatives.
+
+**Chunk 1 COMPLETE on all three platforms.** Next: Chunk 2 — chronological
+auto-advance + the Connect "park" primitive (verify the original
+Android-under-Connect bug is dead).
+
+### Known pre-existing bug to fix *during* Chunk 2 (not a Chunk 1 regression)
+iOS miniplayer play/pause icon **sometimes** sticks on "play" after
+`ended → tap a song in the same show` — the full-player button + track highlight
+stay correct. Both icons read `service.isPlaying` (= `playbackState == .playing`,
+false during `.buffering`); the miniplayer-only divergence is a SwiftUI
+re-render timing gap in `MiniPlayerOverlay` as the engine settles
+`buffering → playing`. Fix in Chunk 2 by driving the icon off **play-intent**
+(`StreamPlayer.onPlayIntentChange`, true through buffering) rather than the
+knife-edge `.playing` state — Chunk 2 reworks this exact `ended → play next`
+transition anyway.

--- a/PLANS/show-queue-v2.md
+++ b/PLANS/show-queue-v2.md
@@ -117,15 +117,22 @@ resolved via new **`GET /api/shows/:id/next`** + `getNextShow()` in
 `api/src/showCatalog.ts` (the browser has no catalog — shows are static SSG and
 the search index lacks recording ids).
 
-Remaining in Chunk 2:
+**Chunk 2 — iOS DONE + device-verified (`77a3def6`).** Advances on its own and
+follows/leads under Connect. `playShow` = loadShow + playTrack(0); coordinator
+`AutoAdvanceCoordinator` (@MainActor @Observable) wired in AppContainer; park via
+the existing `ConnectService.sendStop()`; next-show via on-device
+`getNextShow(afterDate:)`.
+
+### ✅ Advance mechanism COMPLETE + verified on all three platforms (incl. multi-client Connect).
+Remaining in Chunk 2 (UX/polish — mechanism is done):
 1. Cancelable countdown **overlay UI** (advances silently after 15s today).
    - Also: during the countdown the active device is *parked*, so remotes render
      a bare parked scrubber and disagree on its position (Android remote → 0;
      iOS/web → held at end). Minor/cosmetic; likely resolved by giving remotes a
      proper "next show in Ns" display instead of the parked state.
-2. **iOS parity** (last platform; already consolidates play+Connect).
-3. The **"when a show ends" setting** (on/off, countdown/immediate).
-4. The **play/pause affordance fix** (iOS miniplayer icon + Android restore).
+2. The **"when a show ends" setting** (on/off, countdown/immediate) — needed
+   before shipping (auto-advance is hardcoded ON today).
+3. The **play/pause affordance fix** (iOS miniplayer icon + Android restore).
 
 ### Known pre-existing bug to fix *during* Chunk 2 (not a Chunk 1 regression)
 iOS miniplayer play/pause icon **sometimes** sticks on "play" after

--- a/PLANS/show-queue-v2.md
+++ b/PLANS/show-queue-v2.md
@@ -129,9 +129,16 @@ Server `pendingAdvance` + announce_next/cancel_advance/advance_now; each client
 emits + drives the countdown/advance off the shared note; Cancel & Play-now work
 from any device. Web has the fullscreen takeover; Android/iOS use a docked card.
 Also fixed: Android connect-follow now resolves the ticket cover (was logo).
-Remaining polish: **mobile fullscreen-takeover** (parity with web), the
-**"when a show ends" setting** (advance is hardcoded ON — ship gate), and the
+Remaining polish: **mobile fullscreen-takeover** (parity with web) and the
 **play/pause affordance** fixes.
+
+**"When a show ends" ship gate — DONE on all three platforms.** Per-device
+opt-out gating whether THIS device initiates an advance; default ON. Android
+`abafadc9` (AppPreferences + Settings "Playback"), iOS (AppPreferences
+`autoAdvanceEnabled` + gated `AutoAdvanceCoordinator.onShowCompleted` + Settings
+"Playback" section), web (`lib/playbackPrefs.ts` localStorage flag, gated
+`onShowComplete`, toggle in `/me` SettingsTab). `feature_use` /
+`toggle_auto_advance` analytics on each.
 Remaining in Chunk 2 (UX/polish — mechanism is done):
 1. Cancelable countdown **overlay UI** (advances silently after 15s today).
    - Also: during the countdown the active device is *parked*, so remotes render

--- a/PLANS/show-queue-v2.md
+++ b/PLANS/show-queue-v2.md
@@ -134,6 +134,17 @@ Remaining in Chunk 2 (UX/polish — mechanism is done):
    before shipping (auto-advance is hardcoded ON today).
 3. The **play/pause affordance fix** (iOS miniplayer icon + Android restore).
 
+### Phase B (later): broadcast "next up" over Connect (display on remotes)
+Additive `pendingAdvance: { showId, deadline }` on `ConnectState`. The active
+device announces on countdown start; remotes **render only** (resolve art/info by
+showId locally/API; tick from `deadline − now` via existing `serverTimeOffsetMs`).
+**Asymmetry:** the announce is a one-way display hint, but **cancel is two-way
+control** — a remote's Cancel sends a command that clears `pendingAdvance`
+server-side; the **active device watches `pendingAdvance` and cancels its own
+timer when it's cleared** (same as reacting to a remote pause). Server clears it
+on load/stop. Build Phase A (local UI, below) so the countdown component can be
+fed by either the local coordinator OR an incoming `pendingAdvance`.
+
 ### Known pre-existing bug to fix *during* Chunk 2 (not a Chunk 1 regression)
 iOS miniplayer play/pause icon **sometimes** sticks on "play" after
 `ended → tap a song in the same show` — the full-player button + track highlight

--- a/PLANS/show-queue-v2.md
+++ b/PLANS/show-queue-v2.md
@@ -1,0 +1,85 @@
+# Show Queue v2 — auto-advance + queue (build plan)
+
+Branch `show-queue-v2` (fresh off `main`; the old `show-queue` branch is
+**abandoned**, not merged). Design spec: [`docs/adr/0010-playback-auto-advance-and-show-queue.md`](../docs/adr/0010-playback-auto-advance-and-show-queue.md).
+Roadmap: §1 in [`ROADMAP.md`](ROADMAP.md).
+
+## The shape (one paragraph)
+
+Auto-advance is an **independent coordinator** that listens for one positive
+event — **`onShowCompleted(showId)`**, "the final track played to its natural
+end" — and on it (optionally counts down, then) calls `playShow(next)`, which is
+an ordinary play. It reads **no** transport/Connect state, so there is no fight
+and no patch layer. To keep Connect from dragging the device back, the active
+device sends a **park** ("I'm done") command at completion so the server stops
+believing it's playing. The **queue is local-first** (works signed-out;
+authoritative locally) and **syncs as a whole-list snapshot** for signed-in
+users, like Favorites. The advance target is **queue head, else next show by
+date** (client-resolved — the server has no catalog).
+
+## Why this replaces the first attempt
+
+The abandoned `show-queue` branch made advancing a client decision that
+interrogated transport state and fought the server's `playing=true` (the
+"advance immediately / no countdown in Connect" patch, the guessed
+`isActiveDevice` gate, `isAutoAdvancing`, `hasBeenPlaying`). Root cause +
+corrected model are in ADR-0010 ("Why the first model was wrong"). **Do not
+reintroduce those patterns.** If you find yourself reading `playing` /
+`activeDeviceId` to decide whether to advance, stop — that's the old trap.
+
+## Build order — each chunk proven on iOS + Android + web before the next
+
+### Chunk 1 — reliable `onShowCompleted` on all three platforms
+The riskiest atom; prove it in isolation. **No advance, no park, no queue.**
+- Each platform's player adapter emits/logs `onShowCompleted(showId)` only on
+  natural end of the **last** track.
+- Verify on-device that it fires on natural show-end and does **NOT** fire on:
+  pause, user-stop, error/skip, transfer (Connect), or cold-start restored state.
+- Per-platform mapping:
+  - **Android (Media3):** `STATE_ENDED` + "played this session" guard.
+  - **iOS (AVQueuePlayer):** `AVPlayerItemDidPlayToEndTime` on the last item.
+  - **Web:** `ended` on the last track.
+- Proof = a log/toast. Web audio verified on beta / another machine (the
+  primary dev box may not output web audio — unverified note from a prior
+  session; confirm by testing).
+
+### Chunk 2 — chronological auto-advance + the park primitive
+On top of Chunk 1's signal. Still no queue.
+- Advance coordinator: `onShowCompleted` → (cancelable countdown) → `playShow`
+  of the **next show by date** (client-resolved from catalog).
+- Active device sends **park** at completion (first cut may reuse `stop`; add a
+  dedicated park action only if the ~1s remote "stopped" flicker bothers us).
+- **Verify the original bug is dead:** auto-advance works under a Connect session
+  on Android (and iOS/web) — countdown holds, no restart/drag-back, advances on
+  exactly the audio-producing device.
+- If "next" fails even on *immediate* advance, suspect a background-socket
+  gremlin (ADR-0007), not this logic.
+
+### Chunk 3 — local queue feeding the advance
+- Local `play_queue` store (Room / GRDB) + domain model. *(Salvageable from the
+  abandoned branch — re-introduce deliberately, not wholesale.)*
+- Surfaces: add-to-queue entry points, a view/reorder/remove list, tap-to-play.
+- Advance target becomes **queue head, else chronological**. Works signed-out.
+
+### Chunk 4 — whole-list snapshot sync (signed-in)
+- Debounced PUT of the full queue to the userdata layer
+  (`api/src/db/userdata`); last-writer-wins; first-pull on sign-in/foreground.
+- Refresh queue when a device becomes active (covers transfer-mid-queue).
+- Absorbs the old `show-queue-sync` project.
+
+### Settings cleanup (independent, anytime)
+The settings screen is overloaded — regroup and improve findability. Not
+coupled to the queue. Keep any end-of-show options here **minimal** until the
+core advance is proven (the first model over-built this matrix).
+
+## Salvage from the abandoned `show-queue` branch (reference, don't cargo-cult)
+Genuinely good, framework-level pieces (re-introduce in Chunk 3+):
+- `play_queue` table + DAO/entity (Room) and GRDB record/DAO + migration.
+- Domain model (`QueuedShow` / `QueuedShowItem`).
+- Add-to-queue UI entry points and the Favorites "Queue" segment list rows.
+Leave behind: the advance coordinator's transport-state interrogation, the
+Connect guards, the end-of-show settings matrix, the interrupt snackbar.
+
+## Status
+2026-06-10: **Design accepted (ADR-0010), branch created, no code yet.** Next:
+Chunk 1 — `onShowCompleted` detection across the three platforms.

--- a/PLANS/show-queue-v2.md
+++ b/PLANS/show-queue-v2.md
@@ -127,10 +127,21 @@ the existing `ConnectService.sendStop()`; next-show via on-device
 ### ✅ Phase B (cross-device countdown over Connect) COMPLETE + verified on all three.
 Server `pendingAdvance` + announce_next/cancel_advance/advance_now; each client
 emits + drives the countdown/advance off the shared note; Cancel & Play-now work
-from any device. Web has the fullscreen takeover; Android/iOS use a docked card.
-Also fixed: Android connect-follow now resolves the ticket cover (was logo).
-Remaining polish: **mobile fullscreen-takeover** (parity with web) and the
-**play/pause affordance** fixes.
+from any device. Also fixed: Android connect-follow now resolves the ticket cover
+(was logo).
+
+**Full-screen "Up Next" takeover — DONE on all three platforms (2026-06-11).**
+While the countdown runs and the player is open, the player is replaced by a
+preview of the next show (large cover, date/venue/location, "UP NEXT IN Ns",
+Play now / Cancel). Web = `HeaderPlayer` takeover; Android = `AutoAdvanceTakeover`
+(`e06e5841`); iOS = `AutoAdvanceTakeover` (`f2e4a59f`), both fed by the existing
+`AutoAdvanceCoordinator.countdown`, route-gated so the small docked card still
+shows everywhere outside the player. This also gives remotes a real "next show in
+Ns" view instead of the bare parked scrubber (the cosmetic item below).
+
+Remaining polish: the **play/pause affordance** fixes. Known intermittent bug
+(seen once, not reproduced): iOS advance lands on track 0 then a stray `next`
+jumps to "Track 2" — suspect onTrackComplete/reconnect race; needs a repro.
 
 **"When a show ends" ship gate — DONE on all three platforms.** Per-device
 opt-out gating whether THIS device initiates an advance; default ON. Android
@@ -140,14 +151,13 @@ opt-out gating whether THIS device initiates an advance; default ON. Android
 `onShowComplete`, toggle in `/me` SettingsTab). `feature_use` /
 `toggle_auto_advance` analytics on each.
 Remaining in Chunk 2 (UX/polish — mechanism is done):
-1. Cancelable countdown **overlay UI** (advances silently after 15s today).
-   - Also: during the countdown the active device is *parked*, so remotes render
-     a bare parked scrubber and disagree on its position (Android remote → 0;
-     iOS/web → held at end). Minor/cosmetic; likely resolved by giving remotes a
-     proper "next show in Ns" display instead of the parked state.
-2. The **"when a show ends" setting** (on/off, countdown/immediate) — needed
-   before shipping (auto-advance is hardcoded ON today).
-3. The **play/pause affordance fix** (iOS miniplayer icon + Android restore).
+1. ✅ Cancelable countdown **overlay UI** — DONE. Docked card + full-screen
+   "Up Next" takeover on all three platforms (see above). The parked-scrubber
+   disagreement on remotes is subsumed: a remote viewing the player now sees the
+   takeover's "UP NEXT IN Ns" instead of a bare parked scrubber.
+2. ✅ The **"when a show ends" setting** — DONE on all three (see ship gate above).
+3. The **play/pause affordance fix** (iOS miniplayer icon + Android restore) —
+   still open.
 
 ### Phase B: broadcast "next up" over Connect — full design + sequence diagrams in ADR-0010 §7
 One shared note `pendingAdvance: { showId, deadline }` on `ConnectState`

--- a/PLANS/show-queue-v2.md
+++ b/PLANS/show-queue-v2.md
@@ -134,16 +134,17 @@ Remaining in Chunk 2 (UX/polish — mechanism is done):
    before shipping (auto-advance is hardcoded ON today).
 3. The **play/pause affordance fix** (iOS miniplayer icon + Android restore).
 
-### Phase B (later): broadcast "next up" over Connect (display on remotes)
-Additive `pendingAdvance: { showId, deadline }` on `ConnectState`. The active
-device announces on countdown start; remotes **render only** (resolve art/info by
-showId locally/API; tick from `deadline − now` via existing `serverTimeOffsetMs`).
-**Asymmetry:** the announce is a one-way display hint, but **cancel is two-way
-control** — a remote's Cancel sends a command that clears `pendingAdvance`
-server-side; the **active device watches `pendingAdvance` and cancels its own
-timer when it's cleared** (same as reacting to a remote pause). Server clears it
-on load/stop. Build Phase A (local UI, below) so the countdown component can be
-fed by either the local coordinator OR an incoming `pendingAdvance`.
+### Phase B: broadcast "next up" over Connect — full design + sequence diagrams in ADR-0010 §7
+One shared note `pendingAdvance: { showId, deadline }` on `ConnectState`
+(additive). **Explicit commands** `announce_next` / `cancel_advance` /
+`advance_now` (no implicit nulling — that was rejected; see ADR §7 + Alternatives).
+Remotes tick locally to `deadline` via `serverTimeOffsetMs` (no per-second
+traffic) and resolve art/info by `showId`. Uniform rule for the playing device:
+**advance iff the note is present and `now ≥ deadline`** — so Cancel (note gone)
+and Play now (deadline=now) both fall out. Cancel **and Play now work from any
+device** (local + remote). Doing Phase B before porting mobile UI so the
+countdown UI is built ONCE per platform against a merged "local coordinator OR
+broadcast note" source.
 
 ### Known pre-existing bug to fix *during* Chunk 2 (not a Chunk 1 regression)
 iOS miniplayer play/pause icon **sometimes** sticks on "play" after

--- a/PLANS/show-queue-v2.md
+++ b/PLANS/show-queue-v2.md
@@ -124,6 +124,14 @@ the existing `ConnectService.sendStop()`; next-show via on-device
 `getNextShow(afterDate:)`.
 
 ### ✅ Advance mechanism COMPLETE + verified on all three platforms (incl. multi-client Connect).
+### ✅ Phase B (cross-device countdown over Connect) COMPLETE + verified on all three.
+Server `pendingAdvance` + announce_next/cancel_advance/advance_now; each client
+emits + drives the countdown/advance off the shared note; Cancel & Play-now work
+from any device. Web has the fullscreen takeover; Android/iOS use a docked card.
+Also fixed: Android connect-follow now resolves the ticket cover (was logo).
+Remaining polish: **mobile fullscreen-takeover** (parity with web), the
+**"when a show ends" setting** (advance is hardcoded ON — ship gate), and the
+**play/pause affordance** fixes.
 Remaining in Chunk 2 (UX/polish — mechanism is done):
 1. Cancelable countdown **overlay UI** (advances silently after 15s today).
    - Also: during the countdown the active device is *parked*, so remotes render

--- a/PLANS/show-queue-v2.md
+++ b/PLANS/show-queue-v2.md
@@ -101,9 +101,19 @@ web + Android; iOS verification in progress.**
 - **iOS ✓** — verified in Console.app (`PlaylistService` category): fires on
   natural end-of-show, silent on the negatives.
 
-**Chunk 1 COMPLETE on all three platforms.** Next: Chunk 2 — chronological
-auto-advance + the Connect "park" primitive (verify the original
-Android-under-Connect bug is dead).
+**Chunk 1 COMPLETE on all three platforms.**
+
+**Chunk 2 — Android DONE + device-verified (`1f5091a8`).** Chronological
+auto-advance works signed-out and signed-in; under Connect the park
+(`sendStop`) fires and the 15s countdown survives with **no drag-back/restart**
+— the original v1 bug is dead. Built as `playShow(show)` (canonical play entry
+in `core:playlist`: resolve recording/format/tracks → playAll + sendLoad) +
+`AutoAdvanceCoordinator` (app; subscribes to `showCompleted`, reads no transport
+state). Remaining in Chunk 2:
+1. Cancelable countdown **overlay UI** (Android advances silently after 15s today).
+2. **iOS + web parity** (lighter — both already consolidate play+Connect).
+3. The **"when a show ends" setting** (on/off, countdown/immediate).
+4. The **play/pause affordance fix** (iOS miniplayer icon + Android restore).
 
 ### Known pre-existing bug to fix *during* Chunk 2 (not a Chunk 1 regression)
 iOS miniplayer play/pause icon **sometimes** sticks on "play" after

--- a/PLANS/show-queue-v2.md
+++ b/PLANS/show-queue-v2.md
@@ -109,9 +109,21 @@ auto-advance works signed-out and signed-in; under Connect the park
 — the original v1 bug is dead. Built as `playShow(show)` (canonical play entry
 in `core:playlist`: resolve recording/format/tracks → playAll + sendLoad) +
 `AutoAdvanceCoordinator` (app; subscribes to `showCompleted`, reads no transport
-state). Remaining in Chunk 2:
-1. Cancelable countdown **overlay UI** (Android advances silently after 15s today).
-2. **iOS + web parity** (lighter — both already consolidate play+Connect).
+state).
+
+**Chunk 2 — Web DONE + verified on localhost (`a78511be`).** `ended` → park
+(`sendCommand "stop"`) → 15s → `playShow(next)`; remotes followed. Next show
+resolved via new **`GET /api/shows/:id/next`** + `getNextShow()` in
+`api/src/showCatalog.ts` (the browser has no catalog — shows are static SSG and
+the search index lacks recording ids).
+
+Remaining in Chunk 2:
+1. Cancelable countdown **overlay UI** (advances silently after 15s today).
+   - Also: during the countdown the active device is *parked*, so remotes render
+     a bare parked scrubber and disagree on its position (Android remote → 0;
+     iOS/web → held at end). Minor/cosmetic; likely resolved by giving remotes a
+     proper "next show in Ns" display instead of the parked state.
+2. **iOS parity** (last platform; already consolidates play+Connect).
 3. The **"when a show ends" setting** (on/off, countdown/immediate).
 4. The **play/pause affordance fix** (iOS miniplayer icon + Android restore).
 

--- a/androidApp/app/build.gradle.kts
+++ b/androidApp/app/build.gradle.kts
@@ -167,6 +167,7 @@ dependencies {
     implementation(project(":core:notifications"))
     implementation(project(":core:model"))
     implementation(project(":core:domain"))
+    implementation(project(":core:api:playlist"))
     implementation(project(":core:api:auth"))
     implementation(project(":core:auth"))
     implementation(project(":core:api:favorites"))

--- a/androidApp/app/src/main/java/com/grateful/deadly/AppViewModel.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/AppViewModel.kt
@@ -10,6 +10,7 @@ import com.grateful.deadly.core.domain.repository.ShowRepository
 import com.grateful.deadly.core.miniplayer.LastPlayedTrackService
 import com.grateful.deadly.core.model.Show
 import com.grateful.deadly.core.network.monitor.NetworkMonitor
+import com.grateful.deadly.playback.AutoAdvanceCoordinator
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -26,8 +27,15 @@ class AppViewModel @Inject constructor(
     private val lastPlayedTrackService: LastPlayedTrackService,
     private val showRepository: ShowRepository,
     private val favoritesService: FavoritesService,
-    private val appReviewManager: AppReviewManager
+    private val appReviewManager: AppReviewManager,
+    private val autoAdvanceCoordinator: AutoAdvanceCoordinator,
 ) : ViewModel() {
+
+    // ADR-0010: end-of-show countdown UI (active device or remote).
+    val autoAdvanceCountdown: StateFlow<AutoAdvanceCoordinator.Countdown?> =
+        autoAdvanceCoordinator.countdown
+    fun cancelAutoAdvance() = autoAdvanceCoordinator.cancel()
+    fun playNextNow() = autoAdvanceCoordinator.playNow()
 
     val isOffline: StateFlow<Boolean> = combine(
         networkMonitor.isOnline,

--- a/androidApp/app/src/main/java/com/grateful/deadly/MainActivity.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/MainActivity.kt
@@ -18,6 +18,7 @@ import androidx.core.view.WindowCompat
 import com.grateful.deadly.core.connect.ConnectService
 import com.grateful.deadly.core.database.AnalyticsService
 import com.grateful.deadly.core.media.repository.MediaControllerRepository
+import com.grateful.deadly.playback.AutoAdvanceCoordinator
 import com.grateful.deadly.theme.DeadlyMaterialTheme
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -28,6 +29,7 @@ class MainActivity : ComponentActivity() {
     @Inject lateinit var analyticsService: AnalyticsService
     @Inject lateinit var mediaControllerRepository: MediaControllerRepository
     @Inject lateinit var connectService: ConnectService
+    @Inject lateinit var autoAdvanceCoordinator: AutoAdvanceCoordinator
 
     private var deepLinkUri by mutableStateOf<Uri?>(null)
 
@@ -37,6 +39,9 @@ class MainActivity : ComponentActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
         analyticsService.track("app_open")
+
+        // ADR-0010 Chunk 2: drive chronological auto-advance off the end-of-show signal.
+        autoAdvanceCoordinator.start()
 
         deepLinkUri = intent?.data
 

--- a/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
@@ -34,6 +34,7 @@ import com.grateful.deadly.navigation.NavigationBarConfig
 import com.grateful.deadly.core.design.component.ShowArtwork
 import com.grateful.deadly.core.design.resources.IconResources
 import com.grateful.deadly.core.design.scaffold.AppScaffold
+import com.grateful.deadly.playback.AutoAdvanceOverlay
 import com.grateful.deadly.core.model.Show
 import com.grateful.deadly.feature.home.navigation.homeGraph
 import com.grateful.deadly.notifications.NotificationBell
@@ -277,6 +278,8 @@ fun MainNavigation(
         snackbarHostState = snackbarHostState
     ) { paddingValues ->
         Box(modifier = Modifier.fillMaxSize()) {
+            val autoAdvanceCountdown by appViewModel.autoAdvanceCountdown.collectAsState()
+
             NavHost(
                 navController = navController,
                 startDestination = "splash",
@@ -331,6 +334,20 @@ fun MainNavigation(
                 exit = slideOutVertically(targetOffsetY = { it }) + fadeOut()
             ) {
                 OfflineBanner()
+            }
+
+            // ADR-0010: end-of-show "Next up in Ns" countdown — docked above the
+            // mini player; shown on the active device and remotes alike.
+            autoAdvanceCountdown?.let { countdown ->
+                AutoAdvanceOverlay(
+                    countdown = countdown,
+                    onPlayNow = { appViewModel.playNextNow() },
+                    onCancel = { appViewModel.cancelAutoAdvance() },
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(horizontal = 8.dp)
+                        .padding(bottom = paddingValues.calculateBottomPadding() + 8.dp),
+                )
             }
         }
     }

--- a/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
@@ -35,6 +35,7 @@ import com.grateful.deadly.core.design.component.ShowArtwork
 import com.grateful.deadly.core.design.resources.IconResources
 import com.grateful.deadly.core.design.scaffold.AppScaffold
 import com.grateful.deadly.playback.AutoAdvanceOverlay
+import com.grateful.deadly.playback.AutoAdvanceTakeover
 import com.grateful.deadly.core.model.Show
 import com.grateful.deadly.feature.home.navigation.homeGraph
 import com.grateful.deadly.notifications.NotificationBell
@@ -52,6 +53,7 @@ import com.grateful.deadly.feature.search.navigation.searchGraph
 import com.grateful.deadly.feature.playlist.navigation.playlistGraph
 import com.grateful.deadly.feature.playlist.navigation.navigateToPlaylist
 import com.grateful.deadly.feature.player.navigation.playerScreen
+import com.grateful.deadly.feature.player.navigation.PLAYER_ROUTE
 import com.grateful.deadly.feature.miniplayer.screens.main.MiniPlayerScreen
 import com.grateful.deadly.feature.favorites.navigation.favoritesNavigation
 import com.grateful.deadly.feature.collections.navigation.collectionsGraph
@@ -336,18 +338,30 @@ fun MainNavigation(
                 OfflineBanner()
             }
 
-            // ADR-0010: end-of-show "Next up in Ns" countdown — docked above the
-            // mini player; shown on the active device and remotes alike.
+            // ADR-0010: end-of-show "Next up in Ns" countdown — shown on the
+            // active device and remotes alike. On the open player screen it's a
+            // full-screen "Up Next" takeover previewing the next show (parity
+            // with web's HeaderPlayer); everywhere else it's a docked card above
+            // the mini player.
             autoAdvanceCountdown?.let { countdown ->
-                AutoAdvanceOverlay(
-                    countdown = countdown,
-                    onPlayNow = { appViewModel.playNextNow() },
-                    onCancel = { appViewModel.cancelAutoAdvance() },
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(horizontal = 8.dp)
-                        .padding(bottom = paddingValues.calculateBottomPadding() + 8.dp),
-                )
+                if (currentRoute == PLAYER_ROUTE) {
+                    AutoAdvanceTakeover(
+                        countdown = countdown,
+                        onPlayNow = { appViewModel.playNextNow() },
+                        onCancel = { appViewModel.cancelAutoAdvance() },
+                        modifier = Modifier.align(Alignment.Center),
+                    )
+                } else {
+                    AutoAdvanceOverlay(
+                        countdown = countdown,
+                        onPlayNow = { appViewModel.playNextNow() },
+                        onCancel = { appViewModel.cancelAutoAdvance() },
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(horizontal = 8.dp)
+                            .padding(bottom = paddingValues.calculateBottomPadding() + 8.dp),
+                    )
+                }
             }
         }
     }

--- a/androidApp/app/src/main/java/com/grateful/deadly/playback/AutoAdvanceCoordinator.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/playback/AutoAdvanceCoordinator.kt
@@ -1,0 +1,118 @@
+package com.grateful.deadly.playback
+
+import android.util.Log
+import com.grateful.deadly.core.api.playlist.PlaylistService
+import com.grateful.deadly.core.connect.ConnectService
+import com.grateful.deadly.core.domain.repository.ShowRepository
+import com.grateful.deadly.core.media.repository.MediaControllerRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * ADR-0010 Chunk 2 — chronological auto-advance.
+ *
+ * An independent coordinator whose ONLY input is
+ * [MediaControllerRepository.showCompleted] (the positive end-of-show signal
+ * from Chunk 1). It reads NO transport/Connect state to decide *whether* or
+ * *what* to advance — that interrogation was the v1 whack-a-mole. Gating is
+ * intrinsic: only the audio-producing device fires `showCompleted`, so only it
+ * advances; a remote-controlling device never reaches end-of-show locally.
+ *
+ * On end-of-show:
+ *   1. **Park** — tell Connect we're done ([ConnectService.sendStop]) so the
+ *      server stops believing we're playing and can't drag the device back
+ *      during the countdown (the structural fix for the v1 "advance immediately,
+ *      no countdown in Connect" workaround).
+ *   2. **Cancelable countdown.**
+ *   3. **Advance** — [PlaylistService.playShow] of the next chronological show,
+ *      whose output is byte-identical to a user tap (local audio + sendLoad).
+ *
+ * Its only interaction with transport is that final play — input-decoupled,
+ * output-normal.
+ */
+@Singleton
+class AutoAdvanceCoordinator @Inject constructor(
+    private val media: MediaControllerRepository,
+    private val showRepository: ShowRepository,
+    private val playlistService: PlaylistService,
+    private val connectService: ConnectService,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    data class Countdown(val secondsRemaining: Int, val nextShowLabel: String?)
+
+    private val _countdown = MutableStateFlow<Countdown?>(null)
+    /** Drives the cancelable "next show in Ns" overlay; null when idle. */
+    val countdown: StateFlow<Countdown?> = _countdown.asStateFlow()
+
+    private var advanceJob: Job? = null
+    private var started = false
+
+    /** Called once at app launch (MainActivity). */
+    fun start() {
+        if (started) return
+        started = true
+        scope.launch {
+            media.showCompleted.collect { completedShowId ->
+                onShowCompleted(completedShowId)
+            }
+        }
+    }
+
+    /** User canceled the pending advance. */
+    fun cancel() {
+        Log.d(TAG, "auto-advance: canceled by user")
+        advanceJob?.cancel()
+        advanceJob = null
+        _countdown.value = null
+    }
+
+    private fun onShowCompleted(completedShowId: String) {
+        Log.d(TAG, "auto-advance: show completed = $completedShowId")
+        advanceJob?.cancel()
+        advanceJob = scope.launch {
+            // 1. Park: tell Connect we're done so the server stops believing we're
+            //    playing and can't drag us back during the countdown. Sent
+            //    unconditionally — it's a no-op (dropped) when not in a session,
+            //    and `connectState` is an unreliable "am I connected" signal
+            //    (it can be null mid-session). Only the audio-producing (active)
+            //    device reaches here, so a stop is always the right thing to send.
+            Log.d(TAG, "auto-advance: parking Connect (sendStop)")
+            connectService.sendStop()
+
+            // 2. Resolve the next chronological show.
+            val completed = showRepository.getShowById(completedShowId)
+            val next = completed?.let { showRepository.getNextShowByDate(it.date) }
+            if (next == null) {
+                Log.d(TAG, "auto-advance: no next show after $completedShowId — stopping")
+                _countdown.value = null
+                return@launch
+            }
+
+            // 3. Cancelable countdown (server is parked, so no drag-back).
+            for (remaining in COUNTDOWN_SECONDS downTo 1) {
+                _countdown.value = Countdown(remaining, next.displayTitle)
+                delay(1000)
+            }
+            _countdown.value = null
+
+            // 4. Advance — identical to a user tap on the next show.
+            Log.d(TAG, "auto-advance: advancing to ${next.displayTitle}")
+            playlistService.playShow(next, autoPlay = true)
+        }
+    }
+
+    companion object {
+        private const val TAG = "AutoAdvanceCoordinator"
+        private const val COUNTDOWN_SECONDS = 15
+    }
+}

--- a/androidApp/app/src/main/java/com/grateful/deadly/playback/AutoAdvanceCoordinator.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/playback/AutoAdvanceCoordinator.kt
@@ -3,6 +3,7 @@ package com.grateful.deadly.playback
 import android.util.Log
 import com.grateful.deadly.core.api.playlist.PlaylistService
 import com.grateful.deadly.core.connect.ConnectService
+import com.grateful.deadly.core.database.AppPreferences
 import com.grateful.deadly.core.domain.repository.ShowRepository
 import com.grateful.deadly.core.media.repository.MediaControllerRepository
 import com.grateful.deadly.core.model.Show
@@ -42,6 +43,7 @@ class AutoAdvanceCoordinator @Inject constructor(
     private val showRepository: ShowRepository,
     private val playlistService: PlaylistService,
     private val connectService: ConnectService,
+    private val appPreferences: AppPreferences,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
@@ -121,6 +123,10 @@ class AutoAdvanceCoordinator @Inject constructor(
 
     private fun onShowCompleted(completedShowId: String) {
         Log.d(TAG, "auto-advance: show completed = $completedShowId")
+        if (!appPreferences.autoAdvanceEnabled.value) {
+            Log.d(TAG, "auto-advance: disabled by preference — not advancing")
+            return
+        }
         localJob?.cancel()
         localJob = scope.launch {
             val completed = showRepository.getShowById(completedShowId)

--- a/androidApp/app/src/main/java/com/grateful/deadly/playback/AutoAdvanceCoordinator.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/playback/AutoAdvanceCoordinator.kt
@@ -5,6 +5,7 @@ import com.grateful.deadly.core.api.playlist.PlaylistService
 import com.grateful.deadly.core.connect.ConnectService
 import com.grateful.deadly.core.domain.repository.ShowRepository
 import com.grateful.deadly.core.media.repository.MediaControllerRepository
+import com.grateful.deadly.core.model.Show
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -13,31 +14,27 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlin.math.ceil
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * ADR-0010 Chunk 2 — chronological auto-advance.
+ * ADR-0010 Chunk 2 + §7 — chronological auto-advance, cross-device.
  *
- * An independent coordinator whose ONLY input is
- * [MediaControllerRepository.showCompleted] (the positive end-of-show signal
- * from Chunk 1). It reads NO transport/Connect state to decide *whether* or
- * *what* to advance — that interrogation was the v1 whack-a-mole. Gating is
- * intrinsic: only the audio-producing device fires `showCompleted`, so only it
- * advances; a remote-controlling device never reaches end-of-show locally.
+ * Driven by [MediaControllerRepository.showCompleted] (the Chunk 1 end-of-show
+ * signal). It reads no transport state to *decide* whether to advance.
  *
- * On end-of-show:
- *   1. **Park** — tell Connect we're done ([ConnectService.sendStop]) so the
- *      server stops believing we're playing and can't drag the device back
- *      during the countdown (the structural fix for the v1 "advance immediately,
- *      no countdown in Connect" workaround).
- *   2. **Cancelable countdown.**
- *   3. **Advance** — [PlaylistService.playShow] of the next chronological show,
- *      whose output is byte-identical to a user tap (local audio + sendLoad).
- *
- * Its only interaction with transport is that final play — input-decoupled,
- * output-normal.
+ * In a Connect session it `announce`s the next show + a server-time deadline; the
+ * shared `pendingAdvance` note then drives the countdown UI **and** the advance
+ * on every device (this coordinator's note-collector). Offline it runs a purely
+ * local countdown. The active device advances when the note is present and the
+ * deadline passes; its [PlaylistService.playShow] load clears the note for all.
+ * Cancel / Play now work from any device (commands when remote; act directly
+ * when active/offline).
  */
 @Singleton
 class AutoAdvanceCoordinator @Inject constructor(
@@ -48,65 +45,107 @@ class AutoAdvanceCoordinator @Inject constructor(
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
-    data class Countdown(val secondsRemaining: Int, val nextShowLabel: String?)
+    data class Countdown(val secondsRemaining: Int, val nextShow: Show)
 
     private val _countdown = MutableStateFlow<Countdown?>(null)
-    /** Drives the cancelable "next show in Ns" overlay; null when idle. */
+    /** Drives the "Next up in Ns" UI; null when idle. */
     val countdown: StateFlow<Countdown?> = _countdown.asStateFlow()
 
-    private var advanceJob: Job? = null
+    private var localJob: Job? = null
     private var started = false
 
     /** Called once at app launch (MainActivity). */
     fun start() {
         if (started) return
         started = true
+
+        // End-of-show → announce (in a session) or run a local countdown.
         scope.launch {
-            media.showCompleted.collect { completedShowId ->
-                onShowCompleted(completedShowId)
-            }
+            media.showCompleted.collect { completedShowId -> onShowCompleted(completedShowId) }
+        }
+
+        // The shared note drives the countdown + advance when connected. Keyed on
+        // the note alone (distinctUntilChanged), so position broadcasts don't
+        // restart the ticker; collectLatest restarts it when the note changes
+        // (e.g. advance_now moves the deadline).
+        scope.launch {
+            connectService.connectState
+                .map { it?.pendingAdvance }
+                .distinctUntilChanged()
+                .collectLatest { note ->
+                    if (!connectService.isConnected.value) return@collectLatest // offline: local job owns it
+                    if (note == null) {
+                        _countdown.value = null
+                        return@collectLatest
+                    }
+                    val show = showRepository.getShowById(note.showId) ?: return@collectLatest
+                    while (true) {
+                        val serverNow = System.currentTimeMillis() + connectService.serverTimeOffsetMs.value
+                        val remaining = ceil((note.deadline - serverNow) / 1000.0).toInt()
+                        if (remaining <= 0) {
+                            _countdown.value = null
+                            if (connectService.isActiveDevice.value) {
+                                Log.d(TAG, "auto-advance: advancing to ${show.displayTitle}")
+                                playlistService.playShow(show, autoPlay = true) // load clears the note
+                            }
+                            break
+                        }
+                        _countdown.value = Countdown(remaining, show)
+                        delay(1000)
+                    }
+                }
         }
     }
 
-    /** User canceled the pending advance. */
+    /** Cancel the pending advance. */
     fun cancel() {
-        Log.d(TAG, "auto-advance: canceled by user")
-        advanceJob?.cancel()
-        advanceJob = null
+        Log.d(TAG, "auto-advance: cancel")
+        localJob?.cancel()
+        localJob = null
         _countdown.value = null
+        if (connectService.isConnected.value) connectService.sendCancelAdvance()
+    }
+
+    /** Skip the countdown ("Play now"). */
+    fun playNow() {
+        val show = _countdown.value?.nextShow ?: return
+        if (connectService.isConnected.value && !connectService.isActiveDevice.value) {
+            connectService.sendAdvanceNow()
+            return
+        }
+        localJob?.cancel()
+        localJob = null
+        _countdown.value = null
+        scope.launch { playlistService.playShow(show, autoPlay = true) }
     }
 
     private fun onShowCompleted(completedShowId: String) {
         Log.d(TAG, "auto-advance: show completed = $completedShowId")
-        advanceJob?.cancel()
-        advanceJob = scope.launch {
-            // 1. Park: tell Connect we're done so the server stops believing we're
-            //    playing and can't drag us back during the countdown. Sent
-            //    unconditionally — it's a no-op (dropped) when not in a session,
-            //    and `connectState` is an unreliable "am I connected" signal
-            //    (it can be null mid-session). Only the audio-producing (active)
-            //    device reaches here, so a stop is always the right thing to send.
-            Log.d(TAG, "auto-advance: parking Connect (sendStop)")
-            connectService.sendStop()
-
-            // 2. Resolve the next chronological show.
+        localJob?.cancel()
+        localJob = scope.launch {
             val completed = showRepository.getShowById(completedShowId)
             val next = completed?.let { showRepository.getNextShowByDate(it.date) }
             if (next == null) {
-                Log.d(TAG, "auto-advance: no next show after $completedShowId — stopping")
+                Log.d(TAG, "auto-advance: no next show after $completedShowId")
                 _countdown.value = null
                 return@launch
             }
 
-            // 3. Cancelable countdown (server is parked, so no drag-back).
+            if (connectService.isConnected.value) {
+                // In a session: announce; the note-collector above drives the rest.
+                val deadline = (System.currentTimeMillis() +
+                    connectService.serverTimeOffsetMs.value +
+                    COUNTDOWN_SECONDS * 1000L).toDouble()
+                connectService.sendAnnounceNext(next.id, deadline)
+                return@launch
+            }
+
+            // Offline: local-only countdown, then advance.
             for (remaining in COUNTDOWN_SECONDS downTo 1) {
-                _countdown.value = Countdown(remaining, next.displayTitle)
+                _countdown.value = Countdown(remaining, next)
                 delay(1000)
             }
             _countdown.value = null
-
-            // 4. Advance — identical to a user tap on the next show.
-            Log.d(TAG, "auto-advance: advancing to ${next.displayTitle}")
             playlistService.playShow(next, autoPlay = true)
         }
     }

--- a/androidApp/app/src/main/java/com/grateful/deadly/playback/AutoAdvanceOverlay.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/playback/AutoAdvanceOverlay.kt
@@ -1,0 +1,84 @@
+package com.grateful.deadly.playback
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.grateful.deadly.core.design.component.ShowArtwork
+
+/**
+ * ADR-0010 — end-of-show "Next up in Ns" announcement card. Shows the next show's
+ * cover + details while the countdown runs, with Play now / Cancel. Rendered as a
+ * docked card (active device or remote — fed by [AutoAdvanceCoordinator.countdown]).
+ */
+@Composable
+fun AutoAdvanceOverlay(
+    countdown: AutoAdvanceCoordinator.Countdown,
+    onPlayNow: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val show = countdown.nextShow
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = RoundedCornerShape(12.dp),
+        tonalElevation = 6.dp,
+        shadowElevation = 6.dp,
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            ShowArtwork(
+                recordingId = show.bestRecordingId,
+                imageUrl = show.coverImageUrl,
+                contentDescription = show.date,
+                modifier = Modifier.size(48.dp),
+            )
+            Spacer(Modifier.width(12.dp))
+            androidx.compose.foundation.layout.Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Next up in ${countdown.secondsRemaining}s",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    text = show.date,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = show.venue.name,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Spacer(Modifier.width(8.dp))
+            Button(onClick = onPlayNow, contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 14.dp, vertical = 6.dp)) {
+                Text("Play now", style = MaterialTheme.typography.labelLarge)
+            }
+            Spacer(Modifier.width(4.dp))
+            OutlinedButton(onClick = onCancel, contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 12.dp, vertical = 6.dp)) {
+                Text("Cancel", style = MaterialTheme.typography.labelLarge)
+            }
+        }
+    }
+}

--- a/androidApp/app/src/main/java/com/grateful/deadly/playback/AutoAdvanceTakeover.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/playback/AutoAdvanceTakeover.kt
@@ -1,0 +1,125 @@
+package com.grateful.deadly.playback
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.grateful.deadly.core.design.component.ShowArtwork
+
+/**
+ * ADR-0010 — end-of-show "Up Next" takeover. The full-player counterpart to the
+ * docked [AutoAdvanceOverlay]: while the countdown runs and the player screen is
+ * open, the whole player is replaced by a preview of the NEXT show — the same
+ * large cover-art / date / venue layout as the now-playing player, under an
+ * "Up Next in Ns" header, with Play now / Cancel. Mirrors web's HeaderPlayer
+ * takeover ([ui/.../HeaderPlayer.tsx]). Fed by [AutoAdvanceCoordinator.Countdown].
+ */
+@Composable
+fun AutoAdvanceTakeover(
+    countdown: AutoAdvanceCoordinator.Countdown,
+    onPlayNow: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val show = countdown.nextShow
+    Surface(
+        modifier = modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            // "Up Next in Ns" header — the countdown the user is watching tick.
+            Text(
+                text = "UP NEXT IN ${countdown.secondsRemaining}s",
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = 2.sp,
+                color = MaterialTheme.colorScheme.primary,
+            )
+
+            Spacer(Modifier.height(24.dp))
+
+            // Large cover art of the next show — same prominence as the player's.
+            ShowArtwork(
+                recordingId = show.bestRecordingId,
+                imageUrl = show.coverImageUrl,
+                contentDescription = show.date,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(360.dp),
+            )
+
+            Spacer(Modifier.height(24.dp))
+
+            // Next show date / venue / location.
+            Text(
+                text = show.date,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (show.venue.name.isNotBlank()) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = show.venue.name,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            if (show.location.displayText.isNotBlank()) {
+                Text(
+                    text = show.location.displayText,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                    textAlign = TextAlign.Center,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            Spacer(Modifier.height(32.dp))
+
+            // Actions in the transport's place: start now, or stay on this show.
+            Button(
+                onClick = onPlayNow,
+                contentPadding = PaddingValues(horizontal = 32.dp, vertical = 12.dp),
+            ) {
+                Text("Play now", style = MaterialTheme.typography.labelLarge)
+            }
+            Spacer(Modifier.height(12.dp))
+            OutlinedButton(
+                onClick = onCancel,
+                contentPadding = PaddingValues(horizontal = 24.dp, vertical = 10.dp),
+            ) {
+                Text("Cancel", style = MaterialTheme.typography.labelLarge)
+            }
+        }
+    }
+}

--- a/androidApp/core/api/playlist/src/main/java/com/grateful/deadly/core/api/playlist/PlaylistService.kt
+++ b/androidApp/core/api/playlist/src/main/java/com/grateful/deadly/core/api/playlist/PlaylistService.kt
@@ -48,6 +48,17 @@ interface PlaylistService {
     suspend fun playTrack(trackIndex: Int)
     
     /**
+     * Play an arbitrary show from scratch — the canonical "play a show" entry.
+     *
+     * Resolves the show's preferred/best recording, loads its tracks, picks the
+     * best available format, starts local playback, and tells Connect (sendLoad)
+     * — i.e. exactly what a user tap on a show does. Auto-advance (ADR-0010) and
+     * any "play from a list" surface route through this so they can't diverge
+     * from real playback.
+     */
+    suspend fun playShow(show: Show, autoPlay: Boolean = true)
+
+    /**
      * Navigate to the next show chronologically
      */
     suspend fun navigateToNextShow()

--- a/androidApp/core/connect/build.gradle.kts
+++ b/androidApp/core/connect/build.gradle.kts
@@ -39,6 +39,7 @@ android {
 dependencies {
     implementation(project(":core:model"))
     implementation(project(":core:database"))
+    implementation(project(":core:domain"))
     implementation(project(":core:api:auth"))
     implementation(project(":core:media"))
     implementation(project(":core:network"))

--- a/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectService.kt
+++ b/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectService.kt
@@ -29,6 +29,12 @@ interface ConnectService {
     fun handleNetworkRestored()
 
     fun sendStop()
+
+    // ADR-0010 §7: cross-device end-of-show countdown.
+    fun sendAnnounceNext(showId: String, deadline: Double)
+    fun sendCancelAdvance()
+    fun sendAdvanceNow()
+
     fun sendTransfer(targetDeviceId: String)
     fun sendPosition(positionMs: Int)
 

--- a/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
+++ b/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
@@ -646,8 +646,17 @@ class ConnectServiceImpl @Inject constructor(
 
         // When this device just became active (e.g. transfer in), sync local player
         // to server state — the local player may be at a completely different track/position.
+        //
+        // BUT skip the transport sync when a pendingAdvance note is present: here we
+        // "became active" only because we announced our OWN end-of-show (the server
+        // claims the announcer active, ADR-0011). We are parked at the end of the
+        // show waiting for the note-collector to advance — we know our position
+        // better than the server, whose positionMs is the stale pre-end value. Without
+        // this guard we seek back to that stale position and resume, replaying the
+        // tail, which re-fires onShowCompleted and re-announces (resetting the
+        // countdown). The note-collector owns the transition from here.
         val justBecameActive = !wasActive && nowActive
-        if (justBecameActive) {
+        if (justBecameActive && new.pendingAdvance == null) {
             val currentVolume = mediaControllerRepository.getVolume()
             _activeDeviceVolume.value = currentVolume
             sendVolumeReport(currentVolume)

--- a/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
+++ b/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
@@ -725,6 +725,21 @@ class ConnectServiceImpl @Inject constructor(
         sendCommand("stop")
     }
 
+    override fun sendAnnounceNext(showId: String, deadline: Double) {
+        Log.d(TAG, "sendAnnounceNext: $showId @ $deadline")
+        sendCommand("announce_next", mapOf("showId" to showId, "deadline" to deadline))
+    }
+
+    override fun sendCancelAdvance() {
+        Log.d(TAG, "sendCancelAdvance")
+        sendCommand("cancel_advance")
+    }
+
+    override fun sendAdvanceNow() {
+        Log.d(TAG, "sendAdvanceNow")
+        sendCommand("advance_now")
+    }
+
     override fun sendLoad(
         showId: String,
         recordingId: String,

--- a/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
+++ b/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
@@ -49,6 +49,7 @@ class ConnectServiceImpl @Inject constructor(
     private val authService: AuthService,
     private val mediaControllerRepository: MediaControllerRepository,
     private val networkMonitor: NetworkMonitor,
+    private val showRepository: com.grateful.deadly.core.domain.repository.ShowRepository,
 ) : ConnectService {
 
     companion object {
@@ -569,6 +570,11 @@ class ConnectServiceImpl @Inject constructor(
         // Non-active device: load paused so the player shows the shared show.
         if (new.recordingId != null && new.recordingId != localRecordingId) {
             val autoPlay = isActive && new.playing
+            // ConnectState is transport-only (no ticket image). Resolve the show's
+            // cover from the local catalog so a follower's now-playing/mini player
+            // shows the ticket art instead of the Archive-thumbnail fallback.
+            val coverImageUrl = new.showId
+                ?.let { runCatching { showRepository.getShowById(it)?.coverImageUrl }.getOrNull() }
             Log.d(TAG, "reactToState: NEW RECORDING — server=${new.recordingId} local=$localRecordingId " +
                 "isActive=$isActive autoPlay=$autoPlay trackIndex=${new.trackIndex} positionMs=${new.positionMs}")
             mediaControllerRepository.playTrack(
@@ -579,6 +585,7 @@ class ConnectServiceImpl @Inject constructor(
                 showDate = new.date ?: "",
                 venue = new.venue,
                 location = new.location,
+                coverImageUrl = coverImageUrl,
                 position = new.positionMs.toLong(),
                 autoPlay = autoPlay,
             )

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
@@ -39,6 +39,7 @@ class AppPreferences @Inject constructor(
         private const val KEY_EQ_PRESET = "eq_preset"
         private const val KEY_EQ_BAND_LEVELS = "eq_band_levels"
         private const val KEY_SHARE_ATTACH_IMAGE = "share_attach_image"
+        private const val KEY_AUTO_ADVANCE_ENABLED = "auto_advance_enabled"
         private const val KEY_SOURCE_BADGE_STYLE = "source_badge_style"
         private const val KEY_USE_BETA_SHARE_LINKS = "use_beta_share_links"
         private const val KEY_USE_BETA_MODE = "use_beta_mode"
@@ -105,6 +106,18 @@ class AppPreferences @Inject constructor(
         setHomePopularEnabled(true)
         setHomePopularCardSize("small")
         setHomePopularDecade("all")
+    }
+
+    private val _autoAdvanceEnabled = MutableStateFlow(
+        prefs.getBoolean(KEY_AUTO_ADVANCE_ENABLED, true)
+    )
+
+    /** ADR-0010: roll into the next show when one ends. On by default. */
+    val autoAdvanceEnabled: StateFlow<Boolean> = _autoAdvanceEnabled.asStateFlow()
+
+    fun setAutoAdvanceEnabled(value: Boolean) {
+        prefs.edit().putBoolean(KEY_AUTO_ADVANCE_ENABLED, value).apply()
+        _autoAdvanceEnabled.value = value
     }
 
     private val _homePopularEnabled = MutableStateFlow(

--- a/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/repository/MediaControllerRepository.kt
+++ b/androidApp/core/media/src/main/java/com/grateful/deadly/core/media/repository/MediaControllerRepository.kt
@@ -124,6 +124,24 @@ class MediaControllerRepository @Inject constructor(
     private val _trackAutoAdvanced = MutableSharedFlow<Int>(extraBufferCapacity = 1)
     val trackAutoAdvanced: SharedFlow<Int> = _trackAutoAdvanced.asSharedFlow()
 
+    // ADR-0010 Chunk 1: the show-completion signal for auto-advance. Emits the
+    // showId of the show that just finished — and *only* on natural end of the
+    // last track. This is the positive "final track played to its natural end"
+    // event, NOT a generic "playback stopped": ExoPlayer reaches STATE_ENDED only
+    // after running off the end of the media-item list (user-stop is STATE_IDLE,
+    // pause stays STATE_READY, errors go through onPlayerError). The
+    // `hasPlayedThisSession` guard suppresses the cold-start / restored-ENDED case
+    // (a session restored into ENDED must not fire). Disambiguation lives here, in
+    // the player adapter, so the advance coordinator can subscribe to one clean
+    // event and read no transport state.
+    private val _showCompleted = MutableSharedFlow<String>(extraBufferCapacity = 1)
+    val showCompleted: SharedFlow<String> = _showCompleted.asSharedFlow()
+
+    // True once real playback has occurred since the last completion/load. Set on
+    // the first onIsPlayingChanged(true); cleared when we emit showCompleted so a
+    // single end-of-show fires exactly once.
+    @Volatile private var hasPlayedThisSession: Boolean = false
+
     // Analytics: tracks the currently playing item for playback_end
     private var analyticsPlaybackInfo: Triple<String, String, Int>? = null // showId, recordingId, trackNumber
 
@@ -524,6 +542,10 @@ class MediaControllerRepository @Inject constructor(
                         override fun onIsPlayingChanged(isPlaying: Boolean) {
                             if (isPlaying) {
                                 Log.d(TAG, "🕒🎵 [AUDIO] MediaController detected AUDIO STARTED at ${System.currentTimeMillis()}")
+                                // ADR-0010 Chunk 1: real playback has occurred, so a
+                                // subsequent STATE_ENDED is a genuine end-of-show (not a
+                                // cold-start restored ENDED).
+                                hasPlayedThisSession = true
                                 // If no playback_start has been emitted for the current item
                                 // (restore loaded items with playWhenReady=false), emit now
                                 // that playback has actually begun.
@@ -620,6 +642,25 @@ class MediaControllerRepository @Inject constructor(
 
                             currentExoPlayerState = playbackState
                             updatePlaybackState()
+
+                            // ADR-0010 Chunk 1: emit onShowCompleted on the natural end
+                            // of the last track. STATE_ENDED is reached only after the
+                            // media-item list runs off the end; the session guard rejects
+                            // a restored-into-ENDED cold start; the prevState check makes
+                            // it fire exactly once.
+                            if (playbackState == Player.STATE_ENDED &&
+                                prevState != Player.STATE_ENDED &&
+                                hasPlayedThisSession
+                            ) {
+                                hasPlayedThisSession = false
+                                val completedShowId = controller.currentMediaItem
+                                    ?.let { extractShowIdFromMediaItem(it) }
+                                    ?: _currentShowId.value
+                                if (completedShowId != null) {
+                                    Log.d(TAG, "🏁 [SHOW-COMPLETE] onShowCompleted(showId=$completedShowId)")
+                                    _showCompleted.tryEmit(completedShowId)
+                                }
+                            }
 
                             // Stall detection: only count BUFFERING as a stall if we were
                             // already READY (i.e. mid-playback rebuffer). Initial load

--- a/androidApp/core/model/src/main/java/com/grateful/deadly/core/model/ConnectModels.kt
+++ b/androidApp/core/model/src/main/java/com/grateful/deadly/core/model/ConnectModels.kt
@@ -15,6 +15,15 @@ data class ConnectSessionTrack(
     val durationMs: Int,
 )
 
+// ADR-0010 §7: shared end-of-show countdown. deadline is an absolute server
+// timestamp (ms); Double for the same reason as positionTs — the server may
+// send a fractional value and an Int/Long parse would drop the whole state.
+@Serializable
+data class PendingAdvance(
+    val showId: String,
+    val deadline: Double,
+)
+
 @Serializable
 data class ConnectState(
     // Long, not Int: the server seeds version from wall-clock ms (Date.now())
@@ -38,4 +47,6 @@ data class ConnectState(
     val date: String? = null,
     val venue: String? = null,
     val location: String? = null,
+    // ADR-0010 §7: shared end-of-show countdown. Optional/additive.
+    val pendingAdvance: PendingAdvance? = null,
 )

--- a/androidApp/core/playlist/build.gradle.kts
+++ b/androidApp/core/playlist/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation(project(":core:network:archive"))
     implementation(project(":core:media"))
     implementation(project(":core:player"))
+    implementation(project(":core:connect"))
 
     // Hilt
     implementation("com.google.dagger:hilt-android:2.56.1")

--- a/androidApp/core/playlist/src/main/java/com/grateful/deadly/core/playlist/service/PlaylistServiceImpl.kt
+++ b/androidApp/core/playlist/src/main/java/com/grateful/deadly/core/playlist/service/PlaylistServiceImpl.kt
@@ -9,6 +9,7 @@ import com.grateful.deadly.core.model.*
 import com.grateful.deadly.core.network.archive.service.ArchiveService
 import com.grateful.deadly.core.media.download.MediaDownloadManager
 import com.grateful.deadly.core.network.monitor.NetworkMonitor
+import com.grateful.deadly.core.connect.ConnectService
 import com.grateful.deadly.core.media.repository.MediaControllerRepository
 import com.grateful.deadly.core.media.state.MediaControllerStateUtil
 import com.grateful.deadly.core.player.service.ShareService
@@ -46,6 +47,7 @@ class PlaylistServiceImpl @Inject constructor(
     private val archiveService: ArchiveService,
     private val mediaControllerRepository: MediaControllerRepository,
     private val mediaControllerStateUtil: MediaControllerStateUtil,
+    private val connectService: ConnectService,
     private val shareService: ShareService,
     private val collectionsService: DeadCollectionsService,
     private val favoritesService: FavoritesService,
@@ -129,6 +131,69 @@ class PlaylistServiceImpl @Inject constructor(
 
     override fun getCurrentShowLineup(): List<String> {
         return currentShow?.lineup?.members?.map { it.name } ?: emptyList()
+    }
+
+    override suspend fun playShow(show: Show, autoPlay: Boolean) {
+        // Resolve the recording: user's preferred for this show, else the best.
+        val recordingId = favoritesService.getPreferredRecordingId(show.id) ?: show.bestRecordingId
+        if (recordingId.isNullOrBlank()) {
+            Log.w(TAG, "playShow: no recording for show ${show.id}")
+            return
+        }
+
+        // Resolve tracks + format from scratch (this is the "arbitrary show" path,
+        // unlike the playlist screen which plays already-loaded state).
+        val rawTracks = archiveService.getRecordingTracks(recordingId).getOrNull().orEmpty()
+        if (rawTracks.isEmpty()) {
+            Log.w(TAG, "playShow: no tracks for recording $recordingId")
+            return
+        }
+        val format = selectBestAvailableFormat(rawTracks)
+        if (format == null) {
+            Log.w(TAG, "playShow: no playable format for recording $recordingId")
+            return
+        }
+        val formatTracks = filterTracksToFormat(rawTracks, format)
+
+        // Keep service pointers consistent so chronological nav continues correctly.
+        currentShow = show
+        currentRecordingId = recordingId
+        currentSelectedFormat = format
+
+        Log.d(TAG, "playShow: ${show.displayTitle} rec=$recordingId fmt=$format autoPlay=$autoPlay")
+
+        // Local audio — identical to the UI's Play All.
+        mediaControllerRepository.playAll(
+            recordingId = recordingId,
+            format = format,
+            showId = show.id,
+            showDate = show.date,
+            venue = show.venue.name,
+            location = show.location.displayText,
+            coverImageUrl = show.coverImageUrl,
+            autoPlay = autoPlay,
+            source = "auto_advance",
+        )
+
+        // Tell Connect so other devices follow — identical to the UI's sendLoad.
+        val sessionTracks = formatTracks.map { t ->
+            ConnectSessionTrack(
+                title = t.title ?: t.name,
+                durationMs = parseDurationToMs(t.duration).toInt(),
+            )
+        }
+        connectService.sendLoad(
+            showId = show.id,
+            recordingId = recordingId,
+            tracks = sessionTracks,
+            trackIndex = 0,
+            positionMs = 0,
+            durationMs = sessionTracks.firstOrNull()?.durationMs ?: 0,
+            date = show.date,
+            venue = show.venue.name,
+            location = show.location.displayText,
+            autoplay = autoPlay,
+        )
     }
 
     override suspend fun navigateToNextShow() {
@@ -832,6 +897,22 @@ class PlaylistServiceImpl @Inject constructor(
      */
     private fun filterTracksToFormat(tracks: List<Track>, selectedFormat: String): List<Track> {
         return tracks.filter { it.format.equals(selectedFormat, ignoreCase = true) }
+    }
+
+    /** Parse "mm:ss" / "hh:mm:ss" track duration into milliseconds (0 if unknown). */
+    private fun parseDurationToMs(durationString: String?): Long {
+        if (durationString.isNullOrBlank()) return 0L
+        return try {
+            val parts = durationString.split(":").map { it.trim().toLong() }
+            when (parts.size) {
+                2 -> (parts[0] * 60 + parts[1]) * 1000
+                3 -> (parts[0] * 3600 + parts[1] * 60 + parts[2]) * 1000
+                1 -> parts[0] * 1000
+                else -> 0L
+            }
+        } catch (e: NumberFormatException) {
+            0L
+        }
     }
     
     /**

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
@@ -34,6 +34,7 @@ fun SettingsScreen(
     onNavigateToConnect: () -> Unit = {}
 ) {
     val context = LocalContext.current
+    val autoAdvanceEnabled by viewModel.autoAdvanceEnabled.collectAsState()
     val includeShowsWithoutRecordings by viewModel.includeShowsWithoutRecordings.collectAsState()
     val sourceBadgeStyle by viewModel.sourceBadgeStyle.collectAsState()
     val playerControlsStyle by viewModel.playerControlsStyle.collectAsState()
@@ -122,6 +123,20 @@ fun SettingsScreen(
                     }
                 }
             }
+        }
+
+        item { HorizontalDivider() }
+
+        // ── PLAYBACK ─────────────────────────────────────────────────
+        item { SectionHeader("Playback") }
+
+        item {
+            PreferenceToggleRow(
+                title = "When a show ends",
+                subtitle = "Roll into the next show automatically, after a 15-second countdown you can cancel.",
+                checked = autoAdvanceEnabled,
+                onCheckedChange = { viewModel.toggleAutoAdvanceEnabled() }
+            )
         }
 
         item { HorizontalDivider() }

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
@@ -58,6 +58,18 @@ class SettingsViewModel @Inject constructor(
     private val _migrationImportState = MutableStateFlow<MigrationImportState>(MigrationImportState.Idle)
     val migrationImportState: StateFlow<MigrationImportState> = _migrationImportState
 
+    val autoAdvanceEnabled: StateFlow<Boolean> = appPreferences.autoAdvanceEnabled
+
+    fun toggleAutoAdvanceEnabled() {
+        val newValue = !appPreferences.autoAdvanceEnabled.value
+        appPreferences.setAutoAdvanceEnabled(newValue)
+        analyticsService.track("feature_use", mapOf(
+            "feature" to "toggle_auto_advance",
+            "category" to "playback",
+            "enabled" to newValue,
+        ))
+    }
+
     val includeShowsWithoutRecordings: StateFlow<Boolean> = appPreferences.includeShowsWithoutRecordings
 
     fun toggleIncludeShowsWithoutRecordings() {

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -14,6 +14,7 @@ import { connectRoutes } from "./connect/routes.js";
 import { analyticsRoutes } from "./routes/analytics.js";
 import { trendingRoutes } from "./routes/trending.js";
 import { popularRoutes } from "./routes/popular.js";
+import { showRoutes } from "./routes/shows.js";
 import { betaRoutes } from "./routes/beta.js";
 import { notificationRoutes } from "./routes/notifications.js";
 import { devTokenRoutes } from "./auth/dev-token.js";
@@ -68,6 +69,7 @@ export function buildApp() {
   app.register(analyticsRoutes);
   app.register(trendingRoutes);
   app.register(popularRoutes);
+  app.register(showRoutes);
   app.register(betaRoutes);
   app.register(notificationRoutes);
 

--- a/api/src/connect/routes.ts
+++ b/api/src/connect/routes.ts
@@ -13,6 +13,9 @@ import {
   handleTransfer,
   handlePosition,
   handleStop,
+  handleAnnounceNext,
+  handleCancelAdvance,
+  handleAdvanceNow,
   handleVolume,
   handleVolumeReport,
   startHeartbeatSweep,
@@ -112,6 +115,20 @@ export async function connectRoutes(app: FastifyInstance): Promise<void> {
             }
             case "stop": {
               handleStop(userId!);
+              break;
+            }
+            case "announce_next": {
+              const { showId, deadline } = msg as Record<string, unknown>;
+              if (typeof showId !== "string" || typeof deadline !== "number") return;
+              handleAnnounceNext(userId!, registeredDeviceId, { showId, deadline });
+              break;
+            }
+            case "cancel_advance": {
+              handleCancelAdvance(userId!);
+              break;
+            }
+            case "advance_now": {
+              handleAdvanceNow(userId!);
               break;
             }
             case "seek": {

--- a/api/src/connect/state.ts
+++ b/api/src/connect/state.ts
@@ -78,6 +78,7 @@ function initialState(): ConnectState {
     date: null,
     venue: null,
     location: null,
+    pendingAdvance: null,
   };
 }
 
@@ -307,6 +308,8 @@ export function handleLoad(userId: string, deviceId: string, socket: WebSocket, 
     date: params.date ?? null,
     venue: params.venue ?? null,
     location: params.location ?? null,
+    // A new show loading supersedes any pending end-of-show countdown.
+    pendingAdvance: null,
   };
 
   if (params.autoplay) {
@@ -409,6 +412,50 @@ export function handleStop(userId: string): void {
     activeDeviceType: null,
     positionMs,
     positionTs: now,
+    pendingAdvance: null,
+  });
+}
+
+// ── ADR-0010 §7: end-of-show countdown (cross-device) ────────────────────────
+
+/**
+ * The active device finished a show and is counting down to [showId] at
+ * [deadline]. Parks playback (so it isn't dragged back) and sets the shared
+ * note every device renders. Only the active device announces its own end.
+ */
+export function handleAnnounceNext(
+  userId: string,
+  deviceId: string,
+  params: { showId: string; deadline: number },
+): void {
+  const state = userStates.get(userId);
+  if (!state) return;
+  if (state.activeDeviceId && state.activeDeviceId !== deviceId) return;
+  log(`handleAnnounceNext: next=${params.showId} deadline=${params.deadline}`);
+  mutate(userId, {
+    playing: false,
+    pendingAdvance: { showId: params.showId, deadline: params.deadline },
+  });
+}
+
+/** Anyone cancels the pending advance — clears the note; stays parked. */
+export function handleCancelAdvance(userId: string): void {
+  const state = userStates.get(userId);
+  if (!state || !state.pendingAdvance) return;
+  log(`handleCancelAdvance: clearing pendingAdvance`);
+  mutate(userId, { pendingAdvance: null });
+}
+
+/**
+ * "Play now" from anywhere — move the deadline to now so the active device's
+ * uniform rule (advance when present && now >= deadline) fires immediately.
+ */
+export function handleAdvanceNow(userId: string): void {
+  const state = userStates.get(userId);
+  if (!state || !state.pendingAdvance) return;
+  log(`handleAdvanceNow: deadline -> now for ${state.pendingAdvance.showId}`);
+  mutate(userId, {
+    pendingAdvance: { showId: state.pendingAdvance.showId, deadline: Date.now() },
   });
 }
 

--- a/api/src/connect/state.ts
+++ b/api/src/connect/state.ts
@@ -222,6 +222,8 @@ export function unregisterDevice(userId: string, deviceId: string): void {
       activeDeviceName: null,
       activeDeviceType: null,
       playing: false,
+      // The device that would have advanced is gone — drop the countdown note.
+      pendingAdvance: null,
     });
   }
 
@@ -265,6 +267,7 @@ export function startHeartbeatSweep(): void {
           activeDeviceName: null,
           activeDeviceType: null,
           playing: false,
+          pendingAdvance: null,
         });
       }
       // Cancel pending transfer if evicted device was the target

--- a/api/src/connect/state.ts
+++ b/api/src/connect/state.ts
@@ -435,10 +435,28 @@ export function handleAnnounceNext(
   if (!state) return;
   if (state.activeDeviceId && state.activeDeviceId !== deviceId) return;
   log(`handleAnnounceNext: next=${params.showId} deadline=${params.deadline}`);
-  mutate(userId, {
+
+  const patch: Partial<ConnectState> = {
     playing: false,
     pendingAdvance: { showId: params.showId, deadline: params.deadline },
-  });
+  };
+
+  // The announcing device just finished playing locally, so it IS the active
+  // device — even if the server lost that (e.g. in-memory state wiped on a
+  // restart while the device kept playing across the reconnect, leaving it a
+  // connected-but-not-active ghost). Claim it here like handlePlay/handleLoad
+  // do; otherwise the note broadcasts but no device counts as active, so nobody
+  // fires the advance at the deadline and the countdown dies silently.
+  if (!state.activeDeviceId) {
+    const entry = liveDevices.get(deviceKey(userId, deviceId));
+    if (entry) {
+      patch.activeDeviceId = deviceId;
+      patch.activeDeviceName = entry.device.name;
+      patch.activeDeviceType = entry.device.type;
+    }
+  }
+
+  mutate(userId, patch);
 }
 
 /** Anyone cancels the pending advance — clears the note; stays parked. */

--- a/api/src/connect/types.ts
+++ b/api/src/connect/types.ts
@@ -27,6 +27,13 @@ export interface ConnectState {
   date: string | null;
   venue: string | null;
   location: string | null;
+
+  // ADR-0010 §7: end-of-show countdown shared across the session. Set by the
+  // active device's `announce_next`; cleared on load/stop/cancel. `deadline` is
+  // an absolute server timestamp (ms) — every device ticks down to it locally,
+  // and the active device advances when it's still set and `now >= deadline`.
+  // Additive/optional (ADR-0006 §8): older clients ignore it.
+  pendingAdvance?: { showId: string; deadline: number } | null;
 }
 
 export interface ConnectDevice {

--- a/api/src/routes/shows.ts
+++ b/api/src/routes/shows.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance } from "fastify";
-import { getNextShow } from "../showCatalog.js";
+import { getNextShow, getShowMeta } from "../showCatalog.js";
 
 // Minimal show-catalog read endpoints. The web client has no catalog of its own
 // (shows are static SSG; the browser only has a search index without recording
@@ -21,5 +21,23 @@ export async function showRoutes(app: FastifyInstance): Promise<void> {
     const next = getNextShow(request.params.id);
     if (!next) return reply.code(404).send({ error: "no next show" });
     return reply.send({ showId: next.showId, ...next.meta });
+  });
+
+  // Resolve a single show's display metadata by id — used by remotes to render
+  // the cross-device countdown (the broadcast note carries only showId).
+  app.get<{ Params: { id: string } }>("/api/shows/:id", {
+    schema: {
+      tags: ["shows"],
+      summary: "Show metadata by id",
+      params: {
+        type: "object",
+        properties: { id: { type: "string" } },
+        required: ["id"],
+      },
+    },
+  }, async (request, reply) => {
+    const meta = getShowMeta(request.params.id);
+    if (!meta) return reply.code(404).send({ error: "show not found" });
+    return reply.send({ showId: request.params.id, ...meta });
   });
 }

--- a/api/src/routes/shows.ts
+++ b/api/src/routes/shows.ts
@@ -1,0 +1,25 @@
+import type { FastifyInstance } from "fastify";
+import { getNextShow } from "../showCatalog.js";
+
+// Minimal show-catalog read endpoints. The web client has no catalog of its own
+// (shows are static SSG; the browser only has a search index without recording
+// ids), so it asks the API — which holds the catalog in memory — for the next
+// show to play. Backs web auto-advance (ADR-0010 chunk 2).
+export async function showRoutes(app: FastifyInstance): Promise<void> {
+  app.get<{ Params: { id: string } }>("/api/shows/:id/next", {
+    schema: {
+      tags: ["shows"],
+      summary: "Next chronological show",
+      description: "Returns the show immediately after the given show id by date, for auto-advance.",
+      params: {
+        type: "object",
+        properties: { id: { type: "string" } },
+        required: ["id"],
+      },
+    },
+  }, async (request, reply) => {
+    const next = getNextShow(request.params.id);
+    if (!next) return reply.code(404).send({ error: "no next show" });
+    return reply.send({ showId: next.showId, ...next.meta });
+  });
+}

--- a/api/src/showCatalog.ts
+++ b/api/src/showCatalog.ts
@@ -22,6 +22,7 @@ export interface ShowMeta {
 }
 
 let catalog = new Map<string, ShowMeta>();
+let sortedIds: string[] | null = null;
 let loaded = false;
 
 function defaultIndexPath(): string {
@@ -44,6 +45,7 @@ export function loadShowCatalog(filePath: string = defaultIndexPath()): number {
   } catch {
     catalog = new Map();
   }
+  sortedIds = null;
   loaded = true;
   return catalog.size;
 }
@@ -51,4 +53,26 @@ export function loadShowCatalog(filePath: string = defaultIndexPath()): number {
 export function getShowMeta(showId: string): ShowMeta | null {
   if (!loaded) loadShowCatalog();
   return catalog.get(showId) ?? null;
+}
+
+// Show ids sort chronologically (the "YYYY-MM-DD-…" prefix), matching the
+// catalog's own ordering. Cached lazily; invalidated on (re)load.
+function getSortedIds(): string[] {
+  if (!loaded) loadShowCatalog();
+  if (!sortedIds) sortedIds = Array.from(catalog.keys()).sort();
+  return sortedIds;
+}
+
+/**
+ * The next show chronologically after [afterShowId], or null if it's the last
+ * (or unknown). Backs web auto-advance (ADR-0010): the browser has no catalog,
+ * so it asks the API — which already holds it — for the next show to play.
+ */
+export function getNextShow(afterShowId: string): { showId: string; meta: ShowMeta } | null {
+  const ids = getSortedIds();
+  const idx = ids.indexOf(afterShowId);
+  if (idx < 0 || idx >= ids.length - 1) return null;
+  const showId = ids[idx + 1];
+  const meta = catalog.get(showId);
+  return meta ? { showId, meta } : null;
 }

--- a/docs/adr/0010-playback-auto-advance-and-show-queue.md
+++ b/docs/adr/0010-playback-auto-advance-and-show-queue.md
@@ -1,0 +1,191 @@
+# ADR-0010: Playback auto-advance + show queue (local-first, transport-decoupled)
+
+## Status
+
+Accepted (2026-06-10). Implementation on `show-queue-v2`, built and verified
+chunk-by-chunk across iOS, Android, and web simultaneously.
+
+**Supersedes an earlier, abandoned design** (the `show-queue` branch, never
+merged). That branch shipped the queue and auto-advance as one entangled change
+and accreted a layer of patches around Connect — the "advance immediately, no
+countdown, because the server keeps dragging us back" workaround, a client-
+guessed `isActiveDevice` gate, an `isAutoAdvancing` suppression flag, and a
+cold-start `hasBeenPlaying` guard. Those patches were the symptom; the root
+cause is recorded under "Why the first model was wrong" below. This ADR records
+the corrected model.
+
+Related: [ADR-0006](0006-connect-v2.md) (Connect-v2, server is transport SoT),
+[ADR-0007](0007-connect-background-socket-lifecycle.md) (background socket
+lifecycle), [ADR-0008](0008-connect-cloud-coordination-deferred.md) (durable
+server-side session state deferred).
+
+## Context
+
+The community's top ask (ROADMAP §1) is a playback queue + autoplay. Two facts
+shape the design:
+
+1. **Connect-v2 makes the server the single source of truth for transport.**
+   Clients send commands; the server owns `playing` / `activeDeviceId` / position
+   and broadcasts a full snapshot (ADR-0006). The server is deliberately
+   **transport-only and has no catalog** — display metadata and "what's next" are
+   client-resolved (Amendments #1, #4); a server-side track cache was built and
+   reverted.
+2. **There is no per-show resume.** A single global `last_played_track` exists
+   only for app-relaunch restoration; shows otherwise start from the beginning.
+
+### Why the first model was wrong
+
+Auto-advance is a **transport transition** — "stop playing A, start playing B."
+In Connect-v2, transport is the server's job. The abandoned design made advancing
+a **client decision executed locally while interrogating transport state**: the
+client decided there was a next show, guessed whether it was the device that
+should act, and tried to drive a paused countdown — while the server still
+believed A was `playing` and broadcast that, dragging the device back. The two
+authorities fought. Every patch on that branch was a concession to the fight.
+A single-source-of-truth model cannot tolerate a second, local authority over the
+same state; the exceptions become whack-a-mole.
+
+## Decision
+
+### 1. The advance signal is "the final track completed," never "playback stopped"
+
+"Playback stopped" is ambiguous — it conflates end-of-show with user-stop, pause,
+error, transfer-park, and the cold-start restored-state case. The signal is
+instead **positive and specific**: the *last track of the current show reached
+its natural end of content*. Stop/pause/error/transfer do not produce it; a
+cold-start restore does not produce it (no track completed in this session). So
+we never disambiguate a generic stop — we never listen for one.
+
+Disambiguation lives **inside each platform's player adapter** and each emits the
+same semantic event:
+
+> **`onShowCompleted(showId)`** — fired only when the final track of `showId`
+> reaches natural end-of-content.
+
+Per-platform mapping:
+- **Android (Media3/ExoPlayer):** `STATE_ENDED` (reached only after running off
+  the end of the media-item list; user-stop is `STATE_IDLE`, pause stays `READY`)
+  **+ a "played in this session" guard** for the cold-start restored-ENDED case.
+- **iOS (AVQueuePlayer):** `AVPlayerItemDidPlayToEndTime` on the **last** item
+  (not a mid-show item).
+- **Web (HTML5 audio):** the `ended` event on the **last** track.
+
+### 2. Auto-advance is an independent coordinator that reads no transport state
+
+The advance coordinator subscribes to `onShowCompleted` and **nothing else**. It
+does not read `playing` / `activeDeviceId` / "are we parked" to decide anything —
+that interrogation *was* the bug. On the event it (optionally) runs a cancelable
+countdown, then calls `playShow(next)`.
+
+- **Input-decoupled:** decided purely from the completion event + the queue +
+  the timer.
+- **Output-normal:** its only interaction with transport is the final
+  `playShow(next)` — byte-for-byte identical to a user tapping a show. The server
+  cannot tell an auto-advance from a manual play, and does not need to.
+
+Gating falls out for free: **only the device producing audio reaches
+`onShowCompleted`.** A remote-control device isn't playing the show locally, so
+its player never completes — no `isActiveDevice` guess required.
+
+### 3. Connect gains one informational primitive: "I'm done" / park
+
+When a show completes, the active device sends a new **park** command so the
+server stops believing it is `playing` (transitions to parked / `playing=false`).
+This is what kills the v1 fight: once the server is out of `playing=true`, the
+device can hold a countdown and advance without being dragged back.
+
+- Park is a **transport fact**, not a command to the local player — at
+  end-of-show the audio has already stopped on its own. It informs Connect; it
+  drives nothing.
+- Park carries **no queue state and no catalog data.** The server gains no
+  knowledge of the queue and makes no advance decision (consistent with
+  ADR-0006: server owns transport, clients resolve shows).
+- The wire change is **additive** (ADR-0006 §8): a new optional command old
+  clients ignore. First implementation may reuse the existing `stop` command if
+  the ~1s "stopped" flicker on remote devices is acceptable; a dedicated park
+  action that holds device ownership is the seamless upgrade if it isn't.
+
+### 4. The queue is local-first; the server is a synced mirror, never an authority
+
+**You can build a queue without an account, so the queue must live locally.**
+Connect-v2 is per-user — no account means no Connect session, so a signed-out
+user is always single-device and never has the fight or a transfer.
+
+- The **local queue is authoritative** for every operation; the advance logic
+  reads the local copy. Works fully signed-out.
+- For **signed-in** users the queue **syncs as a whole-list snapshot** (debounced
+  PUT, last-writer-wins) through the existing userdata layer
+  (`api/src/db/userdata`), exactly like Favorites and playback position. A
+  dropped or out-of-order snapshot just means the next one wins; a per-op delta
+  log would need ordering/conflict guarantees the tiny list doesn't justify.
+- Sync makes the queue **travel** with the user; it is **not** on the advance
+  critical path. The transfer-mid-queue edge (active device moves, queue must
+  follow) is covered because each signed-in device holds a synced copy; staleness
+  at the moment of transfer is handled by refreshing the queue when a device
+  becomes active.
+
+This places the server-side queue firmly in **durable user data** (no push, no
+live-session coordination), so it is compatible with ADR-0008's deferral of
+durable *session* state — it is the "server-mostly easy half" that ADR named.
+
+### 5. Advance target resolution
+
+The advance coordinator computes the next show as: **queue head if present, else
+the next show chronologically** (later date), resolved client-side from the
+catalog. The server never resolves a show — it has no catalog. Chronological
+auto-advance is therefore just "advance with an empty queue."
+
+### 6. Build order: prove each piece on all three platforms before the next
+
+Built chunk-by-chunk; each chunk is one capability, contract-defined once,
+implemented **and verified on iOS, Android, and web** before the next. (Web audio
+is verified on beta / another machine, not the primary dev box.) This is the
+deliberate antidote to the first model's "one big change, many small problems."
+
+## Consequences
+
+**Gained:**
+- No second authority over transport, so no fight and no patch layer. The advance
+  is a pure function of a specific event; its output is an ordinary play.
+- End-of-show is detected by a specific positive event, eliminating the whole
+  class of "stopped-for-the-wrong-reason" false advances.
+- The queue works signed-out (local-first) and travels signed-in (snapshot sync),
+  absorbing what was the separate `show-queue-sync` project — at no critical-path
+  cost.
+- One wire addition (park), additive and small.
+
+**Accepted / given up:**
+- **Parallel per-platform implementations** kept at contract parity by
+  discipline (no KMM shared module). The shared contract is the `onShowCompleted`
+  event, the park command, and the snapshot sync shape.
+- **Reuse-`stop`-for-park** may flicker remote devices through a "stopped" state
+  for ~1s before the next show loads, until/unless a dedicated park action lands.
+- **Resume-on-interrupt and the end-of-show settings matrix are deferred**, not
+  designed here — the first model over-built settings. Revisit minimally once the
+  core advance + queue are proven.
+- **Sync staleness at transfer** is best-effort (refresh-on-active), consistent
+  with userdata being focus/foreground-refresh rather than realtime.
+
+## Alternatives considered
+
+**Server-authoritative queue + server-arbitrated advance** (server owns the
+ordered list and directs the active device to advance). Rejected: it fails the
+no-account case (no server identity → no queue), pulls forward durable
+server-side state that ADR-0008 deferred, and is unnecessary — once advance is
+input-decoupled (Decision #2) and park kills the fight (Decision #3), the server
+does not need to decide or store anything for advance to be correct. The local-
+first mirror (Decision #4) gets cross-device for free without making the server
+an authority.
+
+**Key advance off a generic "playback stopped" signal.** Rejected (Decision #1):
+ambiguous on every platform; it is the source of the cold-start and
+stopped-for-the-wrong-reason false advances.
+
+**Client-side advance that interrogates transport state to self-gate** (the
+abandoned model). Rejected: that interrogation is the whack-a-mole; the
+audio-producing device is intrinsically the only one that completes a show, so no
+self-gate is needed.
+
+**Per-op delta sync (outbox) for the queue.** Rejected in favor of whole-list
+snapshot (Decision #4): the list is tiny and reorder/remove/pop deltas need
+ordering and conflict resolution that a snapshot makes moot.

--- a/docs/adr/0010-playback-auto-advance-and-show-queue.md
+++ b/docs/adr/0010-playback-auto-advance-and-show-queue.md
@@ -142,6 +142,88 @@ implemented **and verified on iOS, Android, and web** before the next. (Web audi
 is verified on beta / another machine, not the primary dev box.) This is the
 deliberate antidote to the first model's "one big change, many small problems."
 
+### 7. Cross-device countdown over Connect (one shared note + explicit commands)
+
+The end-of-show countdown is shown on **every** device in the session and can be
+controlled from any of them — but the device producing audio stays solely
+responsible for actually starting the next show. The mechanism is **one shared
+piece of server state**, not per-second messaging:
+
+- **Server state:** an additive, optional `pendingAdvance: { showId, deadline } | null`
+  on `ConnectState` (the "note"). `deadline` is an absolute **server timestamp**.
+  Additive-only per ADR-0006 §8; old clients ignore it.
+- **Explicit commands** (no implicit inference — mirrors ADR-0006's `epoch`
+  lesson that explicit beats inferred):
+  - `announce_next { showId, deadline }` → server **sets** the note.
+  - `cancel_advance` → server **clears** the note.
+  - `advance_now` → server sets the note's **`deadline = now`** ("Play now").
+- **Remotes count down locally.** Each device renders the note and computes
+  `remaining = deadline − serverNow` using the existing clock sync
+  (`serverTimeOffsetMs`), ticking on its own. The `announce` is the *only*
+  message; there is **no per-second traffic**. Remotes resolve the show's
+  art/info from `showId` themselves (consistent with Amendment #1).
+- **One uniform rule for the playing device:** *advance when the note is present
+  and `now ≥ deadline`.* So Cancel (note cleared → not present at the deadline →
+  no advance) and Play now (deadline moved to now → advance immediately) both
+  fall out of the same rule. The decision is an **explicit presence check at the
+  deadline**, never an inference from a transition. Offline / no session: the
+  device falls back to a plain local timer (no note exists).
+- **Self-clearing:** the active device's own `load` on advance clears the note
+  server-side; an explicit `cancel_advance` clears it on cancel.
+
+This is **Phase B** (the local, active-device-only countdown is Phase A). It is
+designed so the per-platform countdown UI reads a single merged source —
+*local coordinator countdown OR the broadcast note* — and is therefore built
+**once** per platform rather than retrofitted.
+
+#### Sequence: normal end-of-show advance
+
+```
+ Active device (playing)        Server                Remote(s)
+        |                         |                       |
+   show ends                      |                       |
+        |---- announce_next X,T -->|                      |
+        |                     SET note {X,T}              |
+        |<------- state ----------|------- state -------->|
+   show "Next up Ns"                          show "Next up Ns"
+        |        (every device ticks down to T locally)   |
+   now >= T, note present -> play X                        |
+        |---- load X ------------>|                       |
+        |                    CLEAR note                   |
+        |<------- state ----------|------- state -------->|
+   now playing X                              hide countdown, follow X
+```
+
+#### Sequence: Cancel (from any device)
+
+```
+ Active device (playing)        Server                Remote
+        |                         |<--- cancel_advance ---|   (Cancel tapped on remote)
+        |                     CLEAR note                  |
+        |<------- state ----------|------- state -------->|
+   note no longer present:                     hide countdown
+   at the deadline it won't advance;
+   (and hides its countdown now)
+```
+
+#### Sequence: Play now (from any device)
+
+```
+ Active device (playing)        Server                Remote
+        |                         |<--- advance_now ------|   (Play now tapped on remote)
+        |                  SET note.deadline = now        |
+        |<------- state ----------|------- state -------->|
+   now >= deadline, note present -> play X                |
+        |---- load X ------------>|                       |
+        |                    CLEAR note                   |
+        |<------- state ----------|------- state -------->|
+   now playing X                              follow X
+```
+
+Local Cancel / Play now are the trivial cases — the active device acts directly
+*and* sends the matching command so the shared note (and every remote) stays in
+sync.
+
 ## Consequences
 
 **Gained:**
@@ -180,6 +262,15 @@ an authority.
 **Key advance off a generic "playback stopped" signal.** Rejected (Decision #1):
 ambiguous on every platform; it is the source of the cold-start and
 stopped-for-the-wrong-reason false advances.
+
+**Infer "cancelled" implicitly from the note becoming null** (the active device
+watches `pendingAdvance` go set→null). Rejected (Decision #7): it has a race —
+between sending `announce` and the server echoing it back, the note still reads
+null, so a naive "null ⇒ cancel" would cancel the device's own pending advance.
+Worse, it repeats the exact implicit-inference mistake ADR-0006 fixed with the
+explicit `epoch`. Replaced by an **explicit `cancel_advance` command** plus an
+**explicit presence check at the deadline** ("advance only if the note is still
+there"), which is race-free and unambiguous.
 
 **Client-side advance that interrogates transport state to self-gate** (the
 abandoned model). Rejected: that interrogation is the whack-a-mole; the

--- a/docs/adr/0011-connect-session-ownership-and-protocol-versioning.md
+++ b/docs/adr/0011-connect-session-ownership-and-protocol-versioning.md
@@ -1,0 +1,218 @@
+# ADR-0011: Connect — session ownership as a renewable lease + WS protocol versioning
+
+## Status
+
+Proposed (2026-06-11). Design agreed; not yet implemented. Extends
+[ADR-0006](0006-connect-v2.md) (server is the transport source of truth),
+[ADR-0007](0007-connect-background-socket-lifecycle.md) (socket tied to
+playback/process), and [ADR-0008](0008-connect-cloud-coordination-deferred.md)
+(durable cloud state deferred, gated on social). Touches the active-device path
+introduced in [ADR-0010 §7](0010-playback-auto-advance-and-show-queue.md)
+(cross-device end-of-show countdown), which is where the failure below first bit.
+
+This ADR **does not un-defer ADR-0008.** Session state stays in-memory. What
+changes is *how a still-connected device recovers ownership* — replacing a stack
+of cause-specific detectors with one convergent mechanism.
+
+## Context
+
+ADR-0006 made Connect session state (`userStates`: `showId`, position,
+`playing`, `activeDeviceId`) **in-memory and authoritative on the server**, with
+recovery defined as "recoverable from the still-connected active device." That
+recovery has, in practice, accreted into a pile of **cause-specific heuristics on
+the client**, all answering one question — *"the server forgot I'm the active
+device; how do I prove it again?"*:
+
+- `serverRestarted = lastEpoch != null && epoch changed` → reclaim (Android
+  `ConnectServiceImpl`), mirrored on iOS/web.
+- `new.tracks.isEmpty() && cachedTracks` → re-assert the load.
+- `reassertingTracks` one-shot guard so position broadcasts don't re-fire it.
+
+### The failure that motivated this
+
+Diagnosed 2026-06-11 from device + server logs. A phone playing a show **through a
+server restart** never auto-advanced at end-of-show. Chain:
+
+1. The API (single in-memory instance) restarted; `userStates` was wiped.
+2. The phone's WS reconnected and re-registered ~1s later. The server rehydrated
+   `showId`/position from the persisted playback row, but **not** `activeDeviceId`
+   / `playing` — so the session came back as `playing=false, activeDevice=null`.
+3. The phone kept producing audio across the reconnect (the audio engine doesn't
+   care about the socket) and never re-sent `play` (no new intent), so the server
+   never re-learned the phone was active. `seek`/`position` don't claim active.
+4. At end-of-show the phone announced the next show; the server set the
+   `pendingAdvance` note and broadcast it — but with `activeDevice=null`, **no
+   device considered itself active**, so nobody fired `playShow` at the deadline.
+   The countdown ran out silently.
+
+The existing restart-reclaim path could not save this: it triggers on
+**witnessing an epoch change** (`lastEpoch != null && epoch != lastEpoch`), but a
+client that connects *fresh after* the restart never sees the old epoch
+(`lastEpoch == null`), so `serverRestarted` is false.
+
+### This is not a one-off
+
+The same orphaned-ghost state — *device playing locally, server believes
+`active=null`* — also arises with **no epoch change at all**: `handleDisconnect`
+(state.ts) nulls `activeDeviceId` when the active socket drops, so a device that
+loses its socket on a network blip and reconnects while still playing is the
+identical ghost. Each new way the server can forget ownership needs a new
+detector. That is the tell that the heuristics are leaves, not the root.
+
+### Root cause
+
+`activeDeviceId`/`playing` are **authoritative server state that clients only
+re-establish *reactively*** — on detecting a specific divergence pattern. The
+device that *should* own the session (it's the one making sound) has no
+*declarative* way to keep asserting that; it can only react to narrowly-detected
+loss. Worse, the reactive path is gated on already-being-active (the
+`playWhenReady` reconciler bails with `if (!_isActiveDevice) return`), so the one
+device that should reclaim is forbidden from trying.
+
+## Decision
+
+### 1. Ownership is a renewable lease held by the device making sound
+
+Keep explicit commands (`load`/`play`/`pause`/`transfer`) as the **fast,
+immediately-consistent authoritative path** — they remain how a user action flips
+ownership instantly. *Additionally*, the device that is locally producing audio
+**renews its ownership claim by piggybacking playback state on the existing
+heartbeat**: `{ playing, recordingId, positionMs }`. The server treats
+`activeDeviceId` as a **lease the live, audio-producing device renews**, not a
+fact it must remember forever. Recovery becomes **convergent and cause-agnostic**:
+restart, disconnect-cleanup, or a dropped message all reconverge within one
+heartbeat interval, with no client-side "did the server restart?" inference.
+
+This is the *correct implementation* of ADR-0006's "recoverable from the
+still-connected active device," not a departure from it. Once the lease provably
+covers them, the epoch-reclaim, empty-tracks re-assert, and `reassertingTracks`
+heuristics are **deleted**.
+
+### 2. The lease is conservative: it fills a vacuum, it never preempts
+
+The renewal claims ownership **only when the session is ownerless**
+(`activeDeviceId == null`) **or refreshes the existing owner**. It must **never**
+revoke a device that holds ownership via an explicit command. This is the same
+rule `handlePlay`/`handleLoad`/`handleAnnounceNext` already follow ("claim when
+null"). It is what makes a mixed old/new fleet safe (see §4) and prevents
+split-brain flapping.
+
+- **Ownership ≠ "playing right now."** A paused owner keeps the lease — renewal
+  continues while connected, playing or paused. The lease tracks *"I hold this
+  session,"* not instantaneous `isPlaying` (which dips on every buffering stall).
+- **Conflict resolution.** If two devices both assert an ownerless session
+  (genuine split-brain), tiebreak by **most-recent explicit user action**, then by
+  lease timestamp — deterministic, last-writer-wins, no flap. In normal operation
+  only one device produces audio, so this is the rare path.
+
+### 3. WS protocol versioning (the enabling primitive)
+
+On `register`, every client sends:
+
+- **`protocolVersion`** — a monotonic integer describing the **wire contract**.
+  Absent ⇒ legacy ⇒ treated as `0`. New builds start at `1`. **Server behavior
+  branches only on this.**
+- **`appVersion`** — a string (build identity) for **telemetry, "please update"
+  UX, and debugging only**. Behavior is **never** branched on it.
+
+The server stamps both onto the **in-memory connection record** (`liveDevices`
+entry, alongside the socket) — *not* Redis. Protocol version has the **same
+lifetime as the socket**: it arrives on `register`, is valid until the socket
+closes, and is re-sent on every reconnect (self-refreshing, never stale).
+Persisting it would be wrong — a Redis copy could outlive the socket and misreport
+a reconnecting client's capability before it re-registers.
+
+The lease (§1) is gated on `protocolVersion >= N`. Below that, the server keeps
+the legacy behavior for that device.
+
+Lifetime boundary, stated once so it doesn't blur:
+
+| State | Lifetime | Home |
+|---|---|---|
+| socket, `protocolVersion`, `appVersion`, device name/type | per-**connection** | in-memory `liveDevices` |
+| `showId`, position, ownership/`playing` | per-**session** | in-memory `userStates` (Redis-persist still deferred, ADR-0008) |
+
+### 4. Backwards compatibility (Connect is early; forced update is acceptable)
+
+Connect is newly shipped with a small live base. We accept telling users they
+**must update** to fix Connect issues — and a server-enforced floor turns the
+app-store release lag into update *motivation*. Even so, the server is a single
+shared deployment and mobile builds lag, so changes are **additive + conservative**:
+
+- **Additive fields only.** New `register`/heartbeat fields are optional; old
+  clients omit them and the server reads sensible defaults. Old clients ignore
+  unknown keys in broadcasts (already proven by the additive `pendingAdvance` in
+  ADR-0010 §7). No existing message shape changes.
+- **Old clients are never preempted.** Because the lease only fills a vacuum
+  (§2), a new client renewing its lease cannot yank a session a legacy client
+  owns via command. Old clients keep *today's* behavior — they don't self-heal
+  the restart/disconnect ghost, but they are **no worse** than now.
+- **Soft floor, not a hard wall.** `protocolVersion < MIN_SUPPORTED` degrades
+  Connect gracefully and surfaces an "Update for Connect" nudge (server can send
+  `{type:"error", code:"client_too_old"}`). Reserve hard rejection for
+  correctness/security must-haves — a hard wall would lock out users whose update
+  is stuck in review. Advance `MIN_SUPPORTED` on **telemetry**, not hope.
+- **Mixed fleet is permanent during rollout** (web bumps instantly on deploy,
+  mobile straddles for weeks). The version makes the branches *explicit*; it does
+  not excuse incompatible handlers.
+
+### 5. Keep the `handleAnnounceNext` active-claim already shipped
+
+The 2026-06-11 server fix — `handleAnnounceNext` claims the announcing device as
+active when `activeDeviceId == null` — stands. It is a consistent instance of
+"claim when null" (§2), makes `announce` match `handlePlay`/`handleLoad`, and
+rescues the auto-advance failure even before the lease lands. The Android
+`firstStateAfterConnect` stub started while diagnosing is **reverted** — it is a
+detector the lease makes unnecessary.
+
+## Consequences
+
+- **One convergent recovery mechanism** replaces N cause-specific detectors. Net
+  code is roughly a wash (the lease + conflict rule cost about what the deleted
+  heuristics saved) — the win is *one coherent thing with a retirement path*, not
+  a pile that grows by one each time the server finds a new way to forget.
+- **Recovery is eventually-consistent** (bounded by the heartbeat interval) where
+  the command path is immediate. Acceptable: the lease is the *healing* layer, not
+  the *control* layer; user actions still flip ownership instantly via commands.
+- **A version number is debt with a payoff.** Each `if (proto >= N)` branch must
+  eventually be deleted; protocol-distribution telemetry is what licenses the
+  deletion. Skipping the deletion step re-creates the whack-a-mole in a new shape.
+- **Single source of truth for protocol semantics.** A `docs/PROTOCOL.md` (or a
+  shared constant) must record what each `protocolVersion` means, or the three
+  clients will disagree about what `2` implies.
+- **Single-instance assumption is load-bearing.** Per-connection facts
+  (`protocolVersion`) live only in that instance's memory. Horizontal scaling
+  would require sticky routing or a shared presence registry (and *that* presence
+  record could live in Redis, keyed to the connection and reaped on disconnect).
+  Out of scope now — documented so future-us isn't surprised.
+- **Old clients keep the ghost** until their users update. Chosen deliberately
+  over un-deferring ADR-0008's durable state (which *would* fix old clients on the
+  restart variant, server-side and update-free) — durable state remains gated on
+  the social feature, and the lease additionally covers the disconnect variant
+  that persistence alone would not.
+
+## Alternatives considered
+
+- **Persist session state in Redis (the "root-lite").** Server-only, zero wire
+  change, and it would fix the restart variant for the *entire* fleet including
+  old builds with no update — genuinely attractive. Rejected as the primary fix
+  here because (a) it does **not** cover the disconnect-cleanup variant, where
+  `handleDisconnect` actively nulls `activeDeviceId` with no restart to recover
+  from, and (b) ADR-0008 deliberately gates durable server-side state on the
+  social/presence feature, where it pays for itself. The lease covers what this
+  bug needs without un-deferring that decision. Redis-persist remains the likely
+  path *when social lands*, complementary to the lease.
+- **Keep patching detectors** (finish `firstStateAfterConnect`, add the next one
+  when the next trigger appears). Rejected: it is the accretion this ADR exists to
+  stop; every new failure mode needs a new detector and none are ever deleted.
+- **Capability flags instead of a monotonic int** (`["lease","countdown_v2"]`).
+  More flexible — lets features ship out of order — but more bookkeeping than a
+  single-track protocol with one client codebase per platform needs today (YAGNI).
+  The int gives a clean `MIN_SUPPORTED` gate now; switch to flags if/when two
+  capabilities must ship independently.
+- **Branch behavior on `appVersion`.** Rejected: couples wire capability to
+  marketing/build identity and forces "≥ which build has feature X" lookup tables.
+  `protocolVersion` decouples them so two releases can speak the same protocol.
+- **Silent push to wake a sleeping device** (the ADR-0008 Spotify path). Still
+  deferred and orthogonal — this ADR is about a *connected* device recovering
+  ownership, not waking a suspended one.

--- a/iosApp/Packages/SwiftAudioStreamEx/Sources/SwiftAudioStreamEx/Internal/AudioStreamEngine.swift
+++ b/iosApp/Packages/SwiftAudioStreamEx/Sources/SwiftAudioStreamEx/Internal/AudioStreamEngine.swift
@@ -118,6 +118,11 @@ final class AudioStreamEngine: NSObject, AudioEngineProtocol, @unchecked Sendabl
     // MARK: - AudioEngineProtocol callbacks
     nonisolated(unsafe) var onStateChange: ((PlaybackState) -> Void)?
     nonisolated(unsafe) var onTrackComplete: (() -> Void)?
+    /// Fired when the *last* track of the queue reaches its natural end of file
+    /// (the positive "show completed" signal — see ADR-0010 Chunk 1). Distinct
+    /// from onTrackComplete (mid-queue auto-advance) and from a user stop/pause
+    /// or an error (which never reach this `.eof && isLastTrack` path).
+    nonisolated(unsafe) var onQueueComplete: (() -> Void)?
     nonisolated(unsafe) var onProgressUpdate: ((PlaybackProgress) -> Void)?
     /// Fired when the engine surfaces a user-visible playback failure.
     /// The second parameter, when non-nil, is the playback position at the
@@ -815,6 +820,7 @@ extension AudioStreamEngine: AudioPlayerDelegate {
         if stopReason == .eof && isLastTrack {
             logger.notice("[PB] final track finished, queue ended")
             onStateChange?(.ended)
+            onQueueComplete?()
         }
     }
 

--- a/iosApp/Packages/SwiftAudioStreamEx/Sources/SwiftAudioStreamEx/StreamPlayer.swift
+++ b/iosApp/Packages/SwiftAudioStreamEx/Sources/SwiftAudioStreamEx/StreamPlayer.swift
@@ -56,6 +56,13 @@ public final class StreamPlayer {
     /// uses this so the active device broadcasts the new track index to the session.
     public var onTrackComplete: (() -> Void)?
 
+    /// Called when the *last* track of the queue reaches its natural end of file —
+    /// the positive "show completed" signal (ADR-0010 Chunk 1). Fires only on
+    /// `.eof && isLastTrack`, so a user stop/pause, an error, or a mid-queue
+    /// transition never trigger it. The package stays show-agnostic; the app
+    /// layer translates this into `onShowCompleted(showId)`.
+    public var onQueueComplete: (() -> Void)?
+
     /// Called when play INTENT changes — true when the player wants to be playing
     /// (`.playing`/`.buffering`), false when it has stopped (`.paused`/`.ended`/
     /// `.idle`). Distinct from `playbackState.isPlaying`, which is false during
@@ -464,6 +471,14 @@ public final class StreamPlayer {
                 let newTitle = self.currentTrack?.title ?? "(none)"
                 self.logger.notice("[PB] onTrackComplete prev=\(previousTitle, privacy: .public) → newIdx=\(self.engine.currentIndex, privacy: .public) new=\(newTitle, privacy: .public)")
                 self.onTrackComplete?()
+            }
+        }
+
+        engine.onQueueComplete = { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                self.logger.notice("[PB] onQueueComplete — final track finished naturally")
+                self.onQueueComplete?()
             }
         }
 

--- a/iosApp/deadly/App/AppContainer.swift
+++ b/iosApp/deadly/App/AppContainer.swift
@@ -345,7 +345,8 @@ final class AppContainer {
                 AutoAdvanceCoordinator(
                     playlistService: playlistSvc,
                     showRepository: showRepo,
-                    connectService: connect
+                    connectService: connect,
+                    appPreferences: prefs
                 )
             }
 

--- a/iosApp/deadly/App/AppContainer.swift
+++ b/iosApp/deadly/App/AppContainer.swift
@@ -37,6 +37,7 @@ final class AppContainer {
     let playbackRestorationService: PlaybackRestorationService
     let analyticsService: AnalyticsService
     let connectService: ConnectService
+    let autoAdvanceCoordinator: AutoAdvanceCoordinator
     let notificationStore: NotificationStore
     let notificationService: NotificationService
 
@@ -337,6 +338,17 @@ final class AppContainer {
                     }
                 }
             }
+
+            // ADR-0010 chunk 2: chronological auto-advance, driven off the
+            // end-of-show signal (PlaylistServiceImpl.onShowCompleted).
+            autoAdvanceCoordinator = MainActor.assumeIsolated {
+                AutoAdvanceCoordinator(
+                    playlistService: playlistSvc,
+                    showRepository: showRepo,
+                    connectService: connect
+                )
+            }
+
             // In-app messaging — public/global feed; store + fetch service.
             // No auth, so it isn't wired into the sign-in flow; deadlyApp pulls
             // it on cold start + foreground.

--- a/iosApp/deadly/Core/Model/ConnectModels.swift
+++ b/iosApp/deadly/Core/Model/ConnectModels.swift
@@ -35,6 +35,15 @@ struct SessionTrack: Codable {
     let durationMs: Int
 }
 
+// MARK: - PendingAdvance
+
+// ADR-0010 §7: shared end-of-show countdown. deadline is an absolute server
+// timestamp (ms), Double like positionTs (the server may send a fractional value).
+struct PendingAdvance: Codable, Equatable {
+    let showId: String
+    let deadline: Double
+}
+
 // MARK: - ConnectState
 
 struct ConnectState: Codable {
@@ -55,4 +64,7 @@ struct ConnectState: Codable {
     let date: String?
     let venue: String?
     let location: String?
+    // ADR-0010 §7: shared end-of-show countdown. Optional/additive — a missing
+    // key decodes to nil (synthesized Decodable uses decodeIfPresent for optionals).
+    let pendingAdvance: PendingAdvance?
 }

--- a/iosApp/deadly/Core/Service/AppPreferences.swift
+++ b/iosApp/deadly/Core/Service/AppPreferences.swift
@@ -11,6 +11,7 @@ final class AppPreferences {
     private static let eqPresetKey = "eq_preset"
     private static let eqBandGainsKey = "eq_band_gains"
     private static let shareAttachImageKey = "share_attach_image"
+    private static let autoAdvanceEnabledKey = "auto_advance_enabled"
     private static let sourceBadgeStyleKey = "source_badge_style"
     private static let useBetaShareLinksKey = "use_beta_share_links"
     private static let useBetaModeKey = "use_beta_mode"
@@ -103,6 +104,11 @@ final class AppPreferences {
 
     var sourceBadgeStyle: String {
         didSet { UserDefaults.standard.set(sourceBadgeStyle, forKey: Self.sourceBadgeStyleKey) }
+    }
+
+    /// ADR-0010: roll into the next show when one ends. On by default.
+    var autoAdvanceEnabled: Bool {
+        didSet { UserDefaults.standard.set(autoAdvanceEnabled, forKey: Self.autoAdvanceEnabledKey) }
     }
 
     var analyticsEnabled: Bool {
@@ -204,6 +210,7 @@ final class AppPreferences {
             Self.eqEnabledKey: false,
             Self.eqPresetKey: "flat",
             Self.shareAttachImageKey: false,
+            Self.autoAdvanceEnabledKey: true,
             Self.sourceBadgeStyleKey: "LONG",
             Self.playerControlsStyleKey: "skipTrack",
             Self.homeTrendingWindowKey: "now",
@@ -235,6 +242,7 @@ final class AppPreferences {
             ?? UserDefaults.standard.string(forKey: Self.legacyLibraryDisplayModeKey)
             ?? "LIST"
         shareAttachImage = UserDefaults.standard.bool(forKey: Self.shareAttachImageKey)
+        autoAdvanceEnabled = UserDefaults.standard.bool(forKey: Self.autoAdvanceEnabledKey)
         sourceBadgeStyle = UserDefaults.standard.string(forKey: Self.sourceBadgeStyleKey) ?? "LONG"
         playerControlsStyle = UserDefaults.standard.string(forKey: Self.playerControlsStyleKey) ?? "skipTrack"
         homeTrendingWindow = UserDefaults.standard.string(forKey: Self.homeTrendingWindowKey) ?? "now"

--- a/iosApp/deadly/Core/Service/AutoAdvanceCoordinator.swift
+++ b/iosApp/deadly/Core/Service/AutoAdvanceCoordinator.swift
@@ -29,6 +29,7 @@ final class AutoAdvanceCoordinator {
     private let playlistService: PlaylistServiceImpl
     private let showRepository: any ShowRepository
     private let connectService: ConnectService
+    private let appPreferences: AppPreferences
 
     private var localTask: Task<Void, Never>?
     private var noteWatcher: Task<Void, Never>?
@@ -43,11 +44,13 @@ final class AutoAdvanceCoordinator {
     init(
         playlistService: PlaylistServiceImpl,
         showRepository: any ShowRepository,
-        connectService: ConnectService
+        connectService: ConnectService,
+        appPreferences: AppPreferences
     ) {
         self.playlistService = playlistService
         self.showRepository = showRepository
         self.connectService = connectService
+        self.appPreferences = appPreferences
         playlistService.onShowCompleted = { [weak self] completedShowId in
             self?.onShowCompleted(completedShowId)
         }
@@ -120,6 +123,10 @@ final class AutoAdvanceCoordinator {
 
     private func onShowCompleted(_ completedShowId: String) {
         logger.notice("auto-advance: show completed = \(completedShowId, privacy: .public)")
+        guard appPreferences.autoAdvanceEnabled else {
+            logger.notice("auto-advance: disabled by preference — not advancing")
+            return
+        }
         localTask?.cancel()
         localTask = Task { @MainActor [weak self] in
             guard let self else { return }

--- a/iosApp/deadly/Core/Service/AutoAdvanceCoordinator.swift
+++ b/iosApp/deadly/Core/Service/AutoAdvanceCoordinator.swift
@@ -3,33 +3,40 @@ import os.log
 
 private let logger = Logger(subsystem: "com.grateful.deadly", category: "AutoAdvance")
 
-/// ADR-0010 Chunk 2 — chronological auto-advance (iOS).
+/// ADR-0010 Chunk 2 + §7 — chronological auto-advance, cross-device (iOS).
 ///
-/// An independent coordinator whose only input is
-/// `PlaylistServiceImpl.onShowCompleted` (the Chunk 1 end-of-show signal). It
-/// reads no transport/Connect state to decide whether/what to advance — that
-/// interrogation was the v1 whack-a-mole. Gating is intrinsic: only the
-/// audio-producing device reaches end-of-show, so only it advances.
+/// Driven by `PlaylistServiceImpl.onShowCompleted` (the Chunk 1 end-of-show
+/// signal). Reads no transport state to *decide* whether to advance.
 ///
-/// On end of show: **park** (`sendStop`, so the server stops believing we're
-/// playing and can't drag us back) → **cancelable countdown** →
-/// `playShow(next chronological)`, whose output (local audio + sendLoad) is
-/// identical to a user tap, so remote Connect clients follow for free.
+/// In a Connect session it `announce`s the next show + a server-time deadline;
+/// the shared `pendingAdvance` note then drives the countdown UI **and** the
+/// advance on every device (the note-poll below). Offline it runs a purely local
+/// countdown. The active device advances when the note is present and the
+/// deadline passes; its `playShow` load clears the note for all. Cancel / Play
+/// now work from any device (commands when remote; act directly when
+/// active/offline).
 @MainActor
 @Observable
 final class AutoAdvanceCoordinator {
     struct Countdown: Equatable {
         let secondsRemaining: Int
-        let nextShowLabel: String?
+        let nextShow: Show
     }
 
-    /// Drives the cancelable "next show in Ns" overlay; nil when idle.
+    /// Drives the "Next up in Ns" UI; nil when idle.
     private(set) var countdown: Countdown?
 
     private let playlistService: PlaylistServiceImpl
     private let showRepository: any ShowRepository
     private let connectService: ConnectService
-    private var advanceTask: Task<Void, Never>?
+
+    private var localTask: Task<Void, Never>?
+    private var noteWatcher: Task<Void, Never>?
+
+    // Cache the resolved show for the current note, and guard one-shot advance.
+    private var resolvedShowId: String?
+    private var resolvedShow: Show?
+    private var advanceTriggered = false
 
     private static let countdownSeconds = 15
 
@@ -44,48 +51,106 @@ final class AutoAdvanceCoordinator {
         playlistService.onShowCompleted = { [weak self] completedShowId in
             self?.onShowCompleted(completedShowId)
         }
+        startNoteWatcher()
     }
 
-    /// User canceled the pending advance.
+    /// Cancel the pending advance.
     func cancel() {
-        logger.notice("auto-advance: canceled by user")
-        advanceTask?.cancel()
-        advanceTask = nil
+        logger.notice("auto-advance: cancel")
+        localTask?.cancel()
+        localTask = nil
         countdown = nil
+        if connectService.isConnected { connectService.sendCancelAdvance() }
+    }
+
+    /// Skip the countdown ("Play now").
+    func playNow() {
+        guard let show = countdown?.nextShow else { return }
+        if connectService.isConnected && !connectService.isActiveDevice {
+            connectService.sendAdvanceNow()
+            return
+        }
+        localTask?.cancel()
+        localTask = nil
+        countdown = nil
+        Task { await playlistService.playShow(show) }
+    }
+
+    // ADR-0010 §7: poll the shared note (1s) — drives the countdown + advance on
+    // every device when connected. Cheap; mirrors the always-on interpolation
+    // ticker elsewhere. Offline, the local countdown task owns `countdown`.
+    private func startNoteWatcher() {
+        noteWatcher = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                self?.tickNote()
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+            }
+        }
+    }
+
+    private func tickNote() {
+        guard connectService.isConnected else { return } // offline: local task owns it
+        guard let note = connectService.connectState?.pendingAdvance else {
+            countdown = nil
+            resolvedShowId = nil
+            resolvedShow = nil
+            advanceTriggered = false
+            return
+        }
+        if resolvedShowId != note.showId {
+            resolvedShowId = note.showId
+            resolvedShow = try? showRepository.getShowById(note.showId)
+            advanceTriggered = false
+        }
+        guard let show = resolvedShow else { return }
+
+        let serverNow = Date().timeIntervalSince1970 * 1000 + connectService.serverTimeOffsetMs
+        let remaining = Int(ceil((note.deadline - serverNow) / 1000.0))
+        if remaining <= 0 {
+            countdown = nil
+            if connectService.isActiveDevice && !advanceTriggered {
+                advanceTriggered = true
+                logger.notice("auto-advance: advancing to \(show.displayTitle, privacy: .public)")
+                Task { await playlistService.playShow(show) } // load clears the note
+            }
+            return
+        }
+        countdown = Countdown(secondsRemaining: remaining, nextShow: show)
     }
 
     private func onShowCompleted(_ completedShowId: String) {
         logger.notice("auto-advance: show completed = \(completedShowId, privacy: .public)")
-        advanceTask?.cancel()
-        advanceTask = Task { @MainActor [weak self] in
+        localTask?.cancel()
+        localTask = Task { @MainActor [weak self] in
             guard let self else { return }
-
-            // 1. Park: stop the server believing we're playing so it can't drag
-            //    us back during the countdown. No-op on the wire when not connected.
-            self.connectService.sendStop()
-
-            // 2. Resolve the next chronological show.
             guard
                 let completed = try? self.showRepository.getShowById(completedShowId),
                 let next = try? self.showRepository.getNextShow(afterDate: completed.date)
             else {
                 logger.notice("auto-advance: no next show after \(completedShowId, privacy: .public)")
-                self.countdown = nil
                 return
             }
 
-            // 3. Cancelable countdown (server is parked, so no drag-back).
+            if self.connectService.isConnected {
+                // In a session: announce; the note-poll drives the rest. Deadline
+                // in server time so every device ticks to the same instant.
+                let deadline = Date().timeIntervalSince1970 * 1000
+                    + self.connectService.serverTimeOffsetMs
+                    + Double(Self.countdownSeconds) * 1000
+                self.connectService.sendAnnounceNext(showId: next.id, deadline: deadline)
+                return
+            }
+
+            // Offline: local-only countdown, then advance.
             var remaining = Self.countdownSeconds
             while remaining > 0 {
                 if Task.isCancelled { return }
-                self.countdown = Countdown(secondsRemaining: remaining, nextShowLabel: next.displayTitle)
+                self.countdown = Countdown(secondsRemaining: remaining, nextShow: next)
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
                 remaining -= 1
             }
             if Task.isCancelled { return }
             self.countdown = nil
-
-            // 4. Advance — identical to a user tap; remotes follow via sendLoad.
             logger.notice("auto-advance: advancing to \(next.displayTitle, privacy: .public)")
             await self.playlistService.playShow(next)
         }

--- a/iosApp/deadly/Core/Service/AutoAdvanceCoordinator.swift
+++ b/iosApp/deadly/Core/Service/AutoAdvanceCoordinator.swift
@@ -1,0 +1,93 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.grateful.deadly", category: "AutoAdvance")
+
+/// ADR-0010 Chunk 2 — chronological auto-advance (iOS).
+///
+/// An independent coordinator whose only input is
+/// `PlaylistServiceImpl.onShowCompleted` (the Chunk 1 end-of-show signal). It
+/// reads no transport/Connect state to decide whether/what to advance — that
+/// interrogation was the v1 whack-a-mole. Gating is intrinsic: only the
+/// audio-producing device reaches end-of-show, so only it advances.
+///
+/// On end of show: **park** (`sendStop`, so the server stops believing we're
+/// playing and can't drag us back) → **cancelable countdown** →
+/// `playShow(next chronological)`, whose output (local audio + sendLoad) is
+/// identical to a user tap, so remote Connect clients follow for free.
+@MainActor
+@Observable
+final class AutoAdvanceCoordinator {
+    struct Countdown: Equatable {
+        let secondsRemaining: Int
+        let nextShowLabel: String?
+    }
+
+    /// Drives the cancelable "next show in Ns" overlay; nil when idle.
+    private(set) var countdown: Countdown?
+
+    private let playlistService: PlaylistServiceImpl
+    private let showRepository: any ShowRepository
+    private let connectService: ConnectService
+    private var advanceTask: Task<Void, Never>?
+
+    private static let countdownSeconds = 15
+
+    init(
+        playlistService: PlaylistServiceImpl,
+        showRepository: any ShowRepository,
+        connectService: ConnectService
+    ) {
+        self.playlistService = playlistService
+        self.showRepository = showRepository
+        self.connectService = connectService
+        playlistService.onShowCompleted = { [weak self] completedShowId in
+            self?.onShowCompleted(completedShowId)
+        }
+    }
+
+    /// User canceled the pending advance.
+    func cancel() {
+        logger.notice("auto-advance: canceled by user")
+        advanceTask?.cancel()
+        advanceTask = nil
+        countdown = nil
+    }
+
+    private func onShowCompleted(_ completedShowId: String) {
+        logger.notice("auto-advance: show completed = \(completedShowId, privacy: .public)")
+        advanceTask?.cancel()
+        advanceTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            // 1. Park: stop the server believing we're playing so it can't drag
+            //    us back during the countdown. No-op on the wire when not connected.
+            self.connectService.sendStop()
+
+            // 2. Resolve the next chronological show.
+            guard
+                let completed = try? self.showRepository.getShowById(completedShowId),
+                let next = try? self.showRepository.getNextShow(afterDate: completed.date)
+            else {
+                logger.notice("auto-advance: no next show after \(completedShowId, privacy: .public)")
+                self.countdown = nil
+                return
+            }
+
+            // 3. Cancelable countdown (server is parked, so no drag-back).
+            var remaining = Self.countdownSeconds
+            while remaining > 0 {
+                if Task.isCancelled { return }
+                self.countdown = Countdown(secondsRemaining: remaining, nextShowLabel: next.displayTitle)
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                remaining -= 1
+            }
+            if Task.isCancelled { return }
+            self.countdown = nil
+
+            // 4. Advance — identical to a user tap; remotes follow via sendLoad.
+            logger.notice("auto-advance: advancing to \(next.displayTitle, privacy: .public)")
+            await self.playlistService.playShow(next)
+        }
+    }
+}

--- a/iosApp/deadly/Core/Service/ConnectService.swift
+++ b/iosApp/deadly/Core/Service/ConnectService.swift
@@ -507,8 +507,17 @@ final class ConnectService: NSObject {
 
         // When this device just became active (e.g. transfer in), sync local player
         // to server state — the local player may be at a completely different track/position.
+        //
+        // BUT skip the transport sync when a pendingAdvance note is present: here we
+        // "became active" only because we announced our OWN end-of-show (the server
+        // claims the announcer active, ADR-0011). We are parked at the end of the show
+        // waiting for the note-collector to advance — we know our position better than
+        // the server, whose positionMs is the stale pre-end value. Without this guard
+        // we seek back to that stale position and resume, replaying the tail, which
+        // re-fires onShowCompleted and re-announces (resetting the countdown). The
+        // note-collector owns the transition from here. (Mirrors reclaimAfterRestart.)
         let justBecameActive = !wasActive && nowActive
-        if justBecameActive {
+        if justBecameActive && new.pendingAdvance == nil {
             let currentVolume = Int(streamPlayer.volume * 100)
             activeDeviceVolume = currentVolume
             sendVolumeReport(volume: currentVolume)

--- a/iosApp/deadly/Core/Service/ConnectService.swift
+++ b/iosApp/deadly/Core/Service/ConnectService.swift
@@ -242,6 +242,22 @@ final class ConnectService: NSObject {
         sendCommand("stop")
     }
 
+    // ADR-0010 §7: cross-device end-of-show countdown.
+    func sendAnnounceNext(showId: String, deadline: Double) {
+        logger.info("sendAnnounceNext: \(showId, privacy: .public) @ \(deadline)")
+        sendCommand("announce_next", extra: ["showId": showId, "deadline": deadline])
+    }
+
+    func sendCancelAdvance() {
+        logger.info("sendCancelAdvance")
+        sendCommand("cancel_advance")
+    }
+
+    func sendAdvanceNow() {
+        logger.info("sendAdvanceNow")
+        sendCommand("advance_now")
+    }
+
     func sendVolume(volume: Int) {
         logger.info("sendVolume: \(volume, privacy: .public)")
         sendCommand("volume", extra: ["volume": volume])

--- a/iosApp/deadly/Core/Service/PlaylistServiceImpl.swift
+++ b/iosApp/deadly/Core/Service/PlaylistServiceImpl.swift
@@ -227,6 +227,16 @@ final class PlaylistServiceImpl: PlaylistService {
         }
     }
 
+    /// Play an arbitrary show from scratch — the canonical "play a show" entry.
+    /// Loads its preferred/best recording + tracks, then starts at track 0, which
+    /// also notifies Connect (sendLoad) via playTrack. Auto-advance (ADR-0010)
+    /// routes through this so it can't diverge from a user tap; remotes follow.
+    func playShow(_ show: Show, autoPlay: Bool = true) async {
+        await loadShow(show.id)
+        guard !tracks.isEmpty else { return }
+        playTrack(at: 0, source: "auto_advance", autoPlay: autoPlay)
+    }
+
     func selectRecording(_ recording: Recording) async {
         currentRecording = recording
         reviews = []

--- a/iosApp/deadly/Core/Service/PlaylistServiceImpl.swift
+++ b/iosApp/deadly/Core/Service/PlaylistServiceImpl.swift
@@ -1,8 +1,11 @@
 import Foundation
 import SwiftAudioStreamEx
+import os.log
 #if canImport(UIKit)
 import UIKit
 #endif
+
+private let logger = Logger(subsystem: "com.grateful.deadly", category: "PlaylistService")
 
 @Observable
 @MainActor
@@ -27,6 +30,15 @@ final class PlaylistServiceImpl: PlaylistService {
     var connectService: ConnectService?
     /// When true, playTrack() skips notifying Connect to avoid Connect→load→sendLoad loops.
     var suppressConnectNotify = false
+
+    /// ADR-0010 Chunk 1: the show-completion signal for auto-advance. Fired with
+    /// the showId of the show that just finished — and *only* on the natural end
+    /// of its last track (the package's `onQueueComplete`, which is `.eof &&
+    /// isLastTrack`). A user stop/pause, an error, or a mid-show track transition
+    /// never reach it, and a cold-start restore never plays to EOF, so no session
+    /// guard is needed on iOS. The advance coordinator subscribes to this and
+    /// reads no transport state.
+    var onShowCompleted: ((String) -> Void)?
 
     /// Tracks the currently playing item for playback_end analytics.
     private var playbackStartInfo: (showId: String, recordingId: String, trackNumber: Int)?
@@ -108,6 +120,13 @@ final class PlaylistServiceImpl: PlaylistService {
         MainActor.assumeIsolated {
             self.startProgressObservation()
             self.startPlaybackStateObservation()
+            // ADR-0010 Chunk 1: translate the package's show-agnostic
+            // "queue completed naturally" into onShowCompleted(showId).
+            self.streamPlayer.onQueueComplete = { [weak self] in
+                guard let self, let showId = self.currentShow?.id else { return }
+                logger.notice("🏁 [SHOW-COMPLETE] onShowCompleted(showId=\(showId, privacy: .public))")
+                self.onShowCompleted?(showId)
+            }
             self.willResignActiveObserver = NotificationCenter.default.addObserver(
                 forName: UIApplication.willResignActiveNotification,
                 object: nil,

--- a/iosApp/deadly/Feature/Player/AutoAdvanceOverlay.swift
+++ b/iosApp/deadly/Feature/Player/AutoAdvanceOverlay.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+/// ADR-0010 — end-of-show "Next up in Ns" card. Shows the next show's cover +
+/// details while the countdown runs, with Play now / Cancel. Fed by
+/// `AutoAdvanceCoordinator.countdown`; rendered above the mini player (active
+/// device and remotes alike). Renders nothing when there's no countdown.
+struct AutoAdvanceOverlay: View {
+    @Environment(\.appContainer) private var container
+
+    var body: some View {
+        if let countdown = container.autoAdvanceCoordinator.countdown {
+            let show = countdown.nextShow
+            HStack(spacing: 12) {
+                ShowArtwork(
+                    recordingId: show.bestRecordingId,
+                    imageUrl: show.coverImageUrl,
+                    size: 44,
+                    cornerRadius: DeadlySize.artworkCornerRadius
+                )
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Next up in \(countdown.secondsRemaining)s")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(DeadlyColors.primary)
+                    Text(show.date)
+                        .font(.subheadline)
+                        .lineLimit(1)
+                    Text(show.venue.name)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 4)
+
+                Button("Play now") { container.autoAdvanceCoordinator.playNow() }
+                    .font(.caption.weight(.bold))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+                    .background(DeadlyColors.primary)
+                    .foregroundStyle(.black)
+                    .clipShape(Capsule())
+
+                Button("Cancel") { container.autoAdvanceCoordinator.cancel() }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 7)
+                    .overlay(Capsule().stroke(Color.secondary.opacity(0.4)))
+            }
+            .padding(12)
+            .background(Color(.secondarySystemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal, 8)
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+        }
+    }
+}

--- a/iosApp/deadly/Feature/Player/AutoAdvanceTakeover.swift
+++ b/iosApp/deadly/Feature/Player/AutoAdvanceTakeover.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+/// ADR-0010 — full-screen "Up Next" end-of-show takeover: the full-player
+/// counterpart to the docked `AutoAdvanceOverlay`. While the countdown runs and
+/// the player is open, the player is replaced by a preview of the NEXT show —
+/// the same large artwork / date / venue layout as the now-playing view, under
+/// an "Up Next in Ns" header, with Play now / Cancel. Mirrors web's HeaderPlayer
+/// takeover. Fed by `AutoAdvanceCoordinator.countdown`; renders nothing when
+/// there's no countdown.
+struct AutoAdvanceTakeover: View {
+    @Environment(\.appContainer) private var container
+
+    var body: some View {
+        if let countdown = container.autoAdvanceCoordinator.countdown {
+            let show = countdown.nextShow
+            ZStack {
+                Color(.systemBackground).ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    // "Up Next in Ns" header — the countdown the user watches tick.
+                    Text("UP NEXT IN \(countdown.secondsRemaining)s")
+                        .font(.subheadline.weight(.semibold))
+                        .tracking(2)
+                        .foregroundStyle(DeadlyColors.primary)
+
+                    Spacer().frame(height: 24)
+
+                    // Large cover art of the next show — same prominence (300pt)
+                    // and shadow as the now-playing player's artwork.
+                    ShowArtwork(
+                        recordingId: show.bestRecordingId,
+                        imageUrl: show.coverImageUrl,
+                        size: 300,
+                        cornerRadius: DeadlySize.carouselCornerRadius
+                    )
+                    .shadow(color: .black.opacity(0.4), radius: 20, y: 10)
+
+                    Spacer().frame(height: 32)
+
+                    // Next show date / venue / location.
+                    VStack(spacing: 6) {
+                        Text(show.date)
+                            .font(.title2.weight(.bold))
+                            .foregroundStyle(.primary)
+                            .lineLimit(2)
+                            .multilineTextAlignment(.center)
+                        if !show.venue.name.isEmpty {
+                            Text(show.venue.name)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                        if !show.location.displayText.isEmpty {
+                            Text(show.location.displayText)
+                                .font(.footnote)
+                                .foregroundStyle(.secondary.opacity(0.8))
+                                .lineLimit(1)
+                        }
+                    }
+
+                    Spacer().frame(height: 32)
+
+                    // Actions in the transport's place: start now, or stay put.
+                    Button {
+                        container.autoAdvanceCoordinator.playNow()
+                    } label: {
+                        Text("Play now")
+                            .font(.subheadline.weight(.bold))
+                            .padding(.horizontal, 32)
+                            .padding(.vertical, 12)
+                            .background(DeadlyColors.primary)
+                            .foregroundStyle(.black)
+                            .clipShape(Capsule())
+                    }
+
+                    Spacer().frame(height: 12)
+
+                    Button {
+                        container.autoAdvanceCoordinator.cancel()
+                    } label: {
+                        Text("Cancel")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 24)
+                            .padding(.vertical, 10)
+                            .overlay(Capsule().stroke(Color.secondary.opacity(0.4)))
+                    }
+                }
+                .padding(.horizontal, 24)
+            }
+            .transition(.opacity)
+        }
+    }
+}

--- a/iosApp/deadly/Feature/Player/MiniPlayerOverlay.swift
+++ b/iosApp/deadly/Feature/Player/MiniPlayerOverlay.swift
@@ -5,7 +5,11 @@ extension View {
         self
             .contentMargins(.bottom, miniPlayerService.isVisible ? 80 : 0, for: .scrollContent)
             .overlay(alignment: .bottom) {
-                MiniPlayerOverlay(service: miniPlayerService, showFullPlayer: showFullPlayer)
+                VStack(spacing: 8) {
+                    // ADR-0010: end-of-show countdown card, above the mini player.
+                    AutoAdvanceOverlay()
+                    MiniPlayerOverlay(service: miniPlayerService, showFullPlayer: showFullPlayer)
+                }
             }
     }
 }

--- a/iosApp/deadly/Feature/Player/PlayerScreen.swift
+++ b/iosApp/deadly/Feature/Player/PlayerScreen.swift
@@ -206,6 +206,10 @@ struct PlayerScreen: View {
                     }
                 }
             }
+
+            // ADR-0010: full-screen "Up Next" takeover during the end-of-show
+            // countdown — covers the player with a preview of the next show.
+            AutoAdvanceTakeover()
         }
         .task(id: streamPlayer.currentTrack?.id) {
             let show = container.playlistService.currentShow

--- a/iosApp/deadly/Feature/Settings/SettingsScreen.swift
+++ b/iosApp/deadly/Feature/Settings/SettingsScreen.swift
@@ -146,6 +146,27 @@ struct SettingsScreen: View {
             }
 
             // MARK: - Preferences
+            Section("Playback") {
+                Toggle(isOn: Binding(
+                    get: { container.appPreferences.autoAdvanceEnabled },
+                    set: {
+                        container.appPreferences.autoAdvanceEnabled = $0
+                        container.analyticsService.track("feature_use", props: [
+                            "feature": "toggle_auto_advance",
+                            "category": "playback",
+                            "enabled": $0,
+                        ])
+                    }
+                )) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("When a show ends")
+                        Text("Roll into the next show automatically, after a 15-second countdown you can cancel.")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
             Section("Preferences") {
                 Toggle(isOn: Binding(
                     get: { container.appPreferences.includeShowsWithoutRecordings },

--- a/ui/src/app/me/_components/SettingsTab.tsx
+++ b/ui/src/app/me/_components/SettingsTab.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { deleteAccount } from "@/lib/userDataApi";
 import { SUBREDDIT_HANDLE, SUBREDDIT_URL } from "@/lib/community";
+import { getAutoAdvanceEnabled, setAutoAdvanceEnabled } from "@/lib/playbackPrefs";
+import * as analytics from "@/lib/analytics";
 
 export default function SettingsTab() {
   const { user, signOut } = useAuth();
@@ -14,6 +16,21 @@ export default function SettingsTab() {
   const [confirmText, setConfirmText] = useState("");
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState(false);
+
+  // ADR-0010 ship gate: roll into the next show when one ends. Read from
+  // localStorage on mount (SSR-safe default until then).
+  const [autoAdvance, setAutoAdvance] = useState(true);
+  useEffect(() => setAutoAdvance(getAutoAdvanceEnabled()), []);
+  function toggleAutoAdvance() {
+    const next = !autoAdvance;
+    setAutoAdvance(next);
+    setAutoAdvanceEnabled(next);
+    analytics.track("feature_use", {
+      feature: "toggle_auto_advance",
+      category: "playback",
+      enabled: next,
+    });
+  }
 
   async function handleDelete() {
     setDeleting(true);
@@ -52,6 +69,36 @@ export default function SettingsTab() {
           className="mt-4 rounded-md border border-white/15 px-3 py-1.5 text-sm text-white/70 transition hover:border-white/30 hover:text-white"
         >
           Sign out
+        </button>
+      </section>
+
+      {/* Playback */}
+      <section className="rounded-lg border border-white/10 bg-deadly-surface p-5">
+        <h3 className="mb-3 font-medium text-white">Playback</h3>
+        <button
+          onClick={toggleAutoAdvance}
+          role="switch"
+          aria-checked={autoAdvance}
+          className="flex w-full items-start justify-between gap-4 text-left"
+        >
+          <span>
+            <span className="block text-sm text-white/80">When a show ends</span>
+            <span className="mt-0.5 block text-xs text-white/40">
+              Roll into the next show automatically, after a 15-second countdown
+              you can cancel.
+            </span>
+          </span>
+          <span
+            className={`mt-0.5 flex h-6 w-11 flex-shrink-0 items-center rounded-full p-0.5 transition ${
+              autoAdvance ? "bg-deadly-highlight" : "bg-white/15"
+            }`}
+          >
+            <span
+              className={`h-5 w-5 rounded-full bg-white transition ${
+                autoAdvance ? "translate-x-5" : "translate-x-0"
+              }`}
+            />
+          </span>
         </button>
       </section>
 

--- a/ui/src/components/player/AutoAdvanceBanner.tsx
+++ b/ui/src/components/player/AutoAdvanceBanner.tsx
@@ -15,12 +15,12 @@ export default function AutoAdvanceBanner() {
   const subtitle = [nextShow.venue, nextShow.location].filter(Boolean).join(" · ");
 
   return (
-    <div className="mx-2 mb-2 flex items-center gap-3 rounded-lg border border-deadly-primary/40 bg-deadly-surface px-3 py-2 shadow-lg">
+    <div className="mx-2 mb-2 flex items-center gap-3 rounded-lg border border-deadly-accent/40 bg-deadly-surface px-3 py-2 shadow-lg">
       {/* Ticket image, else the Deadly logo — same convention as ShowArtwork. */}
       <ShowArtwork image={nextShow.image} alt={nextShow.date} />
 
       <div className="min-w-0 flex-1">
-        <div className="text-xs font-semibold uppercase tracking-wide text-deadly-primary">
+        <div className="text-xs font-semibold uppercase tracking-wide text-deadly-highlight">
           Next up in {secondsRemaining}s
         </div>
         <div className="truncate text-sm font-medium text-white">{nextShow.date}</div>
@@ -29,13 +29,13 @@ export default function AutoAdvanceBanner() {
 
       <button
         onClick={playNextNow}
-        className="flex-shrink-0 rounded-full bg-deadly-primary px-3 py-1.5 text-xs font-semibold text-black"
+        className="flex-shrink-0 rounded-full bg-deadly-accent px-4 py-1.5 text-xs font-bold text-black transition hover:scale-105"
       >
         Play now
       </button>
       <button
         onClick={cancelAutoAdvance}
-        className="flex-shrink-0 rounded-full border border-white/20 px-3 py-1.5 text-xs font-medium text-white/80"
+        className="flex-shrink-0 rounded-full border border-white/25 px-4 py-1.5 text-xs font-medium text-white/80"
       >
         Cancel
       </button>

--- a/ui/src/components/player/AutoAdvanceBanner.tsx
+++ b/ui/src/components/player/AutoAdvanceBanner.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { usePlayer } from "@/contexts/PlayerContext";
+import ShowArtwork from "@/components/show/ShowArtwork";
+
+// ADR-0010 chunk 2: end-of-show "Next up in Ns" announcement. Shows the next
+// show's cover + details while the countdown runs, with Play-now / Cancel.
+// v1: a docked card above the player bar (active device only). The richer
+// "full-screen player previews the next show" treatment layers on from here.
+export default function AutoAdvanceBanner() {
+  const { autoAdvance, cancelAutoAdvance, playNextNow } = usePlayer();
+  if (!autoAdvance) return null;
+
+  const { secondsRemaining, nextShow } = autoAdvance;
+  const subtitle = [nextShow.venue, nextShow.location].filter(Boolean).join(" · ");
+
+  return (
+    <div className="mx-2 mb-2 flex items-center gap-3 rounded-lg border border-deadly-primary/40 bg-deadly-surface px-3 py-2 shadow-lg">
+      {/* Ticket image, else the Deadly logo — same convention as ShowArtwork. */}
+      <ShowArtwork image={nextShow.image} alt={nextShow.date} />
+
+      <div className="min-w-0 flex-1">
+        <div className="text-xs font-semibold uppercase tracking-wide text-deadly-primary">
+          Next up in {secondsRemaining}s
+        </div>
+        <div className="truncate text-sm font-medium text-white">{nextShow.date}</div>
+        {subtitle && <div className="truncate text-xs text-white/60">{subtitle}</div>}
+      </div>
+
+      <button
+        onClick={playNextNow}
+        className="flex-shrink-0 rounded-full bg-deadly-primary px-3 py-1.5 text-xs font-semibold text-black"
+      >
+        Play now
+      </button>
+      <button
+        onClick={cancelAutoAdvance}
+        className="flex-shrink-0 rounded-full border border-white/20 px-3 py-1.5 text-xs font-medium text-white/80"
+      >
+        Cancel
+      </button>
+    </div>
+  );
+}

--- a/ui/src/components/player/HeaderPlayer.tsx
+++ b/ui/src/components/player/HeaderPlayer.tsx
@@ -10,6 +10,7 @@ import type { AiShowReview } from "@/types/show";
 import type { ShowReview } from "@/types/userdata";
 
 import { useInterpolatedPosition } from "@/hooks/useInterpolatedPosition";
+import ShowArtwork from "@/components/show/ShowArtwork";
 import AutoplayPrompt from "./AutoplayPrompt";
 import RecordingSelector from "./RecordingSelector";
 import TrackList from "./TrackList";
@@ -419,6 +420,9 @@ export default function HeaderPlayer() {
     dismiss,
     volume,
     setVolume,
+    autoAdvance,
+    cancelAutoAdvance,
+    playNextNow,
   } = usePlayer();
 
   const { connected: isConnected, state: connectState, serverTimeOffsetMs } = useConnect();
@@ -976,6 +980,50 @@ export default function HeaderPlayer() {
             )}
           </div>
         </div>
+
+        {/* ── End-of-show "Next up" takeover (ADR-0010): while the countdown
+            runs, the fullscreen player previews the next show — its cover +
+            details under a "Next up in Ns" banner, with Play now / Cancel.
+            An absolute layer so it covers the now-playing content without
+            disturbing the mobile/desktop layouts beneath. ── */}
+        {autoAdvance && (
+          <div className="absolute inset-0 z-30 flex flex-col items-center justify-center gap-6 bg-gradient-to-b from-deadly-surface to-deadly-bg px-6 text-center">
+            <div className="text-sm font-semibold uppercase tracking-[0.25em] text-deadly-primary">
+              Next up in {autoAdvance.secondsRemaining}s
+            </div>
+            {/* Whole ticket at its natural shape (contain) / square logo —
+                matched to the playing fullscreen view's sizing. */}
+            <ShowArtwork
+              image={autoAdvance.nextShow.image}
+              alt={autoAdvance.nextShow.date}
+              className="max-h-[34vh] max-w-[min(90vw,30rem)] rounded-xl object-contain shadow-2xl shadow-black/50"
+              fallbackClassName="aspect-square w-[min(34vh,18rem)] rounded-xl object-cover"
+            />
+            <div>
+              <p className="text-2xl font-bold text-white">{autoAdvance.nextShow.date}</p>
+              {autoAdvance.nextShow.venue && (
+                <p className="mt-1 text-base text-white/70">{autoAdvance.nextShow.venue}</p>
+              )}
+              {autoAdvance.nextShow.location && (
+                <p className="text-sm text-white/50">{autoAdvance.nextShow.location}</p>
+              )}
+            </div>
+            <div className="flex flex-col items-center gap-3">
+              <button
+                onClick={playNextNow}
+                className="rounded-full bg-deadly-primary px-6 py-2.5 text-sm font-semibold text-black"
+              >
+                Play now
+              </button>
+              <button
+                onClick={cancelAutoAdvance}
+                className="rounded-full border border-white/25 px-6 py-2.5 text-sm font-medium text-white/80"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
 
         {/* ── Mobile layout: native player parity — a compact ticket + show
             info header, the transport docked beneath it, then the TRACK LIST

--- a/ui/src/components/player/HeaderPlayer.tsx
+++ b/ui/src/components/player/HeaderPlayer.tsx
@@ -988,7 +988,7 @@ export default function HeaderPlayer() {
             disturbing the mobile/desktop layouts beneath. ── */}
         {autoAdvance && (
           <div className="absolute inset-0 z-30 flex flex-col items-center justify-center gap-6 bg-gradient-to-b from-deadly-surface to-deadly-bg px-6 text-center">
-            <div className="text-sm font-semibold uppercase tracking-[0.25em] text-deadly-primary">
+            <div className="text-sm font-semibold uppercase tracking-[0.25em] text-deadly-highlight">
               Next up in {autoAdvance.secondsRemaining}s
             </div>
             {/* Whole ticket at its natural shape (contain) / square logo —
@@ -1011,7 +1011,7 @@ export default function HeaderPlayer() {
             <div className="flex flex-col items-center gap-3">
               <button
                 onClick={playNextNow}
-                className="rounded-full bg-deadly-primary px-6 py-2.5 text-sm font-semibold text-black"
+                className="rounded-full bg-deadly-accent px-8 py-2.5 text-sm font-bold text-black transition hover:scale-105"
               >
                 Play now
               </button>

--- a/ui/src/components/player/PlayerProvider.tsx
+++ b/ui/src/components/player/PlayerProvider.tsx
@@ -46,6 +46,13 @@ export default function PlayerProvider({
   const [tracks, setTracks] = useState<ArchiveTrack[] | null>(null);
   const [currentTrackIndex, setCurrentTrackIndex] = useState(-1);
   const [status, setStatus] = useState<PlaybackStatus>("idle");
+  // ADR-0010 chunk 2: pending end-of-show auto-advance, surfaced to the UI so the
+  // full player can preview the next show + a "Next up in Ns" banner. nextShow
+  // carries the display data; secondsRemaining ticks 15→0.
+  const [autoAdvance, setAutoAdvance] = useState<{
+    secondsRemaining: number;
+    nextShow: ViewedShow;
+  } | null>(null);
   const [elapsed, setElapsed] = useState(0);
   const [duration, setDuration] = useState(0);
   const [selectedRecording, setSelectedRecording] = useState<string | null>(
@@ -82,7 +89,7 @@ export default function PlayerProvider({
   // ADR-0010 chunk 2: pending end-of-show auto-advance. Held in refs so the
   // (non-React) audio `ended` handler can trigger the latest coordinator and so
   // the countdown can be canceled by any subsequent play.
-  const autoAdvanceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const autoAdvanceTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const onShowCompleteRef = useRef<((completedShowId: string) => void) | null>(null);
   const reportVolumeRef = useRef(reportVolume);
   const isActiveDeviceRef = useRef(false);
@@ -846,12 +853,13 @@ export default function PlayerProvider({
   const playShow = useCallback(
     async (show: ViewedShow) => {
       // A manual play cancels any pending auto-advance countdown. (When the
-      // countdown timer itself fires it nulls the ref before calling, so this
+      // countdown itself fires it clears the ref/state before calling, so this
       // is a no-op in that path.)
       if (autoAdvanceTimerRef.current) {
-        clearTimeout(autoAdvanceTimerRef.current);
+        clearInterval(autoAdvanceTimerRef.current);
         autoAdvanceTimerRef.current = null;
       }
+      setAutoAdvance(null);
       nextPlaybackSourceRef.current = "browse";
       setActiveShow(show);
       // Remember the cover so a page refresh (which rehydrates from the
@@ -928,18 +936,48 @@ export default function PlayerProvider({
         review: null,
       };
 
-      // 3. Cancelable countdown, then advance (== a user tap; remotes follow
-      //    via the sendLoad inside playShow).
-      if (autoAdvanceTimerRef.current) clearTimeout(autoAdvanceTimerRef.current);
-      console.info(`[auto-advance] next in ${AUTO_ADVANCE_DELAY_MS / 1000}s → ${viewed.showId}`);
-      autoAdvanceTimerRef.current = setTimeout(() => {
+      // 3. Cancelable countdown (ticks the UI each second), then advance (== a
+      //    user tap; remotes follow via the sendLoad inside playShow).
+      if (autoAdvanceTimerRef.current) clearInterval(autoAdvanceTimerRef.current);
+      let remaining = Math.round(AUTO_ADVANCE_DELAY_MS / 1000);
+      setAutoAdvance({ secondsRemaining: remaining, nextShow: viewed });
+      console.info(`[auto-advance] next in ${remaining}s → ${viewed.showId}`);
+      autoAdvanceTimerRef.current = setInterval(() => {
+        remaining -= 1;
+        if (remaining > 0) {
+          setAutoAdvance({ secondsRemaining: remaining, nextShow: viewed });
+          return;
+        }
+        if (autoAdvanceTimerRef.current) clearInterval(autoAdvanceTimerRef.current);
         autoAdvanceTimerRef.current = null;
+        setAutoAdvance(null);
         console.info(`[auto-advance] advancing → ${viewed.showId}`);
         playShow(viewed);
-      }, AUTO_ADVANCE_DELAY_MS);
+      }, 1000);
     },
     [playShow]
   );
+
+  // Cancel a pending auto-advance (user tapped Cancel). Leaves playback stopped.
+  const cancelAutoAdvance = useCallback(() => {
+    if (autoAdvanceTimerRef.current) {
+      clearInterval(autoAdvanceTimerRef.current);
+      autoAdvanceTimerRef.current = null;
+    }
+    setAutoAdvance(null);
+  }, []);
+
+  // Skip the countdown and play the next show immediately ("Play now").
+  const playNextNow = useCallback(() => {
+    const next = autoAdvance?.nextShow;
+    if (!next) return;
+    if (autoAdvanceTimerRef.current) {
+      clearInterval(autoAdvanceTimerRef.current);
+      autoAdvanceTimerRef.current = null;
+    }
+    setAutoAdvance(null);
+    playShow(next);
+  }, [autoAdvance, playShow]);
 
   useEffect(() => {
     onShowCompleteRef.current = onShowComplete;
@@ -1199,6 +1237,9 @@ export default function PlayerProvider({
       autoplayInfo,
       retryAutoplay,
       dismissAutoplay,
+      autoAdvance,
+      cancelAutoAdvance,
+      playNextNow,
     }),
     [
       activeShow,
@@ -1235,6 +1276,9 @@ export default function PlayerProvider({
       retryAutoplay,
       dismissAutoplay,
       updateViewedShow,
+      autoAdvance,
+      cancelAutoAdvance,
+      playNextNow,
     ]
   );
 

--- a/ui/src/components/player/PlayerProvider.tsx
+++ b/ui/src/components/player/PlayerProvider.tsx
@@ -788,6 +788,14 @@ export default function PlayerProvider({
       // load back (next version, by which point activeDeviceId === us).
       if (reclaim) return;
 
+      // Same rule for an end-of-show park: we "became active" only because we
+      // announced our OWN completion and the server claimed us active (ADR-0011).
+      // We're parked at the end of the show waiting for the note effect below to
+      // advance — our position is authoritative, the server's positionMs is the
+      // stale pre-end value. Syncing would seek back and replay the tail, re-firing
+      // completion and resetting the countdown. The note effect owns the transition.
+      if (connectState.pendingAdvance) return;
+
       // Track changed by a remote next/prev.
       if (connectState.trackIndex !== currentTrackIndexRef.current) {
         setCurrentTrackIndex(connectState.trackIndex);

--- a/ui/src/components/player/PlayerProvider.tsx
+++ b/ui/src/components/player/PlayerProvider.tsx
@@ -281,6 +281,13 @@ export default function PlayerProvider({
           sendCommandRef.current("next");
         } else {
           setStatus("paused");
+          // ADR-0010 Chunk 1: the final track finished on its own — the positive
+          // "show completed" signal. `ended` only fires on natural EOF (a user
+          // stop/pause doesn't fire it; load errors go to the "error" listener),
+          // and this is the last-track branch — so this is end-of-show, not a
+          // generic stop. The advance coordinator will hang off this point.
+          const completedShowId = activeShowRef.current?.showId ?? "";
+          console.info(`🏁 [SHOW-COMPLETE] onShowCompleted(showId=${completedShowId})`);
           // Last track finished on its own — no track change will drive the
           // playback_end, so emit the completed end here.
           const c = committedPlaybackRef.current;

--- a/ui/src/components/player/PlayerProvider.tsx
+++ b/ui/src/components/player/PlayerProvider.tsx
@@ -115,6 +115,11 @@ export default function PlayerProvider({
   // the countdown can be canceled by any subsequent play.
   const autoAdvanceTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const onShowCompleteRef = useRef<((completedShowId: string) => void) | null>(null);
+  // ADR-0010: true once real playback has happened this session. Guards the
+  // `ended` end-of-show signal against firing on restore/cold-start, when the
+  // player is rehydrated at the last track and the audio element can emit a
+  // spurious `ended` (mirrors Android's hasPlayedThisSession).
+  const hasPlayedThisSessionRef = useRef(false);
   const reportVolumeRef = useRef(reportVolume);
   const isActiveDeviceRef = useRef(false);
   const isRemoteControllingRef = useRef(false);
@@ -268,6 +273,7 @@ export default function PlayerProvider({
         (activeAudioRef.current === "B" && audio === audioBRef.current)
       ) {
         setStatus("playing");
+        hasPlayedThisSessionRef.current = true;
         retryCountRef.current = 0;
         setAutoplayBlocked(false);
         setAutoplayInfo(null);
@@ -321,12 +327,17 @@ export default function PlayerProvider({
           // ADR-0010 Chunk 1: the final track finished on its own — the positive
           // "show completed" signal. `ended` only fires on natural EOF (a user
           // stop/pause doesn't fire it; load errors go to the "error" listener),
-          // and this is the last-track branch — so this is end-of-show, not a
-          // generic stop. The advance coordinator will hang off this point.
+          // and this is the last-track branch. The `hasPlayedThisSession` guard
+          // rejects the restore/cold-start case (rehydrated at the last track,
+          // where the audio element can emit a spurious `ended` with no real
+          // playback) — without it, a hard refresh spuriously auto-advances.
           const completedShowId = activeShowRef.current?.showId ?? "";
-          console.info(`🏁 [SHOW-COMPLETE] onShowCompleted(showId=${completedShowId})`);
-          // ADR-0010 chunk 2: drive chronological auto-advance off this signal.
-          if (completedShowId) onShowCompleteRef.current?.(completedShowId);
+          if (completedShowId && hasPlayedThisSessionRef.current) {
+            hasPlayedThisSessionRef.current = false;
+            console.info(`🏁 [SHOW-COMPLETE] onShowCompleted(showId=${completedShowId})`);
+            // ADR-0010 chunk 2: drive chronological auto-advance off this signal.
+            onShowCompleteRef.current?.(completedShowId);
+          }
           // Last track finished on its own — no track change will drive the
           // playback_end, so emit the completed end here.
           const c = committedPlaybackRef.current;

--- a/ui/src/components/player/PlayerProvider.tsx
+++ b/ui/src/components/player/PlayerProvider.tsx
@@ -1008,6 +1008,12 @@ export default function PlayerProvider({
       }
       if (cancelled) return;
 
+      // Cache the next show's cover now, so when this (remote) device follows the
+      // advance its now-playing player can resolve the art (the active device
+      // caches it via playShow; remotes otherwise never would). No-op for
+      // ticket-less shows — the player's logo fallback handles those.
+      if (viewed.image) rememberArt(viewed.showId, viewed.image);
+
       const tick = () => {
         const serverNow = Date.now() + serverTimeOffsetMs;
         const remaining = Math.ceil((note.deadline - serverNow) / 1000);

--- a/ui/src/components/player/PlayerProvider.tsx
+++ b/ui/src/components/player/PlayerProvider.tsx
@@ -8,6 +8,7 @@ import { updatePlaybackPosition, addRecentShow } from "@/lib/userDataApi";
 import { notifyUserDataChanged } from "@/lib/userDataEvents";
 import { useAuth } from "@/contexts/AuthContext";
 import { rememberArt, lookupArt, rememberReview, lookupReview } from "@/lib/artCache";
+import { getAutoAdvanceEnabled } from "@/lib/playbackPrefs";
 import { PlayerContext } from "@/contexts/PlayerContext";
 import type { ViewedShow } from "@/contexts/PlayerContext";
 import { useConnect } from "@/contexts/ConnectContext";
@@ -936,6 +937,12 @@ export default function PlayerProvider({
   // to decide whether to advance.
   const onShowComplete = useCallback(
     async (completedShowId: string) => {
+      // ADR-0010 ship gate: per-device opt-out. Gates whether THIS device
+      // initiates an advance when it's the one playing (announce/countdown/advance).
+      if (!getAutoAdvanceEnabled()) {
+        console.info("[auto-advance] disabled by preference — not advancing");
+        return;
+      }
       // Resolve the next chronological show. The browser has no catalog (shows
       // are static SSG), so ask the API, which holds it in memory.
       let next: ShowMetaResponse;

--- a/ui/src/components/player/PlayerProvider.tsx
+++ b/ui/src/components/player/PlayerProvider.tsx
@@ -12,6 +12,7 @@ import { PlayerContext } from "@/contexts/PlayerContext";
 import type { ViewedShow } from "@/contexts/PlayerContext";
 import { useConnect } from "@/contexts/ConnectContext";
 
+const AUTO_ADVANCE_DELAY_MS = 15_000; // ADR-0010 chunk 2: end-of-show countdown
 const PREV_TRACK_THRESHOLD = 3; // seconds
 const AUDIO_RETRY_DELAYS = [0, 1000, 2000];
 const GAPLESS_PRELOAD_THRESHOLD = 2; // seconds before end to start preloading
@@ -78,6 +79,11 @@ export default function PlayerProvider({
   // Connect hydration so we resume at the server's interpolated position.
   const pendingSeekMsRef = useRef<number | null>(null);
   const sendCommandRef = useRef(sendCommand);
+  // ADR-0010 chunk 2: pending end-of-show auto-advance. Held in refs so the
+  // (non-React) audio `ended` handler can trigger the latest coordinator and so
+  // the countdown can be canceled by any subsequent play.
+  const autoAdvanceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onShowCompleteRef = useRef<((completedShowId: string) => void) | null>(null);
   const reportVolumeRef = useRef(reportVolume);
   const isActiveDeviceRef = useRef(false);
   const isRemoteControllingRef = useRef(false);
@@ -288,6 +294,8 @@ export default function PlayerProvider({
           // generic stop. The advance coordinator will hang off this point.
           const completedShowId = activeShowRef.current?.showId ?? "";
           console.info(`🏁 [SHOW-COMPLETE] onShowCompleted(showId=${completedShowId})`);
+          // ADR-0010 chunk 2: drive chronological auto-advance off this signal.
+          if (completedShowId) onShowCompleteRef.current?.(completedShowId);
           // Last track finished on its own — no track change will drive the
           // playback_end, so emit the completed end here.
           const c = committedPlaybackRef.current;
@@ -837,6 +845,13 @@ export default function PlayerProvider({
 
   const playShow = useCallback(
     async (show: ViewedShow) => {
+      // A manual play cancels any pending auto-advance countdown. (When the
+      // countdown timer itself fires it nulls the ref before calling, so this
+      // is a no-op in that path.)
+      if (autoAdvanceTimerRef.current) {
+        clearTimeout(autoAdvanceTimerRef.current);
+        autoAdvanceTimerRef.current = null;
+      }
       nextPlaybackSourceRef.current = "browse";
       setActiveShow(show);
       // Remember the cover so a page refresh (which rehydrates from the
@@ -870,6 +885,65 @@ export default function PlayerProvider({
     },
     [playRecording, sendCommand]
   );
+
+  // ADR-0010 chunk 2: chronological auto-advance. Driven solely by the end-of-show
+  // signal (the `ended` last-track branch); reads no transport state to decide.
+  // Park → countdown → playShow(next), whose output (local audio + sendLoad) is
+  // identical to a user tap, so remote Connect clients follow for free.
+  const onShowComplete = useCallback(
+    async (completedShowId: string) => {
+      // 1. Park: stop the server believing we're playing so it can't drag us
+      //    back during the countdown. No-op when not in a Connect session.
+      sendCommandRef.current("stop");
+
+      // 2. Resolve the next chronological show. The browser has no catalog
+      //    (shows are static SSG), so ask the API, which holds it in memory.
+      let next: {
+        showId: string;
+        date: string | null;
+        venue: string | null;
+        city: string | null;
+        state: string | null;
+        bestRecordingId: string | null;
+        image: string | null;
+      };
+      try {
+        const res = await fetch(`/api/shows/${encodeURIComponent(completedShowId)}/next`);
+        if (!res.ok) {
+          console.info("[auto-advance] no next show after", completedShowId);
+          return;
+        }
+        next = await res.json();
+      } catch {
+        return;
+      }
+      const viewed: ViewedShow = {
+        showId: next.showId,
+        recordings: [],
+        bestRecordingId: next.bestRecordingId,
+        date: next.date ?? "",
+        venue: next.venue ?? "",
+        location: [next.city, next.state].filter(Boolean).join(", "),
+        image: next.image,
+        review: null,
+      };
+
+      // 3. Cancelable countdown, then advance (== a user tap; remotes follow
+      //    via the sendLoad inside playShow).
+      if (autoAdvanceTimerRef.current) clearTimeout(autoAdvanceTimerRef.current);
+      console.info(`[auto-advance] next in ${AUTO_ADVANCE_DELAY_MS / 1000}s → ${viewed.showId}`);
+      autoAdvanceTimerRef.current = setTimeout(() => {
+        autoAdvanceTimerRef.current = null;
+        console.info(`[auto-advance] advancing → ${viewed.showId}`);
+        playShow(viewed);
+      }, AUTO_ADVANCE_DELAY_MS);
+    },
+    [playShow]
+  );
+
+  useEffect(() => {
+    onShowCompleteRef.current = onShowComplete;
+  }, [onShowComplete]);
 
   // Play a show then jump to a specific track once its tracks load. Matches by
   // title first (the stable identity of a favorite song), then by track number.

--- a/ui/src/components/player/PlayerProvider.tsx
+++ b/ui/src/components/player/PlayerProvider.tsx
@@ -13,6 +13,29 @@ import type { ViewedShow } from "@/contexts/PlayerContext";
 import { useConnect } from "@/contexts/ConnectContext";
 
 const AUTO_ADVANCE_DELAY_MS = 15_000; // ADR-0010 chunk 2: end-of-show countdown
+
+// The /api/shows[/:id|/:id/next] catalog shape → a playable ViewedShow.
+interface ShowMetaResponse {
+  showId: string;
+  date: string | null;
+  venue: string | null;
+  city: string | null;
+  state: string | null;
+  bestRecordingId: string | null;
+  image: string | null;
+}
+function metaToViewedShow(m: ShowMetaResponse): ViewedShow {
+  return {
+    showId: m.showId,
+    recordings: [],
+    bestRecordingId: m.bestRecordingId,
+    date: m.date ?? "",
+    venue: m.venue ?? "",
+    location: [m.city, m.state].filter(Boolean).join(", "),
+    image: m.image,
+    review: null,
+  };
+}
 const PREV_TRACK_THRESHOLD = 3; // seconds
 const AUDIO_RETRY_DELAYS = [0, 1000, 2000];
 const GAPLESS_PRELOAD_THRESHOLD = 2; // seconds before end to start preloading
@@ -27,6 +50,7 @@ export default function PlayerProvider({
   const {
     state: connectState,
     myDeviceId,
+    connected,
     sendCommand,
     onVolumeMessage,
     reportVolume,
@@ -894,27 +918,16 @@ export default function PlayerProvider({
     [playRecording, sendCommand]
   );
 
-  // ADR-0010 chunk 2: chronological auto-advance. Driven solely by the end-of-show
-  // signal (the `ended` last-track branch); reads no transport state to decide.
-  // Park → countdown → playShow(next), whose output (local audio + sendLoad) is
-  // identical to a user tap, so remote Connect clients follow for free.
+  // ADR-0010 chunk 2 / §7: end-of-show advance, driven by the `onShowComplete`
+  // signal. In a Connect session it `announce`s the next show + deadline so the
+  // shared note drives the countdown + advance on EVERY device (see the effect
+  // below). Offline it runs a purely local countdown. Reads no transport state
+  // to decide whether to advance.
   const onShowComplete = useCallback(
     async (completedShowId: string) => {
-      // 1. Park: stop the server believing we're playing so it can't drag us
-      //    back during the countdown. No-op when not in a Connect session.
-      sendCommandRef.current("stop");
-
-      // 2. Resolve the next chronological show. The browser has no catalog
-      //    (shows are static SSG), so ask the API, which holds it in memory.
-      let next: {
-        showId: string;
-        date: string | null;
-        venue: string | null;
-        city: string | null;
-        state: string | null;
-        bestRecordingId: string | null;
-        image: string | null;
-      };
+      // Resolve the next chronological show. The browser has no catalog (shows
+      // are static SSG), so ask the API, which holds it in memory.
+      let next: ShowMetaResponse;
       try {
         const res = await fetch(`/api/shows/${encodeURIComponent(completedShowId)}/next`);
         if (!res.ok) {
@@ -925,23 +938,23 @@ export default function PlayerProvider({
       } catch {
         return;
       }
-      const viewed: ViewedShow = {
-        showId: next.showId,
-        recordings: [],
-        bestRecordingId: next.bestRecordingId,
-        date: next.date ?? "",
-        venue: next.venue ?? "",
-        location: [next.city, next.state].filter(Boolean).join(", "),
-        image: next.image,
-        review: null,
-      };
 
-      // 3. Cancelable countdown (ticks the UI each second), then advance (== a
-      //    user tap; remotes follow via the sendLoad inside playShow).
+      if (connected) {
+        // In a session: announce. The server parks playback + sets the shared
+        // note; the effect below renders the countdown and (on the active
+        // device) advances at the deadline. Deadline is in SERVER time so every
+        // device ticks to the same instant.
+        const deadline = Date.now() + serverTimeOffsetMs + AUTO_ADVANCE_DELAY_MS;
+        console.info(`[auto-advance] announce → ${next.showId} @ ${deadline}`);
+        sendCommandRef.current("announce_next", { showId: next.showId, deadline });
+        return;
+      }
+
+      // Offline: local-only countdown, then advance.
+      const viewed = metaToViewedShow(next);
       if (autoAdvanceTimerRef.current) clearInterval(autoAdvanceTimerRef.current);
       let remaining = Math.round(AUTO_ADVANCE_DELAY_MS / 1000);
       setAutoAdvance({ secondsRemaining: remaining, nextShow: viewed });
-      console.info(`[auto-advance] next in ${remaining}s → ${viewed.showId}`);
       autoAdvanceTimerRef.current = setInterval(() => {
         remaining -= 1;
         if (remaining > 0) {
@@ -951,25 +964,85 @@ export default function PlayerProvider({
         if (autoAdvanceTimerRef.current) clearInterval(autoAdvanceTimerRef.current);
         autoAdvanceTimerRef.current = null;
         setAutoAdvance(null);
-        console.info(`[auto-advance] advancing → ${viewed.showId}`);
         playShow(viewed);
       }, 1000);
     },
-    [playShow]
+    [playShow, connected, serverTimeOffsetMs]
   );
 
-  // Cancel a pending auto-advance (user tapped Cancel). Leaves playback stopped.
+  // ADR-0010 §7: in a Connect session, the shared `pendingAdvance` note is the
+  // source of the countdown on EVERY device. Resolve the show, tick down to the
+  // server deadline locally, and — on the active device — advance when it's
+  // present and the deadline passes (uniform rule: cancel clears the note;
+  // "play now" moves the deadline to now). The active device advancing sends a
+  // load, which clears the note for everyone.
+  useEffect(() => {
+    if (!connected) return; // offline: the local driver above owns autoAdvance
+    const note = connectState?.pendingAdvance;
+    if (!note) {
+      setAutoAdvance(null);
+      return;
+    }
+
+    let cancelled = false;
+    let interval: ReturnType<typeof setInterval> | null = null;
+    (async () => {
+      let viewed: ViewedShow;
+      try {
+        const res = await fetch(`/api/shows/${encodeURIComponent(note.showId)}`);
+        if (!res.ok) return;
+        viewed = metaToViewedShow(await res.json());
+      } catch {
+        return;
+      }
+      if (cancelled) return;
+
+      const tick = () => {
+        const serverNow = Date.now() + serverTimeOffsetMs;
+        const remaining = Math.ceil((note.deadline - serverNow) / 1000);
+        if (remaining <= 0) {
+          if (interval) clearInterval(interval);
+          setAutoAdvance(null);
+          if (isActiveDeviceRef.current) playShow(viewed); // load clears the note
+          return;
+        }
+        setAutoAdvance({ secondsRemaining: remaining, nextShow: viewed });
+      };
+      tick();
+      interval = setInterval(tick, 1000);
+    })();
+
+    return () => {
+      cancelled = true;
+      if (interval) clearInterval(interval);
+    };
+  }, [
+    connected,
+    connectState?.pendingAdvance?.showId,
+    connectState?.pendingAdvance?.deadline,
+    serverTimeOffsetMs,
+    playShow,
+  ]);
+
+  // Cancel the pending advance. In a session, tell everyone (server clears the
+  // note); offline, just stop the local countdown.
   const cancelAutoAdvance = useCallback(() => {
     if (autoAdvanceTimerRef.current) {
       clearInterval(autoAdvanceTimerRef.current);
       autoAdvanceTimerRef.current = null;
     }
     setAutoAdvance(null);
-  }, []);
+    if (connected) sendCommandRef.current("cancel_advance");
+  }, [connected]);
 
-  // Skip the countdown and play the next show immediately ("Play now").
+  // "Play now". Active device (or offline) plays immediately — its load clears
+  // the note for everyone. A remote asks the active device to advance now.
   const playNextNow = useCallback(() => {
     const next = autoAdvance?.nextShow;
+    if (connected && !isActiveDevice) {
+      sendCommandRef.current("advance_now");
+      return;
+    }
     if (!next) return;
     if (autoAdvanceTimerRef.current) {
       clearInterval(autoAdvanceTimerRef.current);
@@ -977,7 +1050,7 @@ export default function PlayerProvider({
     }
     setAutoAdvance(null);
     playShow(next);
-  }, [autoAdvance, playShow]);
+  }, [autoAdvance, connected, isActiveDevice, playShow]);
 
   useEffect(() => {
     onShowCompleteRef.current = onShowComplete;

--- a/ui/src/components/player/PlayerProvider.tsx
+++ b/ui/src/components/player/PlayerProvider.tsx
@@ -765,7 +765,21 @@ export default function PlayerProvider({
         !reassertingTracksRef.current
       ) {
         reassertingTracksRef.current = true;
-        const idx = currentTrackIndexRef.current;
+        // This `load` only needs to backfill the `tracks` array the ownerless
+        // session lacked — it must NOT move the transport. Which cursor is
+        // authoritative depends on why we're reasserting:
+        //   • reclaim (server restarted while we kept playing locally) → LOCAL
+        //     is the truth; the server's restored index/position lag behind.
+        //   • fresh claim of an ownerless session (we just seek+play'd to take
+        //     it over) → the SERVER cursor is the truth; our local index is
+        //     stale because we were a remote and hadn't applied the seek yet.
+        //     Using local here clobbered the just-seeked track back to the old
+        //     one (tap Franklin's Tower, get the previously-cued track).
+        const idx = reclaim ? currentTrackIndexRef.current : connectState.trackIndex;
+        const loadIndex = idx >= 0 ? idx : 0;
+        const positionMs = reclaim
+          ? Math.round(audio.currentTime * 1000)
+          : connectState.positionMs;
         sendCommand("load", {
           showId: connectState.showId ?? activeShowRef.current?.showId ?? "",
           recordingId: connectState.recordingId,
@@ -773,13 +787,13 @@ export default function PlayerProvider({
             title: t.title,
             durationMs: Math.round((t.duration || 0) * 1000),
           })),
-          trackIndex: idx >= 0 ? idx : 0,
-          positionMs: Math.round(audio.currentTime * 1000),
-          durationMs: Math.round((localTracks[idx]?.duration ?? 0) * 1000),
+          trackIndex: loadIndex,
+          positionMs,
+          durationMs: Math.round((localTracks[loadIndex]?.duration ?? 0) * 1000),
           date: connectState.date ?? activeShowRef.current?.date,
           venue: connectState.venue ?? activeShowRef.current?.venue,
           location: connectState.location ?? activeShowRef.current?.location,
-          autoplay: !audio.paused,
+          autoplay: reclaim ? !audio.paused : connectState.playing,
         });
       }
 
@@ -796,15 +810,26 @@ export default function PlayerProvider({
       // completion and resetting the countdown. The note effect owns the transition.
       if (connectState.pendingAdvance) return;
 
-      // Track changed by a remote next/prev.
-      if (connectState.trackIndex !== currentTrackIndexRef.current) {
+      // Track changed by a remote next/prev/seek. The trackEffect (keyed on
+      // currentTrackIndex) fully owns loading + starting the NEW track — so we
+      // must NOT also touch the outgoing track here. The old code fell through
+      // and called audio.play() on the still-loaded previous track, then the
+      // trackEffect swapped src and played again — briefly starting the wrong
+      // track (an audible blip of the previous one) before the selected track
+      // loads. Sync the index and let the trackEffect take it from there.
+      const indexChanging = connectState.trackIndex !== currentTrackIndexRef.current;
+      if (indexChanging) {
+        // If the session is paused, tell the trackEffect to load without playing.
+        if (!connectState.playing) suppressAutoplayRef.current = true;
         setCurrentTrackIndex(connectState.trackIndex);
+        return;
       }
 
-      // Position changed by a remote seek or reconnect. Translate Date.now()
-      // into server-clock via serverTimeOffsetMs before subtracting positionTs —
-      // a skewed client clock otherwise jumps by the skew on every periodic
-      // broadcast and trips the guard below, causing audible skipping.
+      // Same track — reconcile position and play/pause on the already-loaded
+      // element. Translate Date.now() into server-clock via serverTimeOffsetMs
+      // before subtracting positionTs — a skewed client clock otherwise jumps by
+      // the skew on every periodic broadcast and trips the guard below, causing
+      // audible skipping.
       const interpolatedPosMs = connectState.playing
         ? connectState.positionMs + ((Date.now() + serverTimeOffsetMs) - connectState.positionTs)
         : connectState.positionMs;
@@ -1108,9 +1133,17 @@ export default function PlayerProvider({
     // Manual track selection — attribute the resulting playback_start.
     nextPlaybackSourceRef.current = "track_list";
     if (isRemoteControllingRef.current) {
-      // Remote: ask the server to move; our audio follows on the broadcast.
-      setPendingCommand("seek");
+      // Remote: move the shared cursor, then express the play-intent. A tap on a
+      // queue item means "play this track" — same as the Play button — but a bare
+      // `seek` only repositions: it never claims ownership or sets playing. On an
+      // ownerless session (activeDeviceId=null, e.g. all devices idle/ghosted)
+      // nobody acts on the seek, so it silently does nothing; on a paused active
+      // device the seek alone wouldn't resume. Following with `play` fixes both —
+      // handlePlay claims THIS device when the session is ownerless (and is a
+      // safe no-op when another device is already playing, so it never hijacks).
+      setPendingCommand("play");
       sendCommandRef.current("seek", { trackIndex: index, positionMs: 0, durationMs });
+      sendCommandRef.current("play");
       return;
     }
     // Reset gapless state since user is manually selecting

--- a/ui/src/components/shell/AppShell.tsx
+++ b/ui/src/components/shell/AppShell.tsx
@@ -28,6 +28,7 @@ import * as analytics from "@/lib/analytics";
 import UserMenu from "@/components/auth/UserMenu";
 import NotificationBell from "@/components/notifications/NotificationBell";
 import HeaderPlayerWrapper from "@/components/player/HeaderPlayerWrapper";
+import AutoAdvanceBanner from "@/components/player/AutoAdvanceBanner";
 import LibraryRail from "./LibraryRail";
 import MobileTabBar from "./MobileTabBar";
 import MobileBackButton from "./MobileBackButton";
@@ -105,6 +106,12 @@ function ShellChrome({ children }: { children: React.ReactNode }) {
             {rightNode}
           </div>
         )}
+      </div>
+
+      {/* End-of-show "Next up in Ns" announcement, docked just above the
+          transport. Renders only while a countdown is running. */}
+      <div className="flex-shrink-0">
+        <AutoAdvanceBanner />
       </div>
 
       {/* bottom transport — existing HeaderPlayer, do not fork. A fixed flex

--- a/ui/src/components/show/ShowArtwork.tsx
+++ b/ui/src/components/show/ShowArtwork.tsx
@@ -12,10 +12,17 @@ import { useState } from "react";
 export default function ShowArtwork({
   image,
   alt = "",
+  className = "h-14 w-14 flex-shrink-0 rounded-md bg-white/5 object-cover",
+  fallbackClassName,
 }: {
   image?: string | null;
   bestRecordingId?: string | null;
   alt?: string;
+  className?: string;
+  // Applied instead of `className` when the logo fallback is showing — lets
+  // callers contain the natural ticket but square-crop the logo (as the
+  // fullscreen player does).
+  fallbackClassName?: string;
 }) {
   const sources = [image].filter(Boolean) as string[];
 
@@ -28,14 +35,12 @@ export default function ShowArtwork({
     <img
       src={src}
       alt={alt}
-      width={56}
-      height={56}
       loading="lazy"
       referrerPolicy="no-referrer"
       onError={() => {
         if (idx < sources.length) setIdx((i) => i + 1);
       }}
-      className="h-14 w-14 flex-shrink-0 rounded-md bg-white/5 object-cover"
+      className={showingFallback ? (fallbackClassName ?? className) : className}
     />
   );
 }

--- a/ui/src/contexts/PlayerContext.ts
+++ b/ui/src/contexts/PlayerContext.ts
@@ -75,6 +75,13 @@ export interface PlayerContextValue {
   autoplayInfo: { showDate: string; venue: string; fromDevice: string } | null;
   retryAutoplay: () => void;
   dismissAutoplay: () => void;
+
+  // End-of-show auto-advance (ADR-0010). Non-null while the countdown to the
+  // next show is running; nextShow carries its display data so the full player
+  // can preview it under a "Next up in Ns" banner.
+  autoAdvance: { secondsRemaining: number; nextShow: ViewedShow } | null;
+  cancelAutoAdvance: () => void;
+  playNextNow: () => void;
 }
 
 export const PlayerContext = createContext<PlayerContextValue | null>(null);

--- a/ui/src/lib/playbackPrefs.ts
+++ b/ui/src/lib/playbackPrefs.ts
@@ -1,0 +1,16 @@
+// ADR-0010: client-local playback preferences (parity with mobile AppPreferences).
+// Web has no preferences store, so these live in localStorage under `deadly_*`
+// keys, like volume. Read directly — no context wiring needed.
+
+const AUTO_ADVANCE_KEY = "deadly_auto_advance";
+
+/** Roll into the next show when one ends. On by default (missing = enabled). */
+export function getAutoAdvanceEnabled(): boolean {
+  if (typeof window === "undefined") return true;
+  return localStorage.getItem(AUTO_ADVANCE_KEY) !== "false";
+}
+
+export function setAutoAdvanceEnabled(value: boolean): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(AUTO_ADVANCE_KEY, value ? "true" : "false");
+}

--- a/ui/src/types/connect.ts
+++ b/ui/src/types/connect.ts
@@ -29,4 +29,6 @@ export interface ConnectState {
   date: string | null;
   venue: string | null;
   location: string | null;
+  // ADR-0010 §7: shared end-of-show countdown. Optional/additive.
+  pendingAdvance?: { showId: string; deadline: number } | null;
 }


### PR DESCRIPTION
## Summary

Ships the community's #1 ask — **end-of-show auto-advance** ("play the next show automatically") — across all three platforms, with a cross-device countdown over Connect and a full-screen "Up Next" takeover. Design in [ADR-0010](docs/adr/0010-playback-auto-advance-and-show-queue.md); plan in [PLANS/show-queue-v2.md](PLANS/show-queue-v2.md).

This is the **auto-advance** slice of show-queue-v2. The queue-of-shows and shuffle layers (ROADMAP §1) and the ADR-0011 ownership lease are **follow-ups**, not in this PR.

## What's included

**Auto-advance mechanism (iOS + Android + web), verified on-device:**
- Natural end-of-show detection (`onShowCompleted`) — fires only on a real end-of-show, silent on pause/stop/skip and on cold-start restore (chunk 1).
- Chronological advance to the next show by date via an independent coordinator that reads no transport state (chunk 2). Built on a canonical `playShow`.
- Cross-device **countdown over Connect** (ADR-0010 §7 / Phase B): a shared `pendingAdvance` note + explicit `announce_next` / `cancel_advance` / `advance_now`; remotes tick locally to the deadline; Cancel and Play-now work from any device.
- Full-screen **"Up Next" takeover** while the countdown runs and the player is open (next-show cover, date/venue/location, "UP NEXT IN Ns", Play now / Cancel) — web `HeaderPlayer`, Android + iOS `AutoAdvanceTakeover`. Docked card everywhere else.
- Per-device **"When a show ends"** setting (default ON) gating whether *this* device initiates an advance, with analytics.

**Connect robustness fixes (ADR-0011 territory, shipped here as fixes):**
- Server claims the announcing device active when the session is ownerless (`handleAnnounceNext` claim-when-null) — rescues auto-advance after a server restart leaves a ghost active device.
- Don't transport-sync a device parked for end-of-show advance (avoids a seek-back that replays the tail and resets the countdown).
- Web: queue taps on an ownerless session now play and keep the tapped track.

## Not in this PR (follow-ups)
- **ADR-0011** ownership lease + `protocolVersion` — the convergent fix that retires the reactive reclaim heuristics. Will be its own focused PR on top of this. (The claim-when-null fix above already mitigates the user-facing failure.)
- Queue-of-shows and shuffle (ROADMAP §1).

## Known issues (non-blocking)
- **Intermittent iOS spurious `next`:** seen once, not reproduced — advance lands on track 0, then a stray `next` jumps to "Track 2". Suspected `onTrackComplete`/reconnect race; needs a repro before fixing.
- **Play/pause affordance polish:** iOS miniplayer icon can stick on "play" through buffering; minor.

## Notes for review
- 31 commits, +2526/−30 across api + web + iOS + Android + docs.
- **Squash-merge:** the PR title is the conventional-commit message `release.sh` will use for changelogs (`feat(all/player)` → all platforms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
