### PR TITLE
feat(web/player): surface recording selection across show page and player

### DIFF
--- a/PLANS/ROADMAP.md
+++ b/PLANS/ROADMAP.md
@@ -40,7 +40,7 @@ web-launch threads, 2026-06).
   bulk-copies a prebuilt SQLite catalog seed (`d8442651`) instead of importing
   ~20k JSON files; FTS rebuilt on-device; fixes Android's silent false-complete
   on kill mid-import. Data pinned to 2.4.0 (`fb90535d`). Decisions in
-  **ADR-0007**; details in [`PLANS/prebuilt-catalog-db.md`](prebuilt-catalog-db.md).
+  **ADR-0013**; details in [`PLANS/prebuilt-catalog-db.md`](prebuilt-catalog-db.md).
 - **Admin → user messaging + notifications.** In-app inbox (v1 + v2, #55),
   engagement funnel + per-notification admin stats (#57), admin dashboard
   Versions panel (#56). New `track()` events must be registered in
@@ -240,7 +240,7 @@ two shows (early/late, same-date multi-venue) surface under only one. A
 composite-PK / `recording_shows` join-table fix is a coordinated iOS+Android+seed
 migration for a small edge case — deferred. Why + path in
 [`PLANS/prebuilt-catalog-db.md`](prebuilt-catalog-db.md) "Known limitations";
-decision in ADR-0007 §9.
+decision in ADR-0013 §9.
 
 **Out of scope entirely:** additional bands / non-Grateful-Dead content. The
 Deadly is bounded by what's in the Grateful Dead's Internet Archive collection.

--- a/PLANS/ROADMAP.md
+++ b/PLANS/ROADMAP.md
@@ -207,6 +207,27 @@ exist (iOS/Android: Account, Playback, Preferences, Home Screen, Audio, Connect,
 Favorites & Data, Support, About) — the work is turning sections into drill-in
 categories, not inventing new groupings. Not started.
 
+## TECH DEBT
+
+Known shortcuts we took deliberately, with the trigger that should make us pay
+them down. Not features — corrections we owe the codebase.
+
+- **Show index is a boot-loaded in-memory JSON blob (move to SQLite when
+  recording fields grow).** The API holds no catalog; `api/src/showCatalog.ts`
+  loads `show-index.json` once at boot into an in-memory `Map`, built offline by
+  `api/scripts/build-show-index.mjs`. PR #66 baked a per-**recording** display
+  array into it for the web recording picker, which ~5×'d the file on disk and in
+  resident memory (~0.6 → ~3.1 MB). Fine today (read-only, keyed reads, single
+  instance), but `better-sqlite3` is already loaded in-process and this is the
+  only show-metadata store *not* in SQLite. **Trigger:** the next time someone
+  adds per-recording fields (track lists, per-recording reviews, waveforms,
+  lineage, sizes…), migrate the index to a SQLite table queried by `showId`
+  instead of fattening the blob — also forced if API memory starts to matter or
+  it needs to scale horizontally. Decision + triggers in **ADR-0012**; code
+  breadcrumbs point there from both the producer and consumer.
+- **Favorite-songs logic mis-placed on `ReviewService`.** Extract onto
+  `FavoritesService` (both platforms) — see §7. File a Linear tech-debt ticket.
+
 ## Deferred / explicit non-goals (sync v0)
 Cross-device deletion **tombstones**, **settings sync**, and **background sync**
 (WorkManager / BGTaskScheduler). Revisit tombstones before flipping sync

--- a/PLANS/prebuilt-catalog-db.md
+++ b/PLANS/prebuilt-catalog-db.md
@@ -4,7 +4,7 @@ Replace the slow first-launch JSON import (download 25 MB `data.zip` → extract
 ~20k JSON → parse → insert → build FTS, minutes on venue cell) with a prebuilt
 SQLite **catalog seed** built in CI and bulk-copied into each app's DB.
 
-Binding decisions + trade-offs: [`docs/adr/0007-prebuilt-catalog-db.md`](../docs/adr/0007-prebuilt-catalog-db.md).
+Binding decisions + trade-offs: [`docs/adr/0013-prebuilt-catalog-db.md`](../docs/adr/0013-prebuilt-catalog-db.md).
 
 ## Release & versioning mechanics (how a seed reaches a device) — 2026-06-08
 
@@ -314,7 +314,7 @@ query through it. That's a coordinated schema migration on iOS (GRDB) + Android
 (Room) + the seed builder + `catalog_schema.json`, plus a data backfill — a real
 chunk of work for a 57-tape edge case. Worth doing if/when we want full fidelity
 for early/late and multi-venue dates, but not blocking the first-launch speedup.
-Surfaced in ROADMAP "Deferred". See ADR-0007 decision #9.
+Surfaced in ROADMAP "Deferred". See ADR-0013 decision #9.
 
 ## Open decisions
 
@@ -323,6 +323,6 @@ Surfaced in ROADMAP "Deferred". See ADR-0007 decision #9.
 - One canonical seed + on-device FTS (chosen) vs two per-platform DBs.
 
 ## Related
-- ADR: [`docs/adr/0007-prebuilt-catalog-db.md`](../docs/adr/0007-prebuilt-catalog-db.md)
+- ADR: [`docs/adr/0013-prebuilt-catalog-db.md`](../docs/adr/0013-prebuilt-catalog-db.md)
 - Existing pipeline docs: [`data/docs/grateful-dead-database-pipeline.md`](../data/docs/grateful-dead-database-pipeline.md)
 - `../dead-metadata` is a stale upstream fork of the pipeline — archive eventually.

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/service/DatabaseHealthService.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/service/DatabaseHealthService.kt
@@ -26,7 +26,7 @@ class DatabaseHealthService @Inject constructor(
      * (after all shows/recordings/FTS), so its presence proves the import ran to
      * completion. Counting rows alone is NOT enough: an import killed mid-recordings
      * leaves shows>0 && recordings>0 but a permanently partial catalog. Requiring the
-     * end-written marker closes that silent-incomplete bug (ADR-0007).
+     * end-written marker closes that silent-incomplete bug (ADR-0013).
      */
     suspend fun isDatabaseHealthy(): Boolean {
         return try {

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/service/DatabaseManager.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/service/DatabaseManager.kt
@@ -108,7 +108,7 @@ class DatabaseManager @Inject constructor(
      * Initialize the catalog from the available sources, preferring the prebuilt
      * seed (SEED) and falling back to the JSON `data.zip` import. If the seed
      * import fails and JSON is available, fall back to it — zero-risk migration
-     * (ADR-0007, Phase 4). No user prompt: the seed is strictly faster/cheaper.
+     * (ADR-0013, Phase 4). No user prompt: the seed is strictly faster/cheaper.
      */
     private suspend fun initializePreferringSeed(available: AvailableSources): DatabaseImportResult {
         val sources = available.sources
@@ -301,7 +301,7 @@ class DatabaseManager @Inject constructor(
 
                             // Attach-and-copy the neutral catalog seed into the live
                             // migrated Room DB. This is NOT a full-DB restore: the seed
-                            // has no Room identity / device-local tables (see ADR-0007).
+                            // has no Room identity / device-local tables (see ADR-0013).
                             Log.i(TAG, "Importing catalog seed...")
                             val seedResult = seedDatabaseImportService.importFromSeed(
                                 seedFile = extractionResult.databaseFile

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/service/SeedDatabaseImportService.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/service/SeedDatabaseImportService.kt
@@ -21,7 +21,7 @@ import javax.inject.Singleton
  * identity hash (`room_master_table`) and none of the device-local tables
  * (favorites, library, recents, reviews, sync outbox). Opening it as the live ORM
  * DB would crash or lose user data. Instead we keep Room's own migrated DB and copy
- * the catalog rows into it. See `docs/adr/0007-prebuilt-catalog-db.md`.
+ * the catalog rows into it. See `docs/adr/0013-prebuilt-catalog-db.md`.
  *
  * Flow (catalog writes in one transaction so the health gate — a committed
  * `data_version` row — flips only on success):

--- a/api/scripts/build-show-index.mjs
+++ b/api/scripts/build-show-index.mjs
@@ -6,14 +6,17 @@
 // one small file. See PLANS/web-profile.md (show-metadata source).
 //
 // Usage (from repo root):
-//   node api/scripts/build-show-index.mjs [showsDir] [outFile]
+//   node api/scripts/build-show-index.mjs [showsDir] [outFile] [recordingsDir]
 // Defaults: ui/data/shows  ->  api-data/show-index.json
+//           recordingsDir defaults to <showsDir>/../recordings
 
 import fs from "node:fs";
 import path from "node:path";
 
 const showsDir = process.argv[2] ?? "ui/data/shows";
 const outFile = process.argv[3] ?? "api-data/show-index.json";
+const recordingsDir =
+  process.argv[4] ?? path.join(path.dirname(showsDir), "recordings");
 
 // Non-fatal if the data isn't present: write an empty index so the image
 // build (and boot) still succeed — the API just returns bare records and
@@ -44,10 +47,40 @@ function resolveImage(s) {
   return null;
 }
 
+// The compact per-recording shape the web recording menu needs (source badge,
+// rating, review count, runtime). Resolved by reading each recording's own
+// JSON; the browser has no catalog, so the API serves this by showId.
+const haveRecordings = fs.existsSync(recordingsDir);
+if (!haveRecordings) {
+  console.warn(
+    `[build-show-index] recordings dir not found: ${recordingsDir} — recordings list omitted.`,
+  );
+}
+function loadRecording(identifier) {
+  if (!haveRecordings) return null;
+  try {
+    const r = JSON.parse(
+      fs.readFileSync(path.join(recordingsDir, `${identifier}.json`), "utf-8"),
+    );
+    return {
+      identifier: r.identifier ?? identifier,
+      source_type: r.source_type ?? "UNKNOWN",
+      rating: r.rating ?? 0,
+      review_count: r.review_count ?? 0,
+      runtime: r.runtime ?? "",
+    };
+  } catch {
+    return null;
+  }
+}
+
 for (const file of files) {
   try {
     const s = JSON.parse(fs.readFileSync(path.join(showsDir, file), "utf-8"));
     if (!s.show_id) continue;
+    const recordings = Array.isArray(s.recordings)
+      ? s.recordings.map(loadRecording).filter(Boolean)
+      : [];
     index[s.show_id] = {
       date: s.date ?? null,
       venue: s.venue ?? null,
@@ -58,6 +91,7 @@ for (const file of files) {
       recordingCount: s.recording_count ?? 0,
       image: resolveImage(s),
       bestRecordingId: s.best_recording ?? null,
+      recordings,
     };
   } catch (err) {
     console.warn(`[build-show-index] skip ${file}: ${err.message}`);

--- a/api/scripts/build-show-index.mjs
+++ b/api/scripts/build-show-index.mjs
@@ -50,6 +50,13 @@ function resolveImage(s) {
 // The compact per-recording shape the web recording menu needs (source badge,
 // rating, review count, runtime). Resolved by reading each recording's own
 // JSON; the browser has no catalog, so the API serves this by showId.
+//
+// ⚠️ TECH DEBT — every field added to this shape is baked into the index for
+// EVERY recording of EVERY show, growing the blob the API loads wholesale into
+// RAM (adding these five fields already ~5×'d it: ~0.6 → ~3.1 MB). Before
+// widening this, read ADR-0012 (docs/adr/0012-show-index-in-memory-json.md):
+// more recording fields is the named trigger to move the show index into a
+// SQLite table instead of growing this file.
 const haveRecordings = fs.existsSync(recordingsDir);
 if (!haveRecordings) {
   console.warn(

--- a/api/src/showCatalog.ts
+++ b/api/src/showCatalog.ts
@@ -10,6 +10,14 @@ import path from "node:path";
 // The compact per-recording fields the web recording menu renders. The browser
 // has no catalog of its own, so the API serves a show's recordings by showId
 // (e.g. to populate the picker for a Connect-hydrated / refreshed session).
+//
+// ⚠️ TECH DEBT — adding fields here grows the in-memory index. See ADR-0012
+// (docs/adr/0012-show-index-in-memory-json.md). This whole catalog is a
+// boot-loaded JSON blob held in RAM (see loadShowCatalog below); attaching these
+// recordings already ~5×'d it (~0.6 → ~3.1 MB), and each new per-recording field
+// multiplies across every recording of every show. If you are here to add a
+// field, that is the trigger to migrate this to a SQLite table (queried by
+// showId) rather than fatten the blob further — read the ADR first.
 export interface RecordingMeta {
   identifier: string;
   source_type: string;

--- a/api/src/showCatalog.ts
+++ b/api/src/showCatalog.ts
@@ -7,6 +7,17 @@ import path from "node:path";
 // user-data responses (recents, favorites) with display fields.
 // See PLANS/web-profile.md (show-metadata source).
 
+// The compact per-recording fields the web recording menu renders. The browser
+// has no catalog of its own, so the API serves a show's recordings by showId
+// (e.g. to populate the picker for a Connect-hydrated / refreshed session).
+export interface RecordingMeta {
+  identifier: string;
+  source_type: string;
+  rating: number;
+  review_count: number;
+  runtime: string;
+}
+
 export interface ShowMeta {
   date: string | null;
   venue: string | null;
@@ -19,6 +30,9 @@ export interface ShowMeta {
   image: string | null;
   // Archive.org recording id, for the thumbnail fallback when image is null.
   bestRecordingId: string | null;
+  // Selectable recordings for this show, in catalog order. May be absent in an
+  // older index built before recordings were included.
+  recordings?: RecordingMeta[];
 }
 
 let catalog = new Map<string, ShowMeta>();

--- a/data/scripts/build_catalog_db.py
+++ b/data/scripts/build_catalog_db.py
@@ -4,7 +4,7 @@ Build the prebuilt catalog seed (catalog.db) from stage02.
 
 The seed is a catalog-only SQLite database that both apps copy into their own
 (already-migrated) DB via ATTACH + INSERT...SELECT, instead of importing ~20k
-JSON files on-device. See docs/adr/0007-prebuilt-catalog-db.md and
+JSON files on-device. See docs/adr/0013-prebuilt-catalog-db.md and
 PLANS/prebuilt-catalog-db.md.
 
   - Schema is created from data/catalog_schema.json (single source of truth; the

--- a/docs/adr/0009-non-destructive-catalog-refresh.md
+++ b/docs/adr/0009-non-destructive-catalog-refresh.md
@@ -4,7 +4,7 @@
 
 Proposed (2026-06-08).
 
-Builds on [ADR-0007](0007-prebuilt-catalog-db.md) (prebuilt catalog seed). That
+Builds on [ADR-0013](0013-prebuilt-catalog-db.md) (prebuilt catalog seed). That
 ADR introduced a second import path (seed) alongside the existing JSON import;
 this ADR fixes a data-loss bug that exists in **both** and predates the seed
 work.
@@ -65,7 +65,7 @@ Make catalog refresh non-destructive to user data by never deleting `shows`.
 
 2. **Keep `DELETE` + re-insert for the childless catalog tables** —
    `recordings`, `dead_collections`, and the `show_search` FTS (rebuilt on-device
-   per ADR-0007 #5). They have no user children, so a clean replace is exact and
+   per ADR-0013 #5). They have no user children, so a clean replace is exact and
    simple. `recordings` is the volatile table (tapes are deprecated/added far more
    often than shows); replacing it wholesale handles its churn with no special
    casing. A `recording_preferences.recordingId` that points at a now-removed
@@ -129,7 +129,7 @@ there is no migration to ship.
   Pre-existing UI behavior already tolerates a missing recording.
 - Two import paths still coexist this release. The JSON path's deprecation is
   **scheduled for the release after the seed bakes in the wild** — it remains the
-  ADR-0007 zero-risk fallback for now, and costs nothing in the happy path
+  ADR-0013 zero-risk fallback for now, and costs nothing in the happy path
   (`data.zip` is only downloaded if the seed import fails).
 
 ## Alternatives considered
@@ -151,7 +151,7 @@ there is no migration to ship.
 - **Kill the JSON import path now and rely on the seed alone.** Tempting (the
   canonical transform already lives in `build_catalog_db.py`, and the duplicated
   bug shows the cost of two paths). Rejected for this release: it removes the
-  ADR-0007 zero-risk fallback in the same release the seed first ships broadly,
+  ADR-0013 zero-risk fallback in the same release the seed first ships broadly,
   with no happy-path benefit. Deferred to a follow-up release.
 </content>
 </invoke>

--- a/docs/adr/0012-show-index-in-memory-json.md
+++ b/docs/adr/0012-show-index-in-memory-json.md
@@ -1,0 +1,99 @@
+# ADR-0012: Show index as a boot-loaded in-memory JSON map (and when to move it to SQLite)
+
+## Status
+
+Accepted (2026-06-12). Documents a decision already shipped in
+`feat(web/player): surface recording selection across show page and player`
+(commit `78849112`, PR #66). This ADR records *why the JSON-map shape was kept*
+when per-recording display data was added to it, and — more importantly — sets
+the **explicit trigger** at which we should stop and migrate to SQLite.
+
+## Context
+
+The API holds no show catalog of its own. `api/src/showCatalog.ts` loads a
+compact index from `show-index.json` **once at boot** into an in-memory `Map`,
+built offline by `api/scripts/build-show-index.mjs` (`make api-show-index`). It
+enriches user-data responses (recents/favorites display fields) and backs web
+auto-advance's `getNextShow` (the browser has no catalog, so it asks the API for
+the next show chronologically — ADR-0010).
+
+PR #66 added a per-recording array to each show entry so the new web recording
+picker works for Connect-hydrated / refreshed sessions (where the client has no
+`activeShow.recordings`). The API serves a show's recordings by id from the same
+in-memory map. **This roughly 5×'d the index on disk and in resident memory
+(~0.6 MB → ~3.1 MB).**
+
+That growth is the thing this ADR exists to flag. The index now carries
+**display data per recording**, not just per show — a dimension that grows with
+both the recording count *and* the number of fields each recording carries. The
+file is also the **only** show-metadata store living as a loose JSON blob next to
+the real SQLite DBs (`users.db`, analytics, notifications) in the mounted data
+dir — it is the odd one out, and `better-sqlite3` is already a dependency and
+already loaded in-process.
+
+So the question was raised directly: **is JSON-in-memory strictly better than
+just adding a SQLite table?** It is not strictly better — it is a deliberate
+trade that is correct *today* and has a clear expiry.
+
+## Decision
+
+**Keep the boot-loaded in-memory JSON map for now.** Do not migrate to SQLite in
+PR #66. The data is read-only, regenerated wholesale by the build script, never
+mutated at runtime, and read on hot paths by key (`catalog.get(showId)`) or by a
+cached chronological key-walk (`getNextShow`) — exactly the shape an in-memory
+map serves well and cheaply, with no query or serialization overhead per read.
+
+**But this is debt with a named trigger, not a settled end state.** Migrate the
+show index to a SQLite table (queried by `showId`, keeping at most a small
+in-memory structure for `getNextShow`'s chronological walk) when **any** of these
+fire:
+
+1. **More per-recording fields get added.** This is the load-bearing trigger.
+   The index grew 5× the *first* time recordings gained display data; the second
+   field-set (track listings, per-recording reviews, waveforms, lineage text,
+   download sizes, …) is where "load the entire catalog into heap to serve one
+   show" stops being defensible. **If you are reaching for this file to add a
+   recording field, that is the signal to do the SQLite migration instead.**
+2. **Resident memory starts to matter** on the API host (it does not today;
+   ~3 MB on a single instance is noise).
+3. **The API needs to scale horizontally.** The in-memory map is per-instance;
+   so is the Connect connection state (ADR-0011 §Consequences). A shared store
+   becomes necessary at the same time for both.
+
+The breadcrumb to this ADR lives in `api/src/showCatalog.ts` (the consumer) and
+`api/scripts/build-show-index.mjs` (the producer), at the points where adding a
+recording field would be tempting.
+
+## Consequences
+
+- **We accept ~3 MB of resident heap and a full-file JSON reparse at boot/regen**
+  in exchange for zero-overhead keyed reads and the smallest possible diff for the
+  recording-picker feature. Fine at current scale on a single instance.
+- **The index is the one show-metadata store not in SQLite.** We keep an
+  inconsistency (loose JSON beside the DBs) deliberately and temporarily, with the
+  migration trigger written down so the inconsistency does not quietly ossify.
+- **The next person to add a recording field inherits a decision, not a blank
+  slate.** The code breadcrumbs route them here; this ADR tells them the field
+  they are about to add is most likely the one that should trigger the migration
+  rather than another bump to the blob.
+- **`getNextShow`'s chronological walk is the one operation that genuinely wants
+  the whole keyspace in memory.** A SQLite migration should preserve a cheap path
+  for it (an `ORDER BY show_id` index, or retain a small sorted-id array in
+  memory) rather than naively round-trip per advance.
+
+## Alternatives considered
+
+- **Migrate to a SQLite table now, in PR #66.** Rejected for *that PR*: #66 is a
+  web feature, and the storage swap is an API refactor touching `loadShowCatalog`
+  / `getShowMeta` / `getNextShow` and the build script's output contract. It
+  deserves its own change and review, not a rider on a UI feature. This ADR is the
+  standing decision to do exactly that migration when a trigger above fires.
+- **Stream/lazy-load recordings from the per-recording JSON files at request
+  time** (skip baking them into the index). Rejected: trades the memory cost for
+  per-request disk reads and filesystem coupling in the API, and still is not the
+  consolidated, indexed store the real fix wants. SQLite is the better
+  destination than either the fat blob or loose file reads.
+- **Keep growing the JSON blob indefinitely.** Rejected as the default path — it
+  is precisely the "quietly accrete display fields until it hurts" failure this
+  ADR is written to interrupt. The map is fine; *unbounded field growth on it* is
+  the part we are pre-committing to stop.

--- a/docs/adr/0013-prebuilt-catalog-db.md
+++ b/docs/adr/0013-prebuilt-catalog-db.md
@@ -1,4 +1,9 @@
-# ADR-0007: Prebuilt catalog DB for first-launch
+# ADR-0013: Prebuilt catalog DB for first-launch
+
+> Renumbered from ADR-0007 (2026-06-12): the number 0007 had been minted twice
+> (this ADR and `0007-connect-background-socket-lifecycle.md`). The connect ADR,
+> referenced more widely, kept 0007; this one moved to 0013. Older references to
+> "ADR-0007" meaning the catalog seed point here.
 
 ## Status
 

--- a/iosApp/deadly/Core/Import/DataImportService.swift
+++ b/iosApp/deadly/Core/Import/DataImportService.swift
@@ -68,7 +68,7 @@ struct DataImportService: Sendable {
 
         // 2. PREFER the prebuilt catalog seed (sub-second attach-copy). Falls through
         //    to the JSON import below if no seed is published yet or the seed fails —
-        //    zero-risk migration (ADR-0007, Phase 4).
+        //    zero-risk migration (ADR-0013, Phase 4).
         if await importFromSeedIfAvailable(progress: emit) {
             return
         }

--- a/iosApp/deadly/Core/Import/SeedImportService.swift
+++ b/iosApp/deadly/Core/Import/SeedImportService.swift
@@ -9,7 +9,7 @@ import GRDB
 /// reviews, recents, sync outbox) and none of GRDB's migration bookkeeping.
 /// Opening it as the live DB would drop user data and confuse the migrator.
 /// Instead we keep the app's own migrated DB and copy the catalog rows into it.
-/// See `docs/adr/0007-prebuilt-catalog-db.md`.
+/// See `docs/adr/0013-prebuilt-catalog-db.md`.
 ///
 /// Flow (catalog writes in one transaction so the health gate — a committed
 /// `data_version` row — flips only on success):

--- a/ui/src/components/Recordings.tsx
+++ b/ui/src/components/Recordings.tsx
@@ -1,23 +1,13 @@
 import type { Recording } from "@/types/recording";
 import type { AiShowReview } from "@/types/show";
-
-const SOURCE_COLORS: Record<string, string> = {
-  SBD: "bg-deadly-highlight text-white",
-  FM: "bg-deadly-highlight text-white",
-  Matrix: "bg-deadly-highlight text-white",
-  Remaster: "bg-deadly-highlight text-white",
-  AUD: "bg-amber-700 text-white",
-  UNKNOWN: "bg-white/20 text-white/70",
-};
+import { sourceColors, sourceLabel } from "@/lib/sourceType";
 
 function SourceBadge({ type }: { type: string }) {
-  const label = type === "UNKNOWN" ? "Unknown" : type;
-  const colors = SOURCE_COLORS[type] ?? SOURCE_COLORS.UNKNOWN;
   return (
     <span
-      className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${colors}`}
+      className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${sourceColors(type)}`}
     >
-      {label}
+      {sourceLabel(type)}
     </span>
   );
 }

--- a/ui/src/components/player/HeaderPlayer.tsx
+++ b/ui/src/components/player/HeaderPlayer.tsx
@@ -13,6 +13,7 @@ import { useInterpolatedPosition } from "@/hooks/useInterpolatedPosition";
 import ShowArtwork from "@/components/show/ShowArtwork";
 import AutoplayPrompt from "./AutoplayPrompt";
 import RecordingSelector from "./RecordingSelector";
+import RecordingMenu from "./RecordingMenu";
 import TrackList from "./TrackList";
 import PlayerRailPanel from "./PlayerRailPanel";
 import DeviceList from "@/components/connect/DeviceList";
@@ -751,7 +752,18 @@ export default function HeaderPlayer() {
         </div>
       </button>
       {showLoaded && (
-       <div className="flex flex-shrink-0 flex-col items-end gap-1">
+       <div className="flex flex-shrink-0 items-center gap-1">
+        {activeShow && activeShow.recordings.length > 1 && (
+          <RecordingMenu
+            recordings={activeShow.recordings}
+            selectedId={selectedRecording}
+            onSelect={selectRecording}
+            variant="icon"
+            openDirection="up"
+            align="right"
+          />
+        )}
+       <div className="flex flex-col items-end gap-1">
         {deviceLabel && (
           <span className="max-w-[110px] truncate text-[10px] font-medium leading-none text-deadly-highlight">
             {deviceLabel}
@@ -777,6 +789,7 @@ export default function HeaderPlayer() {
             </svg>
           )}
         </button>
+       </div>
        </div>
       )}
     </div>
@@ -874,6 +887,16 @@ export default function HeaderPlayer() {
               <path d="M18.6 6.62c-1.44 0-2.8.56-3.77 1.53L7.8 14.39c-.64.64-1.49.99-2.4.99-1.87 0-3.39-1.51-3.39-3.38S3.53 8.62 5.4 8.62c.91 0 1.76.35 2.44 1.03l1.13 1 1.51-1.34L9.22 8.2C8.2 7.18 6.84 6.62 5.4 6.62 2.42 6.62 0 9.04 0 12s2.42 5.38 5.4 5.38c1.44 0 2.8-.56 3.77-1.53l7.03-6.24c.64-.64 1.49-.99 2.4-.99 1.87 0 3.39 1.51 3.39 3.38s-1.52 3.38-3.39 3.38c-.9 0-1.76-.35-2.44-1.03l-1.14-1.01-1.51 1.34 1.27 1.12c1.02 1.01 2.37 1.57 3.82 1.57 2.98 0 5.4-2.41 5.4-5.38s-2.42-5.37-5.4-5.37z" />
             </svg>
           </button>
+        )}
+        {activeShow && activeShow.recordings.length > 1 && (
+          <RecordingMenu
+            recordings={activeShow.recordings}
+            selectedId={selectedRecording}
+            onSelect={selectRecording}
+            variant="icon"
+            openDirection="up"
+            align="right"
+          />
         )}
         {showLoaded && (
           <button
@@ -1216,6 +1239,16 @@ export default function HeaderPlayer() {
             <div className="min-w-0 flex-1">
               <SeekBar progress={progress} elapsed={displayElapsed} duration={displayDuration} onSeek={handleSeek} />
             </div>
+            {activeShow && activeShow.recordings.length > 0 && (
+              <RecordingMenu
+                recordings={activeShow.recordings}
+                selectedId={selectedRecording}
+                onSelect={selectRecording}
+                variant="icon"
+                openDirection="up"
+                align="right"
+              />
+            )}
             <VolumeControl volume={volume} setVolume={setVolume} />
             {displayTrackCount > 1 && (
               <span className="flex-shrink-0 text-xs tabular-nums text-white/40">

--- a/ui/src/components/player/PlayerProvider.tsx
+++ b/ui/src/components/player/PlayerProvider.tsx
@@ -11,6 +11,7 @@ import { rememberArt, lookupArt, rememberReview, lookupReview } from "@/lib/artC
 import { getAutoAdvanceEnabled, setAutoAdvanceEnabled } from "@/lib/playbackPrefs";
 import { PlayerContext } from "@/contexts/PlayerContext";
 import type { ViewedShow } from "@/contexts/PlayerContext";
+import type { Recording } from "@/types/recording";
 import { useConnect } from "@/contexts/ConnectContext";
 
 const AUTO_ADVANCE_DELAY_MS = 15_000; // ADR-0010 chunk 2: end-of-show countdown
@@ -37,6 +38,53 @@ function metaToViewedShow(m: ShowMetaResponse): ViewedShow {
     review: null,
   };
 }
+// The compact recording shape /api/shows/:id returns. Mapped onto the full
+// Recording type (unused fields defaulted) so a Connect-hydrated show can show
+// its recording picker — the browser has no catalog, so the API serves it.
+interface ApiRecordingMeta {
+  identifier: string;
+  source_type: string;
+  rating: number;
+  review_count: number;
+  runtime: string;
+}
+function apiRecordingToRecording(
+  r: ApiRecordingMeta,
+  show: { date?: string | null; venue?: string | null; location?: string | null },
+): Recording {
+  return {
+    identifier: r.identifier,
+    title: "",
+    date: show.date ?? "",
+    venue: show.venue ?? "",
+    location: show.location ?? "",
+    source_type: r.source_type,
+    lineage: "",
+    taper: "",
+    source: "",
+    runtime: r.runtime,
+    rating: r.rating,
+    raw_rating: r.rating,
+    review_count: r.review_count,
+    confidence: 0,
+    high_ratings: 0,
+    low_ratings: 0,
+  };
+}
+
+// Fetch a show's selectable recordings by id (catalog lives only in the API).
+async function fetchShowRecordings(showId: string): Promise<Recording[]> {
+  try {
+    const res = await fetch(`/api/shows/${encodeURIComponent(showId)}`);
+    if (!res.ok) return [];
+    const meta = await res.json();
+    const list: ApiRecordingMeta[] = Array.isArray(meta?.recordings) ? meta.recordings : [];
+    return list.map((r) => apiRecordingToRecording(r, meta));
+  } catch {
+    return [];
+  }
+}
+
 const PREV_TRACK_THRESHOLD = 3; // seconds
 const AUDIO_RETRY_DELAYS = [0, 1000, 2000];
 const GAPLESS_PRELOAD_THRESHOLD = 2; // seconds before end to start preloading
@@ -743,6 +791,20 @@ export default function PlayerProvider({
           setCurrentTrackIndex(targetTrack < fetchedTracks.length ? targetTrack : 0);
         }
       });
+      // Backfill the selectable recordings so the picker works for this
+      // hydrated show (remote viewer, or after a refresh mid-playback). The
+      // server state carries only the active recordingId; the rest come from
+      // the API catalog by showId.
+      if (showId) {
+        fetchShowRecordings(showId).then((recs) => {
+          if (recs.length === 0) return;
+          setActiveShow((prev) =>
+            prev && prev.showId === showId && prev.recordings.length === 0
+              ? { ...prev, recordings: recs }
+              : prev,
+          );
+        });
+      }
       // Resolve real show metadata (date/venue/location) from Archive.org — the
       // session state may carry none (position-only hydrate). Client-resolve.
       fetchArchiveShowMeta(connectState.recordingId).then((meta) => {
@@ -1353,14 +1415,37 @@ export default function PlayerProvider({
   }, [close]);
 
   const selectRecording = useCallback(
-    (identifier: string) => {
+    async (identifier: string) => {
+      if (identifier === selectedRecordingRef.current) return;
       setSelectedRecording(identifier);
-      // If already playing, switch to the new recording
-      if (statusRef.current !== "idle") {
-        playRecording(identifier);
-      }
+      // Idle (parked / not started): just remember the choice — Play loads it.
+      if (statusRef.current === "idle") return;
+      // Switching while playing: load the new recording's tracks and claim the
+      // shared session with it. The `load` is what makes the switch stick — a
+      // bare local swap leaves the server on the old recordingId, and the next
+      // ConnectState broadcast reconciles us right back to it. It also moves any
+      // other devices in the session to the new recording.
+      nextPlaybackSourceRef.current = "browse";
+      const fetched = await playRecording(identifier);
+      if (fetched.length === 0) return;
+      const show = activeShowRef.current;
+      sendCommandRef.current("load", {
+        showId: show?.showId ?? connectState?.showId ?? "",
+        recordingId: identifier,
+        tracks: fetched.map((t) => ({
+          title: t.title,
+          durationMs: Math.round((t.duration || 0) * 1000),
+        })),
+        trackIndex: 0,
+        positionMs: 0,
+        durationMs: Math.round((fetched[0]?.duration ?? 0) * 1000),
+        date: show?.date,
+        venue: show?.venue,
+        location: show?.location,
+        autoplay: true,
+      });
     },
-    [playRecording]
+    [playRecording, connectState?.showId]
   );
 
   const retryAutoplay = useCallback(() => {

--- a/ui/src/components/player/PlayerRailPanel.tsx
+++ b/ui/src/components/player/PlayerRailPanel.tsx
@@ -5,15 +5,7 @@ import { useConnect } from "@/contexts/ConnectContext";
 import TrackList from "./TrackList";
 import RecordingSelector from "./RecordingSelector";
 import DeviceList from "@/components/connect/DeviceList";
-
-const SOURCE_COLORS: Record<string, string> = {
-  SBD: "bg-deadly-highlight text-white",
-  FM: "bg-deadly-highlight text-white",
-  Matrix: "bg-deadly-highlight text-white",
-  Remaster: "bg-deadly-highlight text-white",
-  AUD: "bg-amber-700 text-white",
-  UNKNOWN: "bg-white/20 text-white/70",
-};
+import { sourceColors, sourceLabel } from "@/lib/sourceType";
 
 function formatShowDate(dateStr: string): string {
   const [y, m, d] = dateStr.split("-").map(Number);
@@ -93,14 +85,8 @@ export default function PlayerRailPanel({
   const recording = activeShow.recordings.find(
     (r) => r.identifier === selectedRecording,
   );
-  const sourceLabel = recording
-    ? recording.source_type === "UNKNOWN"
-      ? "Unknown"
-      : recording.source_type
-    : null;
-  const sourceColors = recording
-    ? (SOURCE_COLORS[recording.source_type] ?? SOURCE_COLORS.UNKNOWN)
-    : null;
+  const srcLabel = recording ? sourceLabel(recording.source_type) : null;
+  const srcColors = recording ? sourceColors(recording.source_type) : null;
   const venue =
     activeShow.venue + (activeShow.location ? `, ${activeShow.location}` : "");
 
@@ -111,11 +97,11 @@ export default function PlayerRailPanel({
         <p className="text-sm font-medium text-white">
           {formatShowDate(activeShow.date)}
         </p>
-        {sourceLabel && sourceColors && (
+        {srcLabel && srcColors && (
           <span
-            className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-medium ${sourceColors}`}
+            className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-medium ${srcColors}`}
           >
-            {sourceLabel}
+            {srcLabel}
           </span>
         )}
       </div>

--- a/ui/src/components/player/QueuePanel.tsx
+++ b/ui/src/components/player/QueuePanel.tsx
@@ -4,15 +4,7 @@ import { useEffect } from "react";
 import { usePlayer } from "@/contexts/PlayerContext";
 import TrackList from "./TrackList";
 import RecordingSelector from "./RecordingSelector";
-
-const SOURCE_COLORS: Record<string, string> = {
-  SBD: "bg-deadly-highlight text-white",
-  FM: "bg-deadly-highlight text-white",
-  Matrix: "bg-deadly-highlight text-white",
-  Remaster: "bg-deadly-highlight text-white",
-  AUD: "bg-amber-700 text-white",
-  UNKNOWN: "bg-white/20 text-white/70",
-};
+import { sourceColors, sourceLabel } from "@/lib/sourceType";
 
 function formatShowDate(dateStr: string): string {
   const [y, m, d] = dateStr.split("-").map(Number);
@@ -53,14 +45,8 @@ export default function QueuePanel({ onClose }: QueuePanelProps) {
   const recording = activeShow.recordings.find(
     (r) => r.identifier === selectedRecording
   );
-  const sourceLabel = recording
-    ? recording.source_type === "UNKNOWN"
-      ? "Unknown"
-      : recording.source_type
-    : null;
-  const sourceColors = recording
-    ? (SOURCE_COLORS[recording.source_type] ?? SOURCE_COLORS.UNKNOWN)
-    : null;
+  const srcLabel = recording ? sourceLabel(recording.source_type) : null;
+  const srcColors = recording ? sourceColors(recording.source_type) : null;
 
   const venue =
     activeShow.venue +
@@ -79,11 +65,11 @@ export default function QueuePanel({ onClose }: QueuePanelProps) {
             <p className="text-sm font-medium text-white">
               {formatShowDate(activeShow.date)}
             </p>
-            {sourceLabel && sourceColors && (
+            {srcLabel && srcColors && (
               <span
-                className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-medium ${sourceColors}`}
+                className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-medium ${srcColors}`}
               >
-                {sourceLabel}
+                {srcLabel}
               </span>
             )}
           </div>

--- a/ui/src/components/player/RecordingMenu.tsx
+++ b/ui/src/components/player/RecordingMenu.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { Recording } from "@/types/recording";
+import { sourceColors, sourceLabel } from "@/lib/sourceType";
+
+function SourcePill({ type }: { type: string }) {
+  return (
+    <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${sourceColors(type)}`}>
+      {sourceLabel(type)}
+    </span>
+  );
+}
+
+// Overlapping-layers glyph — "this show has multiple recordings to choose from".
+// Deliberately distinct from the queue's list icon.
+function LayersIcon({ size = 18 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 2 2 7l10 5 10-5-10-5zm0 7.74L4.74 7 12 4.26 19.26 7 12 9.74zM2 12l10 5 10-5-2.27-1.14L12 14.49 4.27 10.86 2 12zm0 5 10 5 10-5-2.27-1.14L12 19.49 4.27 15.86 2 17z" />
+    </svg>
+  );
+}
+
+interface RecordingMenuProps {
+  recordings: Recording[];
+  selectedId: string | null;
+  onSelect: (identifier: string) => void;
+  // "icon" = compact glyph for the player bar / fullscreen controls.
+  // "pill" = labeled pill for the show page actions row.
+  variant?: "icon" | "pill";
+  // Which way the popover opens, relative to the trigger.
+  openDirection?: "up" | "down";
+  align?: "left" | "right";
+  className?: string;
+}
+
+// A single entry point to choose a recording, surfaced everywhere playback is:
+// the show page, the docked player bar, and the fullscreen player. Reads its
+// list + selection from props (PlayerContext for live playback, local pending
+// state on the show page) so one component serves them all.
+export default function RecordingMenu({
+  recordings,
+  selectedId,
+  onSelect,
+  variant = "icon",
+  openDirection = "up",
+  align = "right",
+  className = "",
+}: RecordingMenuProps) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  // Close on outside click or Escape while open.
+  useEffect(() => {
+    if (!open) return;
+    function onDown(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  if (recordings.length === 0) return null;
+
+  const selected = recordings.find((r) => r.identifier === selectedId) ?? null;
+  // With a single recording there's nothing to choose — show the source as a
+  // static label so the fullscreen "always a spot" rule still reads cleanly.
+  const onlyOne = recordings.length <= 1;
+
+  const popoverPos = [
+    openDirection === "up" ? "bottom-full mb-2" : "top-full mt-2",
+    align === "right" ? "right-0" : "left-0",
+  ].join(" ");
+
+  function handlePick(id: string) {
+    onSelect(id);
+    setOpen(false);
+  }
+
+  return (
+    <div ref={rootRef} className={`relative ${className}`} data-no-expand>
+      {variant === "pill" ? (
+        <button
+          onClick={() => !onlyOne && setOpen((o) => !o)}
+          disabled={onlyOne}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-label="Choose recording"
+          title={onlyOne ? "Only one recording" : "Choose a different recording"}
+          className={`inline-flex items-center gap-1.5 rounded-full border py-2.5 pl-3 pr-3.5 text-sm font-semibold transition ${
+            onlyOne
+              ? "border-white/10 text-white/60"
+              : "border-white/15 text-white/80 hover:border-white/30 hover:text-white"
+          }`}
+        >
+          <LayersIcon size={16} />
+          {selected ? <SourcePill type={selected.source_type} /> : <span>Choose</span>}
+          {selected && selected.rating > 0 && (
+            <span className="text-xs text-deadly-star">★ {selected.rating.toFixed(1)}</span>
+          )}
+          {!onlyOne && (
+            <span className={`text-xs text-white/40 transition-transform ${open ? "rotate-180" : ""}`}>▾</span>
+          )}
+        </button>
+      ) : (
+        <button
+          onClick={() => !onlyOne && setOpen((o) => !o)}
+          disabled={onlyOne}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-label="Choose recording"
+          title={onlyOne ? "Only one recording" : "Choose a different recording"}
+          className={`rounded-full p-2 transition-colors disabled:text-white/20 ${
+            open ? "text-deadly-highlight" : "text-white/50 hover:text-white/80"
+          }`}
+        >
+          <LayersIcon />
+        </button>
+      )}
+
+      {open && (
+        <div
+          role="menu"
+          className={`absolute z-50 ${popoverPos} max-h-[60vh] w-72 max-w-[80vw] overflow-y-auto rounded-lg border border-white/10 bg-deadly-surface p-2 shadow-xl shadow-black/40`}
+        >
+          <p className="px-2 pb-1.5 pt-1 text-xs font-bold uppercase tracking-wider text-deadly-title/80">
+            Recordings ({recordings.length})
+          </p>
+          <div className="space-y-1">
+            {recordings.map((rec) => {
+              const isSelected = rec.identifier === selectedId;
+              return (
+                <button
+                  key={rec.identifier}
+                  role="menuitemradio"
+                  aria-checked={isSelected}
+                  onClick={() => handlePick(rec.identifier)}
+                  className={`flex w-full items-center gap-2 rounded-md px-2 py-2 text-left transition-colors hover:bg-white/5 ${
+                    isSelected ? "border border-deadly-highlight/30 bg-white/5" : "border border-transparent"
+                  }`}
+                >
+                  <SourcePill type={rec.source_type} />
+                  {rec.rating > 0 && (
+                    <span className="text-xs text-deadly-star">★ {rec.rating.toFixed(1)}</span>
+                  )}
+                  {rec.review_count > 0 && (
+                    <span className="text-xs text-white/40">({rec.review_count})</span>
+                  )}
+                  {rec.runtime && (
+                    <span className="ml-auto text-xs text-white/30">{rec.runtime}</span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/player/RecordingSelector.tsx
+++ b/ui/src/components/player/RecordingSelector.tsx
@@ -2,24 +2,11 @@
 
 import { useState } from "react";
 import type { Recording } from "@/types/recording";
-
-const SOURCE_COLORS: Record<string, string> = {
-  SBD: "bg-deadly-highlight text-white",
-  FM: "bg-deadly-highlight text-white",
-  Matrix: "bg-deadly-highlight text-white",
-  Remaster: "bg-deadly-highlight text-white",
-  AUD: "bg-amber-700 text-white",
-  UNKNOWN: "bg-white/20 text-white/70",
-};
-
-function sourceLabel(type: string): string {
-  return type === "UNKNOWN" ? "Unknown" : type;
-}
+import { sourceColors, sourceLabel } from "@/lib/sourceType";
 
 function SourcePill({ type }: { type: string }) {
-  const colors = SOURCE_COLORS[type] ?? SOURCE_COLORS.UNKNOWN;
   return (
-    <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${colors}`}>
+    <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${sourceColors(type)}`}>
       {sourceLabel(type)}
     </span>
   );

--- a/ui/src/components/show/HeroActions.tsx
+++ b/ui/src/components/show/HeroActions.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useUserData } from "@/contexts/UserDataContext";
 import { usePlayer } from "@/contexts/PlayerContext";
 import QrButton from "@/components/share/QrButton";
+import RecordingMenu from "@/components/player/RecordingMenu";
 import { useShareLink } from "@/components/share/useShareLink";
 import type { Recording } from "@/types/recording";
 import type { AiShowReview } from "@/types/show";
@@ -40,7 +41,9 @@ export default function HeroActions({
   const fav = isFavorite(showId);
   const existing = getReview(showId);
 
-  const [pendingRecordingId] = useState<string | null>(
+  // Which recording Play will load (and what QR/Share point at). Seeded from the
+  // best recording; the recording menu can change it before you ever hit Play.
+  const [pendingRecordingId, setPendingRecordingId] = useState<string | null>(
     bestRecordingId ?? recordings[0]?.identifier ?? null,
   );
 
@@ -74,6 +77,23 @@ export default function HeroActions({
   const isPlaying = isActiveShow && player.status === "playing";
   const canPlay = recordings.length > 0;
 
+  // The recording shown as selected: mirror the live player while this show is
+  // the active one (so switching from the player reflects here too), otherwise
+  // the pending pick that Play will load.
+  const selectedRecordingId =
+    isActiveShow && player.selectedRecording
+      ? player.selectedRecording
+      : pendingRecordingId;
+
+  function handleSelectRecording(identifier: string) {
+    setPendingRecordingId(identifier);
+    // If this show is already loaded in the player, switch it live; otherwise
+    // it just changes what the Play button will load.
+    if (isActiveShow && player.status !== "idle") {
+      player.selectRecording(identifier);
+    }
+  }
+
   function handlePlay() {
     // If this show is already loaded in the player, behave exactly like the
     // player's own play/pause button (toggle). Only fall through to a fresh
@@ -84,7 +104,7 @@ export default function HeroActions({
       player.playShow({
         showId,
         recordings,
-        bestRecordingId: pendingRecordingId,
+        bestRecordingId: selectedRecordingId,
         date,
         venue,
         location,
@@ -113,6 +133,8 @@ export default function HeroActions({
 
   return (
     <div className="mb-6 w-full">
+      {/* Primary line: Play (labeled) + the recording chip it loads. Secondary
+          actions collapse to icon-only buttons so the row stays uncluttered. */}
       <div className="flex flex-wrap items-center justify-center gap-2 sm:justify-start">
         {canPlay && (
           <button
@@ -125,42 +147,59 @@ export default function HeroActions({
           </button>
         )}
 
-        <PillButton active={fav} onClick={() => toggleFavorite(showId)}>
-          <Icon name="heart" filled={fav} />
-          {fav ? "Favorited" : "Favorite"}
-        </PillButton>
+        {recordings.length > 1 && (
+          <RecordingMenu
+            recordings={recordings}
+            selectedId={selectedRecordingId}
+            onSelect={handleSelectRecording}
+            variant="pill"
+            openDirection="down"
+            align="left"
+          />
+        )}
 
-        <PillButton
+        {/* A thin divider sets the labeled primaries off from the icon cluster. */}
+        <span className="mx-1 hidden h-6 w-px self-center bg-white/10 sm:block" aria-hidden="true" />
+
+        <IconButton
+          active={fav}
+          onClick={() => toggleFavorite(showId)}
+          label={fav ? "Favorited" : "Favorite"}
+        >
+          <Icon name="heart" filled={fav} />
+        </IconButton>
+
+        <IconButton
+          active={!!existing || reviewOpen}
+          onClick={() => setReviewOpen((o) => !o)}
+          label={existing ? "Your review" : "Review"}
+        >
+          <Icon name="star" filled={!!existing} />
+        </IconButton>
+
+        <IconButton
           active={player.autoAdvanceEnabled}
           onClick={player.toggleAutoAdvance}
-          title="Roll into the next show when this one ends"
+          label="Autoplay Next Show — roll into the next show when this one ends"
         >
           <Icon name="autoplay" />
-          Autoplay Next Show
-        </PillButton>
+        </IconButton>
 
-        <PillButton active={reviewOpen || !!existing} onClick={() => setReviewOpen((o) => !o)}>
-          <Icon name="star" filled={!!existing} />
-          {existing ? "Your review" : "Review"}
-        </PillButton>
+        <IconButton onClick={() => shareLink(showId, selectedRecordingId)} label="Share link">
+          <Icon name="share" />
+        </IconButton>
 
         <QrButton
           showId={showId}
-          recordingId={pendingRecordingId}
+          recordingId={selectedRecordingId}
           subtitle={venue ? `${date} · ${venue}` : date}
         >
           {(open) => (
-            <PillButton onClick={open}>
+            <IconButton onClick={open} label="QR code">
               <Icon name="qr" />
-              QR
-            </PillButton>
+            </IconButton>
           )}
         </QrButton>
-
-        <PillButton onClick={() => shareLink(showId, pendingRecordingId)}>
-          <Icon name="share" />
-          Share
-        </PillButton>
       </div>
 
       {reviewOpen && (
@@ -219,22 +258,26 @@ export default function HeroActions({
   );
 }
 
-function PillButton({
+// Compact, icon-only secondary action. `label` is both the tooltip and the
+// accessible name, so the icons stay self-explanatory without text pills.
+function IconButton({
   active,
   onClick,
-  title,
+  label,
   children,
 }: {
   active?: boolean;
   onClick: () => void;
-  title?: string;
+  label: string;
   children: React.ReactNode;
 }) {
   return (
     <button
       onClick={onClick}
-      title={title}
-      className={`inline-flex items-center gap-2 rounded-full border px-4 py-2.5 text-sm font-semibold transition hover:scale-105 ${
+      title={label}
+      aria-label={label}
+      aria-pressed={active}
+      className={`inline-flex h-11 w-11 items-center justify-center rounded-full border transition hover:scale-105 ${
         active
           ? "border-deadly-accent text-deadly-accent"
           : "border-white/15 text-white/80 hover:border-white/30 hover:text-white"

--- a/ui/src/components/show/ShowLinerNotes.tsx
+++ b/ui/src/components/show/ShowLinerNotes.tsx
@@ -1,5 +1,6 @@
 import type { AiShowReview, LineupMember } from "@/types/show";
 import type { Recording } from "@/types/recording";
+import { sourceColors, sourceLabel } from "@/lib/sourceType";
 
 // The "liner notes" right rail on a show page — the editorial content that
 // makes The Deadly more than a Spotify clone. Surfaces the structured parts
@@ -8,20 +9,10 @@ import type { Recording } from "@/types/recording";
 // stays in the middle column ("About this show"); this is the at-a-glance
 // companion rail. Renders only the panels it has data for.
 
-const SOURCE_COLORS: Record<string, string> = {
-  SBD: "bg-deadly-highlight text-white",
-  FM: "bg-deadly-highlight text-white",
-  Matrix: "bg-deadly-highlight text-white",
-  Remaster: "bg-deadly-highlight text-white",
-  AUD: "bg-amber-700 text-white",
-  UNKNOWN: "bg-white/20 text-white/70",
-};
-
 function SourceBadge({ type }: { type: string }) {
-  const colors = SOURCE_COLORS[type] ?? SOURCE_COLORS.UNKNOWN;
   return (
-    <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${colors}`}>
-      {type === "UNKNOWN" ? "Unknown" : type}
+    <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${sourceColors(type)}`}>
+      {sourceLabel(type)}
     </span>
   );
 }

--- a/ui/src/lib/sourceType.ts
+++ b/ui/src/lib/sourceType.ts
@@ -1,0 +1,29 @@
+// Single source of truth for recording source-type badges. Catalog data is
+// inconsistently cased (e.g. "MATRIX" vs "Matrix", "SBD"), so every lookup
+// normalizes to uppercase. Acronyms (SBD/FM/AUD) display as-is; multi-letter
+// words get title-cased so they don't shout ("MATRIX" -> "Matrix").
+
+const SOURCE_COLORS: Record<string, string> = {
+  SBD: "bg-deadly-highlight text-white",
+  FM: "bg-deadly-highlight text-white",
+  MATRIX: "bg-deadly-highlight text-white",
+  REMASTER: "bg-deadly-highlight text-white",
+  AUD: "bg-amber-700 text-white",
+  UNKNOWN: "bg-white/20 text-white/70",
+};
+
+// Override the default uppercase rendering for types that read better cased.
+const SOURCE_LABELS: Record<string, string> = {
+  MATRIX: "Matrix",
+  REMASTER: "Remaster",
+  UNKNOWN: "Unknown",
+};
+
+export function sourceColors(type: string): string {
+  return SOURCE_COLORS[(type ?? "").toUpperCase()] ?? SOURCE_COLORS.UNKNOWN;
+}
+
+export function sourceLabel(type: string): string {
+  const key = (type ?? "").toUpperCase();
+  return SOURCE_LABELS[key] ?? (key || "Unknown");
+}


### PR DESCRIPTION
## Problem
Choosing a different recording on the web app was effectively hidden. It only lived inside the player's **queue panel**, gated on `activeShow.recordings`, so:
- the **show page** had no recording control at all, and
- it **vanished entirely** for Connect-hydrated / refreshed shows (which carry `recordings: []`).

Picking a recording also didn't reliably switch playback in a Connect session.

## What changed
**New reusable control**
- `RecordingMenu` — a layered-stack icon (or labeled pill) popover that lists each recording with source · rating · reviews · runtime. One component serves the show page and the player.

**Show page (`HeroActions`)**
- A recording chip sits next to **Play** and drives what Play loads (and what QR/Share point at).
- Secondary actions (Favorite / Review / Autoplay / Share / QR) collapse to icon-only buttons so the row stops being a wall of pills.

**Player**
- The menu is reachable from the **mobile bar**, the **desktop bar** (right of the autoplay ∞), and the **desktop fullscreen** controls.

**Switching actually sticks (bug fix)**
- `selectRecording` now sends a Connect `load`, so the pick holds instead of being reverted by the next `ConnectState` broadcast — and other devices in the session follow.

**Recordings by id for hydrated sessions**
- `build-show-index.mjs` attaches a compact `recordings` array; `ShowMeta` / `GET /api/shows/:id` carry it (no route change); `PlayerProvider` backfills `activeShow.recordings` so the picker appears for remote viewers / after a refresh. Index grew ~0.6 → ~3.1 MB (in-memory, fine).

**Cleanup**
- Normalized source-type badge casing (e.g. `MATRIX` → `Matrix`) via a shared `lib/sourceType` helper, routing all six prior call sites through it.

## Testing
- `tsc --noEmit` clean (ui + api), `make ui-build` clean.
- `make api-show-index` regenerates the enriched index; `GET /api/shows/:id` verified returning 23 recordings for Cornell '77.
- Exercised locally on the dockerized stack (show page chip, player icons, live switching).

> Note: `api/show-index.json` is a generated artifact (gitignored; rebuilt by `make api-show-index`, which `docker-up` depends on) — not included in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)