### PR TITLE
feat(all/connect): session ownership lease + WS protocol versioning (ADR-0011)

### DIFF
--- a/PLANS/connect-ownership-lease.md
+++ b/PLANS/connect-ownership-lease.md
@@ -81,5 +81,17 @@ Once B is proven on all three platforms and telemetry shows the fleet on
 
 ## Status
 2026-06-11: **ADR-0011 accepted (design); server claim-when-null shipped
-(`52942d45`). Chunks A–C not started.** Ship Chunk A (protocol versioning) ASAP —
-it has standalone value (telemetry + forced-update lever) independent of the lease.
+(`52942d45`).**
+- **Chunk A — DONE** (`4564d2d4`, `feat(all/connect)`): `protocolVersion`(=1) +
+  `appVersion` on register, stamped onto the in-memory `liveDevices` record, with
+  per-session protocol-distribution telemetry. `docs/PROTOCOL.md` added.
+- **Chunk B — code-complete, built on all 3 platforms + server, NOT yet
+  device-verified.** Heartbeat carries `{playing, recordingId, positionMs}` when
+  audio is loaded locally; `handleHeartbeat` claims an ownerless session
+  (`activeDeviceId == null`, requires `playing`, recordingId must match the
+  session) and never preempts an existing owner. Gated on `protocolVersion >= 1`.
+  **Outstanding: run the exit-criterion test** — play through an API restart →
+  next heartbeat reconverges `activeDeviceId` → end-of-show advance fires; plus the
+  disconnect-reconnect variant.
+- **Chunk C — not started.** Gated on Chunk B device-verification + telemetry
+  showing the fleet on `protocolVersion >= 1`.

--- a/PLANS/connect-ownership-lease.md
+++ b/PLANS/connect-ownership-lease.md
@@ -93,5 +93,19 @@ Once B is proven on all three platforms and telemetry shows the fleet on
   **Outstanding: run the exit-criterion test** — play through an API restart →
   next heartbeat reconverges `activeDeviceId` → end-of-show advance fires; plus the
   disconnect-reconnect variant.
-- **Chunk C — not started.** Gated on Chunk B device-verification + telemetry
-  showing the fleet on `protocolVersion >= 1`.
+- **Chunk C — code-complete, built on all 3 platforms, NOT yet device-verified.**
+  Deleted the epoch-change reclaim (`lastEpoch`/`serverRestarted`) on iOS/Android/
+  web. Reconcile now honors "the device producing audio is the transport authority":
+  ownerless session + still playing our recording ⇒ keep playing, let the lease
+  reclaim (no pause-on-null, no self-claim via `load`). The empty-tracks re-send is
+  kept but decoupled — it hydrates tracks with `autoplay=false` so it restores the
+  tracklist WITHOUT claiming ownership (the lease owns that). This removes the
+  masking that hid the lease, so a restart/blip on a new build now produces
+  `handleHeartbeat: lease claim`. Kept deliberately: the `playWhenReady`
+  `if (!isActive) return` gate (removing it risks a follower pushing pause onto the
+  active session; the lease doesn't need it gone) and the `justBecameActive &&
+  pendingAdvance == null` guard (still protects the announce-park seek-back, and is
+  safe now because the lease seeds the server with our own position on claim).
+  **Outstanding: device test — new build, play → restart server (or network blip) →
+  device keeps playing → next heartbeat → `lease claim` → advance fires; and a real
+  takeover by another device still pauses the loser (no double-play).**

--- a/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
+++ b/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
@@ -106,12 +106,14 @@ class ConnectServiceImpl @Inject constructor(
     // forgets it (e.g. a server restart rehydrates the session position-only).
     private var cachedTracks: List<ConnectSessionTrack> = emptyList()
     private var cachedTracksRecordingId: String? = null
-    // Guards the one-shot re-assert so position broadcasts arriving before our
-    // load echoes back don't make us re-send it repeatedly.
+    // Guards the one-shot tracklist re-hydration so position broadcasts arriving
+    // before our load echoes back don't make us re-send it repeatedly.
     private var reassertingTracks = false
-    // Last server epoch seen. A change means the server restarted (and rehydrated
-    // the session), which is the only situation a still-playing device reclaims.
-    @Volatile private var lastEpoch: Long? = null
+    // True from a (re)connect until the server next assigns an owner. Distinguishes
+    // an ownerless GHOST (server lost us across a restart/socket drop — reclaim) from
+    // a deliberate PARK (transfer/stop on a live socket — pause). Only the ghost
+    // arrives right after a reconnect; a park arrives mid-connection.
+    @Volatile private var reclaimOnReconnect = false
 
     private val _pendingTransfer = MutableStateFlow<String?>(null)
     override val pendingTransfer: StateFlow<String?> = _pendingTransfer.asStateFlow()
@@ -305,6 +307,9 @@ class ConnectServiceImpl @Inject constructor(
             // snapshot after connecting is authoritative regardless of version.
             // (-1 so the server's lowest possible version, 0, is still accepted.)
             currentVersion = -1L
+            // Arm ghost-reclaim: a null active device in the first state(s) after
+            // this (re)connect is a ghost to heal (lease), not a deliberate park.
+            reclaimOnReconnect = true
             sendRegister(webSocket)
             startHeartbeat(webSocket)
             startTimeSyncRefresh(webSocket)
@@ -564,25 +569,26 @@ class ConnectServiceImpl @Inject constructor(
         val localRecordingId = mediaControllerRepository.currentRecordingId.value
         val locallyPlaying = mediaControllerRepository.isPlaying.value
 
-        // Did the server restart? An epoch change is the explicit, authoritative
-        // signal (vs. inferring it from null-active + empty-tracks coincidences).
-        val serverRestarted = lastEpoch != null && new.epoch != lastEpoch
-        lastEpoch = new.epoch
-
-        // Reclaim only when the server restarted and rehydrated the session (so it
-        // has no active device) while we're still playing this recording — take
-        // ownership back without a gap. reassertingTracks keeps us in this mode
-        // while our reclaim load is in flight (epoch is unchanged on later states).
-        // A deliberate transition (transfer park, stop) keeps the same epoch, so
-        // it is never mistaken for a restart.
-        val reclaimAfterRestart = new.activeDeviceId == null &&
+        // ADR-0011 Chunk C: the device producing audio is the transport authority.
+        // When the session is ownerless (server forgot the active device across a
+        // restart/socket drop) and we're still playing this recording, KEEP PLAYING
+        // and let the heartbeat ownership lease reclaim us server-side. Gated on
+        // reclaimOnReconnect so a deliberate PARK (transfer/stop, which nulls active
+        // on our LIVE socket) is NOT mistaken for a ghost — only a post-reconnect
+        // null active is a ghost. Cause-agnostic (restart + disconnect both reconnect).
+        val reclaimOwnerless = new.activeDeviceId == null &&
             locallyPlaying && localRecordingId == new.recordingId &&
-            (serverRestarted || reassertingTracks)
+            reclaimOnReconnect
+        // Once the server assigns an owner (us via the lease, or another device), the
+        // post-reconnect ghost window is over: any later activeDevice=null is then a
+        // deliberate park we must pause for, not reclaim.
+        if (new.activeDeviceId != null) reclaimOnReconnect = false
 
         // If this device was active but is no longer — a different device took
         // over, or we were parked during a transfer — pause and report final
-        // position. Skipped on a reclaim, where we keep playing and re-assert.
-        if (wasActive && !nowActive && !reclaimAfterRestart) {
+        // position. Skipped when the session went ownerless (reclaimOwnerless): a
+        // null active device is a ghost we heal by holding the lease, not a takeover.
+        if (wasActive && !nowActive && !reclaimOwnerless) {
             val positionMs = mediaControllerRepository.currentPosition.value.toInt()
             Log.d(TAG, "reactToState: parked/transferred away — pausing and reporting position ${positionMs}ms")
             mediaControllerRepository.pause()
@@ -621,8 +627,9 @@ class ConnectServiceImpl @Inject constructor(
         // Compare against the LOCAL track index (not old server state) so the
         // very first snapshot (old == null) still aligns — e.g. when the app
         // just restored the same recording at a different track on startup.
-        // Skipped while reclaiming: we keep playing and re-assert below instead.
-        if (!isActive && !reclaimAfterRestart) {
+        // Skipped when we're the ownerless ghost: we keep playing and let the
+        // lease reclaim us (and hydrate tracks below) instead of pausing.
+        if (!isActive && !reclaimOwnerless) {
             reassertingTracks = false
             val localTrackIndex = mediaControllerRepository.currentTrackIndex.value
             if (new.trackIndex != localTrackIndex) {
@@ -639,15 +646,17 @@ class ConnectServiceImpl @Inject constructor(
             return
         }
 
-        // Server forgot our tracklist (it restarted and rehydrated the session
-        // from the saved position only). We still hold it — re-assert the load so
-        // viewers' display and the server's next/prev get the tracks back.
-        // handleLoad keeps us active and honors the index/position we pass.
+        // Server forgot our tracklist (a restart rehydrated the session from the
+        // saved position only). We still hold it — re-send the load so viewers'
+        // display and the server's next/prev get the tracks back. This hydrates
+        // TRACKS ONLY: autoplay=false when we're the ownerless ghost, so the load
+        // does NOT claim ownership — the heartbeat lease does that. (When we're
+        // already active, autoplay tracks our real playing state.)
         if (new.tracks.isEmpty() && cachedTracks.isNotEmpty() &&
             cachedTracksRecordingId == new.recordingId && !reassertingTracks) {
             reassertingTracks = true
             val idx = mediaControllerRepository.currentTrackIndex.value
-            Log.d(TAG, "reactToState: server tracks empty — re-asserting load (${cachedTracks.size} tracks, idx=$idx)")
+            Log.d(TAG, "reactToState: server tracks empty — hydrating tracklist (${cachedTracks.size} tracks, idx=$idx, active=$nowActive)")
             sendLoad(
                 showId = new.showId ?: mediaControllerRepository.currentShowId.value ?: "",
                 recordingId = new.recordingId ?: cachedTracksRecordingId ?: "",
@@ -658,15 +667,15 @@ class ConnectServiceImpl @Inject constructor(
                 date = new.date,
                 venue = new.venue,
                 location = new.location,
-                autoplay = mediaControllerRepository.isPlaying.value,
+                autoplay = nowActive && mediaControllerRepository.isPlaying.value,
             )
         }
 
-        // On a reclaim we are the source of truth: don't sync transport down to
-        // the stale playing:false / saved position. The server echoes our
-        // re-asserted load back on the next version (activeDeviceId == us), and
+        // Ownerless ghost: we are the transport authority — don't sync transport
+        // down to the stale playing:false / saved position. Keep playing; the lease
+        // claims us within a heartbeat, the server echoes activeDeviceId == us, and
         // normal active-device sync resumes from there.
-        if (reclaimAfterRestart) return
+        if (reclaimOwnerless) return
 
         // When this device just became active (e.g. transfer in), sync local player
         // to server state — the local player may be at a completely different track/position.

--- a/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
+++ b/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
@@ -50,10 +50,14 @@ class ConnectServiceImpl @Inject constructor(
     private val mediaControllerRepository: MediaControllerRepository,
     private val networkMonitor: NetworkMonitor,
     private val showRepository: com.grateful.deadly.core.domain.repository.ShowRepository,
+    @javax.inject.Named("appVersionName") private val appVersion: String,
 ) : ConnectService {
 
     companion object {
         private const val TAG = "ConnectService"
+        // Connect WS wire-contract version. See docs/PROTOCOL.md for semantics.
+        // Bump in lockstep with the documented protocol; the server may branch on it.
+        private const val CONNECT_PROTOCOL_VERSION = 1
         private val RECONNECT_DELAYS_S = listOf(1L, 2L, 4L, 8L, 30L)
         private const val HEARTBEAT_INTERVAL_MS = 15_000L
         private const val CLOSE_CODE_UNAUTHORIZED = 4003
@@ -328,6 +332,10 @@ class ConnectServiceImpl @Inject constructor(
             put("deviceId", appPreferences.installId)
             put("deviceType", "android")
             put("deviceName", Build.MODEL)
+            // ADR-0011 §3 / docs/PROTOCOL.md: wire-contract version the server may
+            // branch on; appVersion is build identity for telemetry only.
+            put("protocolVersion", CONNECT_PROTOCOL_VERSION)
+            put("appVersion", appVersion)
         }
         ws.send(msg.toString())
     }

--- a/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
+++ b/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
@@ -345,9 +345,25 @@ class ConnectServiceImpl @Inject constructor(
         heartbeatJob = scope.launch {
             while (isActive) {
                 delay(HEARTBEAT_INTERVAL_MS)
-                if (isActive) ws.send("""{"type":"heartbeat"}""")
+                if (isActive) ws.send(buildHeartbeat())
             }
         }
+    }
+
+    // ADR-0011 Chunk B: renew the ownership lease. When this device has audio
+    // loaded locally, piggyback {playing, recordingId, positionMs} so the server
+    // can heal an ownerless session from our heartbeat (the restart/disconnect
+    // "ghost" fix). Plain heartbeat when nothing is loaded (we're not a candidate
+    // owner). See docs/PROTOCOL.md.
+    private fun buildHeartbeat(): String {
+        val recordingId = mediaControllerRepository.currentRecordingId.value
+            ?: return """{"type":"heartbeat"}"""
+        return buildJsonObject {
+            put("type", "heartbeat")
+            put("playing", mediaControllerRepository.isPlaying.value)
+            put("recordingId", recordingId)
+            put("positionMs", mediaControllerRepository.currentPosition.value.toInt())
+        }.toString()
     }
 
     private fun stopHeartbeat() {

--- a/api/src/connect/__tests__/state.lease.test.ts
+++ b/api/src/connect/__tests__/state.lease.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// state.ts persists position to SQLite; stub it out so these are pure
+// in-memory state-machine tests.
+vi.mock("../../db/userdata.js", () => ({
+  getPlaybackPosition: vi.fn(() => null),
+  upsertPlaybackPosition: vi.fn(),
+}));
+
+const {
+  registerDevice,
+  handleLoad,
+  handleHeartbeat,
+  getOrCreateState,
+} = await import("../state.js");
+
+// Minimal WebSocket stand-in: OPEN so broadcasts don't warn, send/close noop.
+function fakeSocket() {
+  return { readyState: 1, OPEN: 1, send: vi.fn(), close: vi.fn() } as never;
+}
+
+const TRACKS = [
+  { title: "Track 1", durationMs: 600_000 },
+  { title: "Track 2", durationMs: 600_000 },
+];
+
+let seq = 0;
+// Module-level maps persist across tests; unique ids keep each test isolated.
+function freshUser() {
+  seq += 1;
+  return { userId: `u-${seq}`, deviceId: `d-${seq}` };
+}
+
+// Register a device + load rec1 WITHOUT autoplay → session has a recording but
+// activeDeviceId stays null. That's exactly the ownerless "ghost" the lease heals.
+function ownerlessSession(proto = 1) {
+  const { userId, deviceId } = freshUser();
+  const socket = fakeSocket();
+  registerDevice(userId, deviceId, "web", "Web", socket, proto, "1.0.0");
+  handleLoad(userId, deviceId, socket, {
+    showId: "s1",
+    recordingId: "rec1",
+    tracks: TRACKS,
+    trackIndex: 0,
+    positionMs: 0,
+    durationMs: 600_000,
+  });
+  return { userId, deviceId, socket };
+}
+
+describe("handleHeartbeat ownership lease (ADR-0011 Chunk B)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("claims an ownerless session when the heartbeat is playing + recording matches", () => {
+    const { userId, deviceId } = ownerlessSession();
+    expect(getOrCreateState(userId).activeDeviceId).toBeNull();
+
+    handleHeartbeat(userId, deviceId, { playing: true, recordingId: "rec1", positionMs: 5_000 });
+
+    const s = getOrCreateState(userId);
+    expect(s.activeDeviceId).toBe(deviceId);
+    expect(s.playing).toBe(true);
+    expect(s.positionMs).toBe(5_000); // position taken from the lease
+  });
+
+  it("does NOT claim when the lease is paused (parked/transferred-away device)", () => {
+    const { userId, deviceId } = ownerlessSession();
+    handleHeartbeat(userId, deviceId, { playing: false, recordingId: "rec1", positionMs: 5_000 });
+    expect(getOrCreateState(userId).activeDeviceId).toBeNull();
+  });
+
+  it("does NOT claim when the lease recording differs from the session", () => {
+    const { userId, deviceId } = ownerlessSession();
+    handleHeartbeat(userId, deviceId, { playing: true, recordingId: "OTHER", positionMs: 5_000 });
+    expect(getOrCreateState(userId).activeDeviceId).toBeNull();
+  });
+
+  it("ignores a legacy heartbeat with no lease payload", () => {
+    const { userId, deviceId } = ownerlessSession();
+    handleHeartbeat(userId, deviceId); // bare heartbeat
+    expect(getOrCreateState(userId).activeDeviceId).toBeNull();
+  });
+
+  it("does NOT claim from a protocolVersion 0 (legacy) connection even with a lease", () => {
+    const { userId, deviceId } = ownerlessSession(0);
+    handleHeartbeat(userId, deviceId, { playing: true, recordingId: "rec1", positionMs: 5_000 });
+    expect(getOrCreateState(userId).activeDeviceId).toBeNull();
+  });
+
+  it("never preempts a device that already owns the session (claim-when-null only)", () => {
+    const { userId, deviceId: a } = freshUser();
+    const socketA = fakeSocket();
+    registerDevice(userId, a, "web", "Web A", socketA, 1, "1.0.0");
+    // A loads WITH autoplay → A is the active, playing owner.
+    handleLoad(userId, a, socketA, {
+      showId: "s1",
+      recordingId: "rec1",
+      tracks: TRACKS,
+      trackIndex: 0,
+      positionMs: 0,
+      durationMs: 600_000,
+      autoplay: true,
+    });
+    expect(getOrCreateState(userId).activeDeviceId).toBe(a);
+
+    // B connects and leases the same recording while playing — must back off.
+    const b = `${a}-b`;
+    registerDevice(userId, b, "ios", "Phone B", fakeSocket(), 1, "1.0.0");
+    handleHeartbeat(userId, b, { playing: true, recordingId: "rec1", positionMs: 9_999 });
+
+    const s = getOrCreateState(userId);
+    expect(s.activeDeviceId).toBe(a); // unchanged — never preempted
+    expect(s.positionMs).not.toBe(9_999);
+  });
+
+  it("refreshing as the existing owner leaves ownership intact", () => {
+    const { userId, deviceId } = ownerlessSession();
+    // First heartbeat claims the vacuum.
+    handleHeartbeat(userId, deviceId, { playing: true, recordingId: "rec1", positionMs: 5_000 });
+    const versionAfterClaim = getOrCreateState(userId).version;
+    // Owner re-heartbeats → no ownership change, no extra broadcast/mutate.
+    handleHeartbeat(userId, deviceId, { playing: true, recordingId: "rec1", positionMs: 6_000 });
+    const s = getOrCreateState(userId);
+    expect(s.activeDeviceId).toBe(deviceId);
+    expect(s.version).toBe(versionAfterClaim); // refresh didn't mutate/broadcast
+  });
+});

--- a/api/src/connect/routes.ts
+++ b/api/src/connect/routes.ts
@@ -68,7 +68,16 @@ export async function connectRoutes(app: FastifyInstance): Promise<void> {
 
         case "heartbeat": {
           if (!registeredDeviceId) return;
-          handleHeartbeat(userId!, registeredDeviceId);
+          // ADR-0011 Chunk B: optional ownership-lease payload. Present only when
+          // the client has audio loaded locally (it carries recordingId).
+          const lease = typeof msg.recordingId === "string"
+            ? {
+                playing: msg.playing === true,
+                recordingId: msg.recordingId,
+                positionMs: typeof msg.positionMs === "number" ? msg.positionMs : 0,
+              }
+            : undefined;
+          handleHeartbeat(userId!, registeredDeviceId, lease);
           break;
         }
 

--- a/api/src/connect/routes.ts
+++ b/api/src/connect/routes.ts
@@ -59,7 +59,10 @@ export async function connectRoutes(app: FastifyInstance): Promise<void> {
         case "register": {
           if (!msg.deviceId || !msg.deviceType || !msg.deviceName) return;
           registeredDeviceId = msg.deviceId;
-          registerDevice(userId!, msg.deviceId, msg.deviceType as DeviceType, msg.deviceName, socket);
+          // ADR-0011 §3: additive, optional. Absent ⇒ legacy ⇒ 0.
+          const protocolVersion = typeof msg.protocolVersion === "number" ? msg.protocolVersion : 0;
+          const appVersion = typeof msg.appVersion === "string" ? msg.appVersion : null;
+          registerDevice(userId!, msg.deviceId, msg.deviceType as DeviceType, msg.deviceName, socket, protocolVersion, appVersion);
           break;
         }
 

--- a/api/src/connect/state.ts
+++ b/api/src/connect/state.ts
@@ -288,6 +288,11 @@ export function handleHeartbeat(userId: string, deviceId: string, lease?: LeaseR
   // held, so nothing to broadcast. (A paused owner keeps the lease — ADR §2.)
   if (state.activeDeviceId === deviceId) return;
 
+  // A transfer is mid-flight for this user (the server parked the source and is
+  // about to activate the target — activeDeviceId is transiently null). Don't let
+  // the source's lease re-claim the parked session and fight the handoff.
+  if (pendingTransfers.has(userId)) return;
+
   // Vacuum claim: only a device actually producing audio (playing) fills an
   // ownerless session. Requiring `playing` disambiguates a parked-but-still-
   // loaded device (playing=false, e.g. transferred away) from the real source,

--- a/api/src/connect/state.ts
+++ b/api/src/connect/state.ts
@@ -1,5 +1,6 @@
 import type { WebSocket } from "ws";
 import type { ConnectState, ConnectDevice, DeviceType, SessionTrack } from "./types.js";
+import { LEGACY_PROTOCOL_VERSION } from "./types.js";
 import { upsertPlaybackPosition, getPlaybackPosition } from "../db/userdata.js";
 
 const log = (msg: string) => console.log(`[Connect] ${msg}`);
@@ -12,6 +13,12 @@ const SERVER_EPOCH = Date.now();
 interface LiveDevice {
   device: ConnectDevice;
   socket: WebSocket;
+  // Per-CONNECTION facts (ADR-0011 §3). Same lifetime as the socket: stamped on
+  // `register`, valid until close, re-sent on every reconnect (self-refreshing,
+  // never persisted). `protocolVersion` is the wire contract the server may
+  // branch on; `appVersion` is build identity for telemetry only.
+  protocolVersion: number;
+  appVersion: string | null;
 }
 
 // userId -> ConnectState
@@ -172,6 +179,8 @@ export function registerDevice(
   type: DeviceType,
   name: string,
   socket: WebSocket,
+  protocolVersion: number = LEGACY_PROTOCOL_VERSION,
+  appVersion: string | null = null,
 ): void {
   const key = deviceKey(userId, deviceId);
 
@@ -189,12 +198,32 @@ export function registerDevice(
     lastHeartbeat: Date.now(),
   };
 
-  liveDevices.set(key, { device, socket });
+  liveDevices.set(key, { device, socket, protocolVersion, appVersion });
 
   const state = getOrCreateState(userId);
-  log(`registerDevice: ${name}[${type}] (${deviceId}) — sending state v${state.version} show=${state.showId} rec=${state.recordingId} track=${state.trackIndex}/${state.tracks.length} pos=${state.positionMs} playing=${state.playing}`);
+  log(`registerDevice: ${name}[${type}] (${deviceId}) proto=${protocolVersion} app=${appVersion ?? "?"} — sending state v${state.version} show=${state.showId} rec=${state.recordingId} track=${state.trackIndex}/${state.tracks.length} pos=${state.positionMs} playing=${state.playing}`);
+  logProtocolDistribution(userId);
   sendJson(socket, { type: "state", state });
   broadcastDevices(userId);
+}
+
+// Telemetry (ADR-0011 §3, Chunk A): per-session distribution of the connected
+// devices' protocol/app versions. This is what licenses retiring a legacy
+// branch / advancing MIN_SUPPORTED later — on evidence, not hope.
+function logProtocolDistribution(userId: string): void {
+  const byProto = new Map<number, string[]>();
+  for (const [k, entry] of liveDevices) {
+    if (!k.startsWith(`${userId}:`)) continue;
+    const tag = `${entry.device.type}${entry.appVersion ? `@${entry.appVersion}` : ""}`;
+    const list = byProto.get(entry.protocolVersion) ?? [];
+    list.push(tag);
+    byProto.set(entry.protocolVersion, list);
+  }
+  const dist = [...byProto.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([proto, tags]) => `proto${proto}×${tags.length}[${tags.join(",")}]`)
+    .join(" ");
+  log(`protocolDistribution: ${userId} — ${dist}`);
 }
 
 export function unregisterDevice(userId: string, deviceId: string): void {

--- a/api/src/connect/state.ts
+++ b/api/src/connect/state.ts
@@ -259,11 +259,56 @@ export function unregisterDevice(userId: string, deviceId: string): void {
   broadcastDevices(userId);
 }
 
-export function handleHeartbeat(userId: string, deviceId: string): void {
+export interface LeaseRenewal {
+  playing: boolean;
+  recordingId: string;
+  positionMs: number;
+}
+
+export function handleHeartbeat(userId: string, deviceId: string, lease?: LeaseRenewal): void {
   const entry = liveDevices.get(deviceKey(userId, deviceId));
-  if (entry) {
-    entry.device.lastHeartbeat = Date.now();
+  if (!entry) return;
+  entry.device.lastHeartbeat = Date.now();
+
+  // ── ADR-0011 Chunk B: ownership lease ──────────────────────────────────────
+  // The audio-producing device heals an ownerless session by claiming it on its
+  // heartbeat. This is the convergent recovery for the restart/disconnect
+  // "ghost" — server believes activeDeviceId == null while a device is in fact
+  // still playing — replacing the cause-specific client reclaim heuristics
+  // (those stay until Chunk C proves the lease covers them). Conservative rule
+  // (ADR §2): the renewal FILLS A VACUUM, it never preempts an existing owner.
+  if (!lease) return;                       // legacy heartbeat — no lease payload
+  if (entry.protocolVersion < 1) return;    // gated on the Chunk A primitive
+
+  const state = userStates.get(userId);
+  if (!state || !state.recordingId) return;          // no session to heal
+  if (lease.recordingId !== state.recordingId) return; // device is on a different recording
+
+  // Owner: its lease renews implicitly via lastHeartbeat above; ownership already
+  // held, so nothing to broadcast. (A paused owner keeps the lease — ADR §2.)
+  if (state.activeDeviceId === deviceId) return;
+
+  // Vacuum claim: only a device actually producing audio (playing) fills an
+  // ownerless session. Requiring `playing` disambiguates a parked-but-still-
+  // loaded device (playing=false, e.g. transferred away) from the real source,
+  // so it can't steal ownership back after a restart.
+  if (state.activeDeviceId === null && lease.playing) {
+    log(`handleHeartbeat: lease claim — ${entry.device.name}[${entry.device.type}] heals ownerless session rec=${lease.recordingId} pos=${lease.positionMs}`);
+    mutate(userId, {
+      activeDeviceId: deviceId,
+      activeDeviceName: entry.device.name,
+      activeDeviceType: entry.device.type,
+      playing: true,
+      positionMs: lease.positionMs,
+      positionTs: Date.now(),
+    });
+    return;
   }
+
+  // Otherwise owned by another device (or ownerless + paused): back off — the
+  // lease never preempts. Split-brain (two devices both playing the same
+  // recording with no owner) is the rare path; first heartbeat wins, the other
+  // backs off here.
 }
 
 export function startHeartbeatSweep(): void {

--- a/api/src/connect/types.ts
+++ b/api/src/connect/types.ts
@@ -66,6 +66,13 @@ export interface RegisterMessage {
 
 export interface HeartbeatMessage {
   type: "heartbeat";
+  // ADR-0011 Chunk B: ownership-lease renewal. The device producing audio
+  // piggybacks its local playback state so the server can heal an ownerless
+  // session (activeDeviceId == null) without a new explicit command. Additive/
+  // optional — legacy clients omit them. Server gates on protocolVersion >= 1.
+  playing?: boolean;
+  recordingId?: string;
+  positionMs?: number;
 }
 
 export interface CommandMessage {

--- a/api/src/connect/types.ts
+++ b/api/src/connect/types.ts
@@ -1,5 +1,11 @@
 export type DeviceType = "ios" | "android" | "web";
 
+// WS wire-contract version. See docs/PROTOCOL.md for the authoritative semantics.
+// Clients that omit `protocolVersion` on register are legacy and treated as 0.
+// Behavior is gated on this integer ONLY — never on `appVersion` (ADR-0011 §3).
+export const CURRENT_PROTOCOL_VERSION = 1;
+export const LEGACY_PROTOCOL_VERSION = 0;
+
 export interface SessionTrack {
   title: string;
   durationMs: number;
@@ -51,6 +57,11 @@ export interface RegisterMessage {
   deviceId: string;
   deviceType: DeviceType;
   deviceName: string;
+  // ADR-0011 §3. Additive/optional: absent ⇒ legacy ⇒ LEGACY_PROTOCOL_VERSION (0).
+  // `protocolVersion` is the wire contract the server may branch on; `appVersion`
+  // is build identity for telemetry/"please update" UX only — never branched on.
+  protocolVersion?: number;
+  appVersion?: string;
 }
 
 export interface HeartbeatMessage {

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -48,14 +48,14 @@ separate per-session lifetime; see ADR-0011 §3.)
 | `protocolVersion` | Shipped | Meaning |
 |---|---|---|
 | `0` | (implicit) | Legacy: any client that omits the field. No `protocolVersion`/`appVersion` on register. |
-| `1` | Chunk A (ADR-0011) | Client sends `protocolVersion` + `appVersion` on `register`. Purely additive — no message shape changed, no server behavior branches on it yet. Establishes the primitive + telemetry that later chunks gate on. |
+| `1` | Chunk A + B (ADR-0011) | **A:** client sends `protocolVersion` + `appVersion` on `register`. **B:** the audio-producing device piggybacks `{ playing, recordingId, positionMs }` on its `heartbeat` to renew the ownership lease. Server reads the lease only when `protocolVersion >= 1`; a renewal **claims an ownerless session** (`activeDeviceId == null`, requires `playing`) but never preempts an existing owner. All additive — no register/heartbeat shape that an old client sends changed. |
 
 ### Reserved / planned
 
-- **Ownership lease (ADR-0011 Chunk B)** will be gated on `protocolVersion >= 1`:
-  the audio-producing device renews ownership by piggybacking `{ playing,
-  recordingId, positionMs }` on the heartbeat. When that lands, note here whether it
-  rides on `1` or bumps to `2`.
+- **Heuristic deletion (ADR-0011 Chunk C)** removes the client-side reclaim
+  detectors (epoch-change reclaim, empty-tracks re-assert) and the `playWhenReady`
+  reconciler's `if (!isActive) return` gate once telemetry shows the fleet on
+  `protocolVersion >= 1`. No wire change — purely deleting code the lease subsumes.
 
 ## When you bump the version
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1,0 +1,72 @@
+# Connect WS protocol — version semantics
+
+Source of truth for the `protocolVersion` integer carried on the Connect
+WebSocket. Spec rationale: [ADR-0011](adr/0011-connect-session-ownership-and-protocol-versioning.md).
+Build plan: [`PLANS/connect-ownership-lease.md`](../PLANS/connect-ownership-lease.md).
+
+If the three clients ever disagree about what a version number *means*, this file
+is what they were supposed to agree on. Update it in the **same change** that
+bumps a client's `protocolVersion`.
+
+## What the two fields are
+
+Both ride on the `register` message (client → server), and only there:
+
+| Field | Type | Server uses it for | Branch on it? |
+|---|---|---|---|
+| `protocolVersion` | int | the **wire contract** — what message shapes/semantics this connection speaks | **Yes** — this is the *only* field behavior may branch on |
+| `appVersion` | string | telemetry, "please update" UX, debugging | **Never** |
+
+`appVersion` is marketing/build identity (iOS `CFBundleShortVersionString`,
+Android `BuildConfig.VERSION_NAME`, web `NEXT_PUBLIC_DATA_VERSION`). Two releases
+can ship the same `protocolVersion`; coupling capability to build identity forces
+"≥ which build has feature X" lookup tables, so we don't.
+
+## Lifetime
+
+`protocolVersion`/`appVersion` are **per-connection**, not per-session. They arrive
+on `register`, are stamped onto the in-memory `liveDevices` record next to the
+socket, are valid until that socket closes, and are re-sent on every reconnect
+(self-refreshing, never stale). They are **not** persisted to Redis — a persisted
+copy could outlive the socket and misreport a reconnecting client's capability
+before it re-registers. (Session state — `showId`, position, ownership — has the
+separate per-session lifetime; see ADR-0011 §3.)
+
+## Defaults and the soft floor
+
+- **Absent ⇒ `0` (legacy).** A client that omits `protocolVersion` predates this
+  primitive. The server reads `0` and keeps today's behavior for it.
+- **`MIN_SUPPORTED = 0`** today — nothing is gated yet. When a correctness/security
+  must-have needs it, raise `MIN_SUPPORTED` on **telemetry** (the per-session
+  protocol distribution the server logs on register), not hope. Below the floor the
+  server degrades Connect gracefully and may send `{ type: "error",
+  code: "client_too_old" }` for clients to render an "Update for Connect" nudge —
+  a *soft* floor, not a hard reject (app-store review lag can strand a fix).
+
+## Version history
+
+| `protocolVersion` | Shipped | Meaning |
+|---|---|---|
+| `0` | (implicit) | Legacy: any client that omits the field. No `protocolVersion`/`appVersion` on register. |
+| `1` | Chunk A (ADR-0011) | Client sends `protocolVersion` + `appVersion` on `register`. Purely additive — no message shape changed, no server behavior branches on it yet. Establishes the primitive + telemetry that later chunks gate on. |
+
+### Reserved / planned
+
+- **Ownership lease (ADR-0011 Chunk B)** will be gated on `protocolVersion >= 1`:
+  the audio-producing device renews ownership by piggybacking `{ playing,
+  recordingId, positionMs }` on the heartbeat. When that lands, note here whether it
+  rides on `1` or bumps to `2`.
+
+## When you bump the version
+
+1. Decide it's a real wire-contract change (new required field, changed semantics,
+   a new server branch) — not just a new build. If it's only a build, that's
+   `appVersion`, leave `protocolVersion` alone.
+2. Add a row to **Version history** above describing the contract delta.
+3. Bump the constant in **all three clients in the same change**:
+   - iOS: `ConnectService.protocolVersion` (`iosApp/.../Core/Service/ConnectService.swift`)
+   - Android: `ConnectServiceImpl.CONNECT_PROTOCOL_VERSION` (`androidApp/core/connect/.../ConnectServiceImpl.kt`)
+   - Web: `CONNECT_PROTOCOL_VERSION` (`ui/src/components/connect/ConnectProvider.tsx`)
+   - Server reference: `CURRENT_PROTOCOL_VERSION` (`api/src/connect/types.ts`)
+4. Keep server branches `if (proto >= N)` until telemetry shows the fleet has moved,
+   then delete them — a version number is debt with a payoff (ADR-0011 Consequences).

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -50,12 +50,17 @@ separate per-session lifetime; see ADR-0011 §3.)
 | `0` | (implicit) | Legacy: any client that omits the field. No `protocolVersion`/`appVersion` on register. |
 | `1` | Chunk A + B (ADR-0011) | **A:** client sends `protocolVersion` + `appVersion` on `register`. **B:** the audio-producing device piggybacks `{ playing, recordingId, positionMs }` on its `heartbeat` to renew the ownership lease. Server reads the lease only when `protocolVersion >= 1`; a renewal **claims an ownerless session** (`activeDeviceId == null`, requires `playing`) but never preempts an existing owner. All additive — no register/heartbeat shape that an old client sends changed. |
 
-### Reserved / planned
+### Chunk C (landed) — client recovery is now lease-driven
 
-- **Heuristic deletion (ADR-0011 Chunk C)** removes the client-side reclaim
-  detectors (epoch-change reclaim, empty-tracks re-assert) and the `playWhenReady`
-  reconciler's `if (!isActive) return` gate once telemetry shows the fleet on
-  `protocolVersion >= 1`. No wire change — purely deleting code the lease subsumes.
+No wire/version change. All three clients deleted the **epoch-change reclaim**
+heuristic (`lastEpoch`/`serverRestarted`) and made the reconcile loop honor one
+invariant: **the device producing audio is the transport authority.** When the
+session is ownerless (`activeDeviceId == null`) and we're still playing the
+session's recording, we keep playing and let the heartbeat **lease** reclaim us
+server-side instead of pausing or self-claiming via `load`. The empty-tracks
+re-send is **kept but decoupled** — it now hydrates the tracklist with
+`autoplay=false`, so it restores tracks without claiming ownership (the lease owns
+that). This is what makes the lease the load-bearing, observable recovery path.
 
 ## When you bump the version
 

--- a/iosApp/deadly/Core/Service/ConnectService.swift
+++ b/iosApp/deadly/Core/Service/ConnectService.swift
@@ -57,12 +57,14 @@ final class ConnectService: NSObject {
     private var timeSyncRefreshTask: Task<Void, Never>?
     private var reconnectAttempt = 0
     private var shouldConnect = false
-    // Guards the one-shot track re-assert so position broadcasts arriving before
-    // our load echoes back don't make us re-send it repeatedly.
+    // Guards the one-shot tracklist re-hydration so position broadcasts arriving
+    // before our load echoes back don't make us re-send it repeatedly.
     private var reassertingTracks = false
-    // Last server epoch seen. A change means the server restarted (and rehydrated
-    // the session), which is the only situation a still-playing device reclaims.
-    private var lastEpoch: Int? = nil
+    // True from a (re)connect until the server next assigns an owner. Distinguishes
+    // an ownerless GHOST (server lost us across a restart/socket drop — reclaim) from
+    // a deliberate PARK (transfer/stop on a live socket — pause). Only the ghost
+    // arrives right after a reconnect; a park arrives mid-connection.
+    private var reclaimOnReconnect = false
     // Set on every (re)connect. The monotonic version guard only dedupes
     // out-of-order messages within one connection; across a reconnect the
     // server may have restarted and reset its counter, so the first snapshot
@@ -416,29 +418,29 @@ final class ConnectService: NSObject {
             pendingTransfer = nil
         }
 
-        // Did the server restart? An epoch change is the explicit, authoritative
-        // signal (vs. inferring it from null-active + empty-tracks coincidences).
-        let prevEpoch = lastEpoch
-        let serverRestarted = prevEpoch != nil && new.epoch != prevEpoch
-        lastEpoch = new.epoch
-
-        // Reclaim only when the server restarted and rehydrated the session (so it
-        // has no active device) while we're still playing this recording — take
-        // ownership back without a gap. reassertingTracks keeps us in this mode
-        // while our reclaim load is in flight (epoch is unchanged on later states).
-        // A deliberate transition (transfer park, stop) keeps the same epoch, so
-        // it is never mistaken for a restart.
-        let reclaimAfterRestart = new.activeDeviceId == nil
+        // ADR-0011 Chunk C: the device producing audio is the transport authority.
+        // When the session is ownerless (server forgot the active device across a
+        // restart/socket drop) and we're still playing this recording, KEEP PLAYING
+        // and let the heartbeat ownership lease reclaim us server-side. Gated on
+        // reclaimOnReconnect so a deliberate PARK (transfer/stop, which nulls active
+        // on our LIVE socket) is NOT mistaken for a ghost — only a post-reconnect
+        // null active is a ghost. Cause-agnostic (restart + disconnect both reconnect).
+        let reclaimOwnerless = new.activeDeviceId == nil
             && streamPlayer.playbackState.isPlaying
             && streamPlayer.currentTrack?.metadata["recordingId"] == new.recordingId
-            && (serverRestarted || reassertingTracks)
+            && reclaimOnReconnect
+        // Once the server assigns an owner (us via the lease, or another device), the
+        // post-reconnect ghost window is over: any later activeDevice=nil is then a
+        // deliberate park we must pause for, not reclaim.
+        if new.activeDeviceId != nil { reclaimOnReconnect = false }
 
         // If this device was active but is no longer — a different device took
         // over, or we were parked during a transfer — pause and report final
-        // position. Skipped on a reclaim, where we keep playing and re-assert.
+        // position. Skipped when the session went ownerless (reclaimOwnerless): a
+        // null active device is a ghost we heal by holding the lease, not a takeover.
         let wasActive = old?.activeDeviceId == appPreferences.installId
         let nowActive = new.activeDeviceId == appPreferences.installId
-        if wasActive && !nowActive && !reclaimAfterRestart {
+        if wasActive && !nowActive && !reclaimOwnerless {
             let positionMs = Int(streamPlayer.progress.currentTime * 1000)
             logger.info("reactToState: parked/transferred away — pausing and reporting position \(positionMs, privacy: .public)ms")
             streamPlayer.pause()
@@ -459,19 +461,21 @@ final class ConnectService: NSObject {
             return
         }
 
-        // Only drive local playback when this device is active (or reclaiming a
-        // restarted session — reclaimAfterRestart computed above).
-        guard isActiveDevice || reclaimAfterRestart else {
+        // Only drive local playback when this device is active (or we're the
+        // ownerless ghost holding the lease — reclaimOwnerless computed above).
+        guard isActiveDevice || reclaimOwnerless else {
             logger.info("reactToState: not active device, skipping playback control")
             reassertingTracks = false
             stopPositionReporting()
             return
         }
 
-        // Server forgot our tracklist (it restarted and rehydrated the session
-        // from the saved position only). We still hold the queue — re-assert the
-        // load so viewers' display and the server's next/prev get the tracks
-        // back. handleLoad keeps us active and honors the index/position we pass.
+        // Server forgot our tracklist (a restart rehydrated the session from the
+        // saved position only). We still hold the queue — re-send the load so
+        // viewers' display and the server's next/prev get the tracks back. This
+        // hydrates TRACKS ONLY: autoplay=false when we're the ownerless ghost, so
+        // the load does NOT claim ownership — the heartbeat lease does that. (When
+        // already active, autoplay tracks our real playing state.)
         if new.tracks.isEmpty {
             let queue = streamPlayer.loadedTracks
             let localRecId = streamPlayer.currentTrack?.metadata["recordingId"]
@@ -495,18 +499,18 @@ final class ConnectService: NSObject {
                     date: new.date ?? meta["showDate"],
                     venue: new.venue ?? meta["venue"],
                     location: new.location ?? meta["location"],
-                    autoplay: streamPlayer.playbackState.isPlaying
+                    autoplay: nowActive && streamPlayer.playbackState.isPlaying
                 )
             }
         } else {
             reassertingTracks = false
         }
 
-        // On a reclaim we are the source of truth: don't sync transport down to
-        // the stale playing:false / saved position. The server will echo our
-        // re-asserted load back on the next version (activeDeviceId == us), and
+        // Ownerless ghost: we are the transport authority — don't sync transport
+        // down to the stale playing:false / saved position. Keep playing; the lease
+        // claims us within a heartbeat, the server echoes activeDeviceId == us, and
         // normal active-device sync resumes from there.
-        if reclaimAfterRestart { return }
+        if reclaimOwnerless { return }
 
         // When this device just became active (e.g. transfer in), sync local player
         // to server state — the local player may be at a completely different track/position.
@@ -518,7 +522,7 @@ final class ConnectService: NSObject {
         // the server, whose positionMs is the stale pre-end value. Without this guard
         // we seek back to that stale position and resume, replaying the tail, which
         // re-fires onShowCompleted and re-announces (resetting the countdown). The
-        // note-collector owns the transition from here. (Mirrors reclaimAfterRestart.)
+        // note-collector owns the transition from here. (Mirrors reclaimOwnerless.)
         let justBecameActive = !wasActive && nowActive
         if justBecameActive && new.pendingAdvance == nil {
             let currentVolume = Int(streamPlayer.volume * 100)
@@ -667,6 +671,9 @@ final class ConnectService: NSObject {
     // MARK: - Registration
 
     private func sendRegister() {
+        // Arm ghost-reclaim: a null active device in the first state(s) after this
+        // (re)connect is a ghost to heal (lease), not a deliberate park.
+        reclaimOnReconnect = true
         let deviceId = appPreferences.installId
         #if canImport(UIKit)
         let deviceName = UIDevice.current.name

--- a/iosApp/deadly/Core/Service/ConnectService.swift
+++ b/iosApp/deadly/Core/Service/ConnectService.swift
@@ -751,9 +751,29 @@ final class ConnectService: NSObject {
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: Self.heartbeatInterval)
                 guard !Task.isCancelled else { break }
-                webSocket?.send(.string(#"{"type":"heartbeat"}"#)) { _ in }
+                webSocket?.send(.string(buildHeartbeat())) { _ in }
             }
         }
+    }
+
+    // ADR-0011 Chunk B: renew the ownership lease. When audio is loaded locally,
+    // piggyback {playing, recordingId, positionMs} so the server can heal an
+    // ownerless session from our heartbeat (the restart/disconnect "ghost" fix).
+    // Plain heartbeat when nothing is loaded. See docs/PROTOCOL.md.
+    private func buildHeartbeat() -> String {
+        let plain = #"{"type":"heartbeat"}"#
+        guard let recordingId = streamPlayer.currentTrack?.metadata["recordingId"] else {
+            return plain
+        }
+        let lease: [String: Any] = [
+            "type": "heartbeat",
+            "playing": streamPlayer.playbackState.isPlaying,
+            "recordingId": recordingId,
+            "positionMs": Int(streamPlayer.progress.currentTime * 1000),
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: lease),
+              let text = String(data: data, encoding: .utf8) else { return plain }
+        return text
     }
 
     private func stopHeartbeat() {

--- a/iosApp/deadly/Core/Service/ConnectService.swift
+++ b/iosApp/deadly/Core/Service/ConnectService.swift
@@ -75,6 +75,9 @@ final class ConnectService: NSObject {
     // gets promoted to serverTimeOffsetMs.
     private var timeSyncBestRttMs: Double = .infinity
 
+    // Connect WS wire-contract version. See docs/PROTOCOL.md for semantics.
+    // Bump in lockstep with the documented protocol; the server may branch on it.
+    private static let protocolVersion = 1
     private static let reconnectDelays: [Double] = [1, 2, 4, 8, 30]
     private static let heartbeatInterval: UInt64 = 15_000_000_000 // 15s in nanoseconds
     private static let timeSyncRefreshInterval: UInt64 = 5 * 60 * 1_000_000_000 // 5 min
@@ -671,14 +674,22 @@ final class ConnectService: NSObject {
         let deviceName = "iPhone"
         #endif
 
-        logger.info("sendRegister: deviceId=\(deviceId, privacy: .public) name=\(deviceName, privacy: .public)")
-        let msg: [String: String] = [
+        // ADR-0011 §3 / docs/PROTOCOL.md: build identity for telemetry only —
+        // the server never branches behavior on appVersion.
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+
+        logger.info("sendRegister: deviceId=\(deviceId, privacy: .public) name=\(deviceName, privacy: .public) proto=\(Self.protocolVersion, privacy: .public) app=\(appVersion, privacy: .public)")
+        // Mixed value types (string + int) → encode as a JSON object explicitly.
+        let msg: [String: Any] = [
             "type": "register",
             "deviceId": deviceId,
             "deviceType": "ios",
             "deviceName": deviceName,
+            // Wire-contract version the server may branch on; see docs/PROTOCOL.md.
+            "protocolVersion": Self.protocolVersion,
+            "appVersion": appVersion,
         ]
-        guard let data = try? JSONEncoder().encode(msg),
+        guard let data = try? JSONSerialization.data(withJSONObject: msg),
               let text = String(data: data, encoding: .utf8) else { return }
         webSocket?.send(.string(text)) { _ in }
     }

--- a/ui/src/components/connect/ConnectProvider.tsx
+++ b/ui/src/components/connect/ConnectProvider.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { ConnectContext } from "@/contexts/ConnectContext";
+import type { LocalPlaybackSnapshot } from "@/contexts/ConnectContext";
 import type { ConnectDevice, ConnectState } from "@/types/connect";
 import { randomUUID } from "@/lib/uuid";
 
@@ -70,6 +71,10 @@ export default function ConnectProvider({
   const shouldConnectRef = useRef(false);
   const currentVersionRef = useRef(0);
   const volumeListenersRef = useRef<Array<(volume: number) => void>>([]);
+  // ADR-0011 Chunk B: getter for this device's local playback, registered by the
+  // player. The heartbeat calls it to renew the ownership lease. Default: no
+  // source loaded ⇒ plain heartbeat.
+  const localPlaybackRef = useRef<() => LocalPlaybackSnapshot | null>(() => null);
   // Tracks the best (lowest-RTT) sample within the current sync batch so we
   // can keep updating as better samples arrive but ignore worse ones.
   const timeSyncBestRttRef = useRef<number>(Number.POSITIVE_INFINITY);
@@ -154,7 +159,10 @@ export default function ConnectProvider({
       clearHeartbeat();
       heartbeatRef.current = setInterval(() => {
         if (ws.readyState === WebSocket.OPEN) {
-          ws.send(JSON.stringify({ type: "heartbeat" }));
+          // ADR-0011 Chunk B: piggyback the ownership-lease renewal when audio is
+          // loaded locally so the server can heal an ownerless session.
+          const lease = localPlaybackRef.current();
+          ws.send(JSON.stringify(lease ? { type: "heartbeat", ...lease } : { type: "heartbeat" }));
         }
       }, HEARTBEAT_INTERVAL_MS);
 
@@ -272,6 +280,13 @@ export default function ConnectProvider({
     }
   }, []);
 
+  const setLocalPlaybackSource = useCallback(
+    (source: (() => LocalPlaybackSnapshot | null) | null) => {
+      localPlaybackRef.current = source ?? (() => null);
+    },
+    [],
+  );
+
   const disconnect = useCallback(() => {
     log("disconnect() called");
     shouldConnectRef.current = false;
@@ -312,7 +327,7 @@ export default function ConnectProvider({
   }, [user, isLoading]);
 
   return (
-    <ConnectContext.Provider value={{ devices, state: connectState, myDeviceId, connected, sendCommand, activeDeviceVolume, onVolumeMessage, reportVolume, serverTimeOffsetMs }}>
+    <ConnectContext.Provider value={{ devices, state: connectState, myDeviceId, connected, sendCommand, activeDeviceVolume, onVolumeMessage, reportVolume, setLocalPlaybackSource, serverTimeOffsetMs }}>
       {children}
     </ConnectContext.Provider>
   );

--- a/ui/src/components/connect/ConnectProvider.tsx
+++ b/ui/src/components/connect/ConnectProvider.tsx
@@ -6,6 +6,12 @@ import { ConnectContext } from "@/contexts/ConnectContext";
 import type { ConnectDevice, ConnectState } from "@/types/connect";
 import { randomUUID } from "@/lib/uuid";
 
+// Connect WS wire-contract version. See docs/PROTOCOL.md for semantics.
+// Bump in lockstep with the documented protocol; the server may branch on it.
+const CONNECT_PROTOCOL_VERSION = 1;
+// Build identity for telemetry only — never branched on. Mirrors analytics.ts.
+const APP_VERSION = (process.env.NEXT_PUBLIC_DATA_VERSION ?? "web").slice(0, 20);
+
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const RECONNECT_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 30_000];
 const DEVICE_ID_KEY = "deadly-device-id";
@@ -139,6 +145,10 @@ export default function ConnectProvider({
         deviceId,
         deviceType: "web",
         deviceName,
+        // ADR-0011 §3 / docs/PROTOCOL.md: wire-contract version the server may
+        // branch on; appVersion is build identity for telemetry only.
+        protocolVersion: CONNECT_PROTOCOL_VERSION,
+        appVersion: APP_VERSION,
       }));
 
       clearHeartbeat();

--- a/ui/src/components/player/PlayerProvider.tsx
+++ b/ui/src/components/player/PlayerProvider.tsx
@@ -55,6 +55,7 @@ export default function PlayerProvider({
     sendCommand,
     onVolumeMessage,
     reportVolume,
+    setLocalPlaybackSource,
     serverTimeOffsetMs,
   } = useConnect();
 
@@ -640,6 +641,24 @@ export default function PlayerProvider({
     }, 5000);
     return () => clearInterval(id);
   }, [isActiveDevice, connectState?.playing]);
+
+  // ADR-0011 Chunk B: expose this device's local playback to the Connect
+  // heartbeat so it can renew the ownership lease (heals an ownerless session
+  // after a server restart / socket blip). The getter reads live refs, so a
+  // single registration stays current; null when nothing is loaded.
+  useEffect(() => {
+    setLocalPlaybackSource(() => {
+      const audio = getActiveAudio();
+      const recordingId = selectedRecordingRef.current;
+      if (!audio || !recordingId) return null;
+      return {
+        playing: !audio.paused,
+        recordingId,
+        positionMs: Math.round(audio.currentTime * 1000),
+      };
+    });
+    return () => setLocalPlaybackSource(null);
+  }, [setLocalPlaybackSource]);
 
   // ── React to authoritative ConnectState broadcasts ───────────────────
   // Single reconciliation path keyed on the server's monotonic version: clear

--- a/ui/src/components/player/PlayerProvider.tsx
+++ b/ui/src/components/player/PlayerProvider.tsx
@@ -125,12 +125,15 @@ export default function PlayerProvider({
   const reportVolumeRef = useRef(reportVolume);
   const isActiveDeviceRef = useRef(false);
   const isRemoteControllingRef = useRef(false);
-  // Guards the one-shot track re-assert (below) so position broadcasts arriving
-  // before our load echoes back don't make us re-send it repeatedly.
+  // Guards the one-shot tracklist re-hydration (below) so position broadcasts
+  // arriving before our load echoes back don't make us re-send it repeatedly.
   const reassertingTracksRef = useRef(false);
-  // Last server epoch seen. A change means the server restarted (and rehydrated
-  // the session), which is the only situation a still-playing device reclaims.
-  const lastEpochRef = useRef<number | null>(null);
+  // True from a (re)connect until the server next assigns an owner. Distinguishes
+  // an ownerless GHOST (server lost us across a restart/socket drop — reclaim) from
+  // a deliberate PARK (transfer/stop on a live socket — pause). Set on the
+  // disconnected→connected transition; cleared once active is non-null again.
+  const reclaimOnReconnectRef = useRef(false);
+  const prevConnectedRef = useRef(false);
   // Name of the most recent OTHER active device, used to attribute the
   // "Play on this device?" autoplay prompt after a transfer to us.
   const prevActiveDeviceNameRef = useRef<string | null>(null);
@@ -642,6 +645,16 @@ export default function PlayerProvider({
     return () => clearInterval(id);
   }, [isActiveDevice, connectState?.playing]);
 
+  // ADR-0011 Chunk C: arm ghost-reclaim on each (re)connect. A null active device
+  // in the first state(s) after the socket reconnects is a ghost to heal; once
+  // connected steady-state, a null active is a deliberate park (transfer/stop).
+  useEffect(() => {
+    if (connected && !prevConnectedRef.current) {
+      reclaimOnReconnectRef.current = true;
+    }
+    prevConnectedRef.current = connected;
+  }, [connected]);
+
   // ADR-0011 Chunk B: expose this device's local playback to the Connect
   // heartbeat so it can renew the ownership lease (heals an ownerless session
   // after a server restart / socket blip). The getter reads live refs, so a
@@ -734,24 +747,25 @@ export default function PlayerProvider({
       return; // defer play/pause sync until tracks load
     }
 
-    // Did the server restart? An epoch change is the explicit, authoritative
-    // signal (vs. inferring it from null-active + empty-tracks coincidences).
-    const prevEpoch = lastEpochRef.current;
-    const serverRestarted = prevEpoch !== null && connectState.epoch !== prevEpoch;
-    lastEpochRef.current = connectState.epoch;
-
-    // Reclaim only when the server restarted and rehydrated the session (so it
-    // has no active device) while we're still playing this recording — take
-    // ownership back without a gap. reassertingTracksRef keeps us in this mode
-    // while our reclaim load is in flight (epoch is unchanged on later states).
-    // A deliberate transition (transfer park, stop) keeps the same epoch, so it
-    // is never mistaken for a restart.
+    // ADR-0011 Chunk C: the device producing audio is the transport authority.
+    // Whenever the session is ownerless (server forgot the active device — a
+    // restart rehydrated position-only, or a socket drop nulled it) and we're
+    // still playing this recording, keep playing and let the heartbeat ownership
+    // lease reclaim us server-side. No epoch heuristic — this is cause-agnostic
+    // (restart, disconnect-cleanup, dropped message all converge the same way).
+    // Gated on reclaimOnReconnect so a deliberate PARK (transfer/stop, which nulls
+    // active on our LIVE socket) is NOT mistaken for a ghost — only a post-reconnect
+    // null active is a ghost. Cause-agnostic (restart + disconnect both reconnect).
     const audio = getActiveAudio();
     const reclaim =
       connectState.activeDeviceId === null &&
       !!audio && !audio.paused &&
       connectState.recordingId === selectedRecordingRef.current &&
-      (serverRestarted || reassertingTracksRef.current);
+      reclaimOnReconnectRef.current;
+    // Once the server assigns an owner (us via the lease, or another device), the
+    // post-reconnect ghost window is over: any later activeDevice=null is then a
+    // deliberate park we must pause for, not reclaim.
+    if (connectState.activeDeviceId !== null) reclaimOnReconnectRef.current = false;
 
     // Not the active device and not reclaiming → another device owns the session
     // (a real takeover) OR we were parked/stopped during a transfer. Either way,
@@ -766,13 +780,14 @@ export default function PlayerProvider({
       return;
     }
 
-    // We ARE the active device, or we're reclaiming a restarted session.
+    // We ARE the active device, or we're the ownerless ghost holding the lease.
     if (isActiveDevice || reclaim) {
       if (!audio) return;
 
-      // handleLoad (re)claims us active, honors the index/position we pass, and
-      // — because we pass autoplay — restores playing, so this refills tracks
-      // (and re-establishes the active device on a reclaim) without a gap.
+      // Hydrate the tracklist the ownerless session lost. On a reclaim we pass
+      // autoplay=false so this load does NOT claim ownership — the heartbeat lease
+      // does that; this only backfills `tracks` so viewers/next-prev work. (When
+      // we're already active with an empty tracklist, autoplay tracks real state.)
       const localTracks = tracksRef.current;
       if (connectState.tracks.length > 0 && !reclaim) {
         reassertingTracksRef.current = false;
@@ -812,13 +827,13 @@ export default function PlayerProvider({
           date: connectState.date ?? activeShowRef.current?.date,
           venue: connectState.venue ?? activeShowRef.current?.venue,
           location: connectState.location ?? activeShowRef.current?.location,
-          autoplay: reclaim ? !audio.paused : connectState.playing,
+          autoplay: reclaim ? false : connectState.playing,
         });
       }
 
-      // On a reclaim, don't sync transport DOWN to the stale playing:false /
-      // saved position — we're the source of truth until the server echoes our
-      // load back (next version, by which point activeDeviceId === us).
+      // Ownerless ghost: we're the transport authority — don't sync transport DOWN
+      // to the stale playing:false / saved position. Keep playing; the lease claims
+      // us within a heartbeat and the server echoes activeDeviceId === us.
       if (reclaim) return;
 
       // Same rule for an end-of-show park: we "became active" only because we

--- a/ui/src/contexts/ConnectContext.ts
+++ b/ui/src/contexts/ConnectContext.ts
@@ -3,6 +3,15 @@
 import { createContext, useContext } from "react";
 import type { ConnectDevice, ConnectState } from "@/types/connect";
 
+// ADR-0011 Chunk B: a snapshot of this device's LOCAL playback, read by the
+// Connect heartbeat to renew the ownership lease. Returned by the source the
+// player registers via setLocalPlaybackSource; null when nothing is loaded.
+export interface LocalPlaybackSnapshot {
+  playing: boolean;
+  recordingId: string;
+  positionMs: number;
+}
+
 export interface ConnectContextValue {
   devices: ConnectDevice[];
   state: ConnectState | null;
@@ -12,6 +21,9 @@ export interface ConnectContextValue {
   activeDeviceVolume: number | null;
   onVolumeMessage: (handler: (volume: number) => void) => () => void;
   reportVolume: (volume: number) => void;
+  // ADR-0011 Chunk B: the player registers a getter for this device's local
+  // playback so the heartbeat can renew the ownership lease. Pass null to clear.
+  setLocalPlaybackSource: (source: (() => LocalPlaybackSnapshot | null) | null) => void;
   // Server-clock - local-clock, in ms. Add to Date.now() to approximate the
   // server's current wall-clock. 0 until the first time_sync round-trip
   // completes. See docs/connect-v2-architecture.md "Clock Sync".


### PR DESCRIPTION
Implements [ADR-0011](docs/adr/0011-connect-session-ownership-and-protocol-versioning.md): replaces the pile of cause-specific client reclaim detectors with one convergent **ownership lease**, gated by a new **WS protocol version**. Fixes the silent failure where a Connect listener playing **through an API restart or socket drop** became a ghost (server believes `activeDeviceId == null` while the device is still playing) — so end-of-show auto-advance died and transport broke.

Three chunks (squashes to one commit on merge — see below for the per-chunk history):

### A — `protocolVersion` + `appVersion` on register (`feat`)
Every client announces `protocolVersion` (=1) and `appVersion` on the WS `register`. The server stamps both onto the in-memory `liveDevices` connection record (NOT Redis — same lifetime as the socket) and logs the per-session protocol distribution. Purely additive; `docs/PROTOCOL.md` is the source of truth for version semantics. `MIN_SUPPORTED` stays `0` — nothing is gated/forced yet.

### B — heartbeat-renewed ownership lease (`feat`)
The device producing audio piggybacks `{playing, recordingId, positionMs}` on its heartbeat. `handleHeartbeat` treats `activeDeviceId` as a renewable lease: a renewal **claims an ownerless session** (`activeDeviceId == null`, requires `playing`, recordingId must match) or refreshes the owner, and **never preempts** a device that owns via command. Gated on `protocolVersion >= 1`; legacy/bare heartbeats are untouched. Covered by a focused unit test (`api/src/connect/__tests__/state.lease.test.ts`, 7 cases).

### C — lease-driven recovery, retire epoch reclaim (`fix`)
Deletes the epoch-change reclaim (`lastEpoch`/`serverRestarted`) on all three clients. The reconcile loop now honors one invariant — *the device producing audio is the transport authority*: ownerless + still playing our recording ⇒ keep playing and let the lease reclaim, instead of pausing or self-claiming via an autoplay load. Ghost-reclaim is gated on a `reclaimOnReconnect` flag so a **deliberate park** (transfer/stop, which nulls active on the live socket) isn't mistaken for a **ghost** (which only arrives right after a reconnect) — a better discriminator than the deleted epoch (covers restart AND disconnect). The empty-tracks re-send is kept but decoupled: it hydrates the tracklist with `autoplay=false`, restoring tracks without claiming ownership.

## Backwards compatibility
Additive + conservative (ADR §4). Server changes are no-ops for legacy clients (`handleHeartbeat` returns early when there's no lease payload). The lease only fills a vacuum, never preempts a command owner, so a mixed old/new fleet is safe. No existing message shape changes; no `protocolVersion` floor is enforced.

## Verification
- API lease unit test 7/7; all four targets build (api/web `tsc`, Android `:core:connect`, iOS `xcodebuild`).
- Live on local docker across a real mixed `proto0`/`proto1` fleet (web + iOS @2.36.1 + Android):
  - **Restart while playing → `handleHeartbeat: lease claim` heals the session** (the original bug, now self-healing).
  - **Transfer between devices parks cleanly with no spurious lease claim** (regression caught + fixed via `reclaimOnReconnect` + a server `pendingTransfers` guard).
  - Legacy (`proto=0`) clients keep working alongside.

## Not in scope
No store release is triggered by this PR. Raising `MIN_SUPPORTED` / a forced-update nudge stays gated on telemetry. Redis-persist of session state stays deferred (ADR-0008).

🤖 Generated with [Claude Code](https://claude.com/claude-code)