### PR TITLE
feat(mobile/settings): categorize Settings into a landing + subscreens, with icons

### DIFF
--- a/PLANS/ui-decluttering.md
+++ b/PLANS/ui-decluttering.md
@@ -219,8 +219,21 @@ declutter-only, don't over-specify in the ADR.
   has no web equivalent — dropped. Web Settings = Account + Playback + Community + About.
 - **Web show page:** already album-style; no change needed.
 
-### Phase 2+ — Settings (mobile) — NOT started
-- **Settings:** categorized subscreens + consolidated Home Layout screen (iOS+Android).
+### Phase 2 — Settings (mobile) — DONE (2026-06-12, branch `mobile-settings-rework`)
+- Flat `List`/`LazyColumn` replaced with a short landing of 5 categories, each its
+  own subscreen: **Account · Playback & Audio · Home Layout · Library & Data ·
+  About & Support**. All home-layout knobs gathered onto the one Home Layout screen.
+- iOS (`SettingsScreen.swift`): landing `List` of `NavigationLink`s → 5 subscreen
+  views; every binding/analytics call preserved verbatim. Compiles (`make ios-remote-build`).
+- Android (`SettingsScreen.kt`): Settings lives in the nav drawer, so landing →
+  subscreen is a local state drill-down with a back header + `BackHandler`; leaf
+  screens (Equalizer/Connect/Legal/…) stay full-screen routes. `SettingsScreen`
+  signature unchanged, so `SettingsNavigation.kt`/`MainNavigation.kt` untouched.
+  Compiles (`:feature:settings` + `:app`).
+- Knob→category map: Account=sign-in; Playback&Audio=controls+source badge+EQ+devices;
+  Home Layout=all trending/rails/fan-favorites/card-size knobs+reset; Library&Data=
+  include-no-recordings+downloads+import/export+migration; About&Support=version+
+  release notes+donate+community+mission+legal+privacy+developer.
 
 ---
 

--- a/androidApp/core/design/src/main/java/com/grateful/deadly/core/design/resources/IconResources.kt
+++ b/androidApp/core/design/src/main/java/com/grateful/deadly/core/design/resources/IconResources.kt
@@ -278,7 +278,10 @@ object IconResources {
         
         @Composable
         fun Cast() = customIcon(R.drawable.ic_cast)
-        
+
+        @Composable
+        fun Coffee() = customIcon(R.drawable.ic_coffee)
+
         @Composable
         fun TrendingUp() = customIcon(R.drawable.ic_trending_up)
         

--- a/androidApp/core/design/src/main/res/drawable/ic_coffee.xml
+++ b/androidApp/core/design/src/main/res/drawable/ic_coffee.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24" android:tint="?attr/colorControlNormal">
+  <path android:fillColor="#000000" android:pathData="M20,3H4v10c0,2.21 1.79,4 4,4h6c2.21,0 4,-1.79 4,-4v-3h2c1.11,0 2,-0.89 2,-2V5C22,3.89 21.11,3 20,3zM20,8h-2V5h2V8zM4,19h16v2H4z"/>
+</vector>

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
@@ -4,11 +4,16 @@ import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Message
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -22,6 +27,18 @@ import com.grateful.deadly.core.model.PlayerControlsStyle
 import com.grateful.deadly.core.model.SourceBadgeStyle
 import com.grateful.deadly.feature.settings.BuildConfig
 
+// ADR-0014: Settings is a short landing of stable categories, each its own
+// screen — Account · Playback & Audio · Home Layout · Library & Data ·
+// About & Support. The flat "scroll-forever" list is gone; every control now
+// lives behind the category it belongs to, with all home-layout knobs gathered
+// onto one dedicated screen.
+//
+// Android renders Settings inside the navigation drawer (not a nav destination),
+// so landing → subscreen is a local state drill-down with a back affordance.
+// The leaf screens (Equalizer, Connect, Legal, …) stay full-screen routes,
+// reached through the callbacks the host wires up.
+private enum class SettingsCategory { Account, PlaybackAudio, HomeLayout, LibraryData }
+
 @Composable
 fun SettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel(),
@@ -33,31 +50,318 @@ fun SettingsScreen(
     onNavigateToPrivacyData: () -> Unit = {},
     onNavigateToConnect: () -> Unit = {}
 ) {
+    var category by remember { mutableStateOf<SettingsCategory?>(null) }
+    BackHandler(enabled = category != null) { category = null }
+
+    when (category) {
+        null -> SettingsLanding(
+            viewModel,
+            onSelect = { category = it },
+            onNavigateToMission = onNavigateToMission,
+            onNavigateToLegal = onNavigateToLegal,
+            onNavigateToPrivacyData = onNavigateToPrivacyData,
+            onNavigateToDeveloper = onNavigateToDeveloper
+        )
+        SettingsCategory.Account ->
+            AccountSettingsScreen(viewModel, onBack = { category = null })
+        SettingsCategory.PlaybackAudio ->
+            PlaybackAudioSettingsScreen(
+                viewModel,
+                onBack = { category = null },
+                onNavigateToEqualizer = onNavigateToEqualizer,
+                onNavigateToConnect = onNavigateToConnect
+            )
+        SettingsCategory.HomeLayout ->
+            HomeLayoutSettingsScreen(viewModel, onBack = { category = null })
+        SettingsCategory.LibraryData ->
+            LibraryDataSettingsScreen(
+                viewModel,
+                onBack = { category = null },
+                onNavigateToDownloads = onNavigateToDownloads
+            )
+    }
+}
+
+// ── Landing ─────────────────────────────────────────────────────────────────
+
+@Composable
+private fun SettingsLanding(
+    viewModel: SettingsViewModel,
+    onSelect: (SettingsCategory) -> Unit,
+    onNavigateToMission: () -> Unit,
+    onNavigateToLegal: () -> Unit,
+    onNavigateToPrivacyData: () -> Unit,
+    onNavigateToDeveloper: () -> Unit
+) {
     val context = LocalContext.current
-    val includeShowsWithoutRecordings by viewModel.includeShowsWithoutRecordings.collectAsState()
-    val sourceBadgeStyle by viewModel.sourceBadgeStyle.collectAsState()
-    val playerControlsStyle by viewModel.playerControlsStyle.collectAsState()
-    val homeTrendingWindow by viewModel.homeTrendingWindow.collectAsState()
-    val homeTrendingAboveToday by viewModel.homeTrendingAboveToday.collectAsState()
-    val homeTrendingIncludeAnniversaries by viewModel.homeTrendingIncludeAnniversaries.collectAsState()
-    val homeRecentRows by viewModel.homeRecentRows.collectAsState()
-    val homeTrendingCardSize by viewModel.homeTrendingCardSize.collectAsState()
-    val homeTodayCardSize by viewModel.homeTodayCardSize.collectAsState()
-    val homeCollectionsCardSize by viewModel.homeCollectionsCardSize.collectAsState()
-    val homePopularEnabled by viewModel.homePopularEnabled.collectAsState()
-    val homePopularCardSize by viewModel.homePopularCardSize.collectAsState()
-    val homePopularDecade by viewModel.homePopularDecade.collectAsState()
-    val authState by viewModel.authState.collectAsState()
-    val serverEnvironment by viewModel.serverEnvironment.collectAsState()
     val developerModeUnlocked by viewModel.developerModeUnlocked.collectAsState()
     val version = BuildConfig.VERSION_NAME
     var versionTapCount by remember(developerModeUnlocked) { mutableIntStateOf(0) }
 
     LazyColumn(modifier = Modifier.fillMaxSize()) {
+        item {
+            Text(
+                text = "Settings",
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 8.dp)
+            )
+        }
+        item {
+            CategoryRow(
+                "Account", "Sign-in & profile",
+                leading = { LeadingIcon(Icons.Filled.AccountCircle) }
+            ) { onSelect(SettingsCategory.Account) }
+        }
+        item {
+            CategoryRow(
+                "Playback & Audio", "Controls, equalizer, devices",
+                leading = { LeadingIcon(IconResources.PlayerControls.VolumeUp()) }
+            ) { onSelect(SettingsCategory.PlaybackAudio) }
+        }
+        item {
+            CategoryRow(
+                "Home Layout", "Rails, card sizes, trending",
+                leading = { LeadingIcon(IconResources.Content.GridView()) }
+            ) { onSelect(SettingsCategory.HomeLayout) }
+        }
+        item {
+            CategoryRow(
+                "Library & Data", "Downloads, import & export",
+                leading = { LeadingIcon(IconResources.Content.Folder()) }
+            ) { onSelect(SettingsCategory.LibraryData) }
+        }
 
-        // ── ACCOUNT ───────────────────────────────────────────────────
-        item { SectionHeader("Account") }
+        item { HorizontalDivider() }
 
+        // About & Support — informational links live right on the root
+        // (low-traffic, no need to bury them behind a category).
+        item {
+            PreferenceRow(
+                title = "Community (r/thedeadlyapp)",
+                leading = { LeadingIcon(Icons.AutoMirrored.Filled.Message) },
+                onClick = {
+                    context.startActivity(
+                        Intent(Intent.ACTION_VIEW, Uri.parse("https://www.reddit.com/r/thedeadlyapp"))
+                    )
+                },
+                trailing = {
+                    Icon(
+                        painter = IconResources.Navigation.ChevronRight(),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            )
+        }
+        item {
+            PreferenceRow(
+                title = "Donate to Internet Archive",
+                subtitle = "Help cover hosting and bandwidth costs",
+                leading = { LeadingIcon(IconResources.Content.Favorite()) },
+                onClick = {
+                    context.startActivity(
+                        Intent(Intent.ACTION_VIEW, Uri.parse("https://archive.org/donate/"))
+                    )
+                },
+                trailing = {
+                    Icon(
+                        painter = IconResources.Navigation.ChevronRight(),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            )
+        }
+        item {
+            PreferenceRow(
+                title = "Buy Me a Coffee",
+                subtitle = "Support the project",
+                leading = { LeadingIcon(IconResources.Content.Coffee()) },
+                onClick = {
+                    context.startActivity(
+                        Intent(Intent.ACTION_VIEW, Uri.parse("https://buymeacoffee.com/dsilberg"))
+                    )
+                },
+                trailing = {
+                    Icon(
+                        painter = IconResources.Navigation.ChevronRight(),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            )
+        }
+        item {
+            PreferenceRow(
+                title = "Our Mission",
+                onClick = onNavigateToMission,
+                trailing = {
+                    Icon(
+                        painter = IconResources.Navigation.ChevronRight(),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            )
+        }
+        item {
+            PreferenceRow(
+                title = "Legal & Policies",
+                onClick = onNavigateToLegal,
+                trailing = {
+                    Icon(
+                        painter = IconResources.Navigation.ChevronRight(),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            )
+        }
+        item {
+            PreferenceRow(
+                title = "Privacy & Data",
+                onClick = onNavigateToPrivacyData,
+                trailing = {
+                    Icon(
+                        painter = IconResources.Navigation.ChevronRight(),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            )
+        }
+        if (developerModeUnlocked) {
+            item {
+                PreferenceRow(
+                    title = "Developer",
+                    onClick = onNavigateToDeveloper,
+                    trailing = {
+                        Icon(
+                            painter = IconResources.Navigation.ChevronRight(),
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                )
+            }
+        }
+
+        item { HorizontalDivider() }
+
+        // Version footer — kept on the root so the build is always visible at a
+        // glance (and the tap-to-unlock developer mode stays reachable), with
+        // Release Notes one row below it.
+        item {
+            PreferenceRow(
+                title = "Version $version",
+                onClick = {
+                    versionTapCount++
+                    val remaining = 7 - versionTapCount
+                    if (remaining <= 0 && !developerModeUnlocked) {
+                        viewModel.unlockDeveloperMode()
+                        Toast.makeText(context, "Developer mode enabled", Toast.LENGTH_SHORT).show()
+                    } else if (remaining in 1..3 && !developerModeUnlocked) {
+                        Toast.makeText(context, "$remaining taps to enable developer mode", Toast.LENGTH_SHORT).show()
+                    }
+                }
+            )
+        }
+        item {
+            PreferenceRow(
+                title = "Release Notes",
+                leading = { LeadingIcon(IconResources.Content.FilePresent()) },
+                onClick = {
+                    val url = "https://github.com/ds17f/deadly-monorepo/releases/tag/android%2Fv$version"
+                    context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                },
+                trailing = {
+                    Icon(
+                        painter = IconResources.Navigation.ChevronRight(),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun CategoryRow(
+    title: String,
+    subtitle: String,
+    leading: @Composable () -> Unit,
+    onClick: () -> Unit
+) {
+    PreferenceRow(
+        title = title,
+        subtitle = subtitle,
+        leading = leading,
+        onClick = onClick,
+        trailing = {
+            Icon(
+                painter = IconResources.Navigation.ChevronRight(),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    )
+}
+
+// Leading icon for a settings row — tinted with the accent, matching iOS.
+@Composable
+private fun LeadingIcon(painter: androidx.compose.ui.graphics.painter.Painter) {
+    Icon(
+        painter = painter,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.primary
+    )
+}
+
+@Composable
+private fun LeadingIcon(imageVector: androidx.compose.ui.graphics.vector.ImageVector) {
+    Icon(
+        imageVector = imageVector,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.primary
+    )
+}
+
+// Header bar shown atop each subscreen so it can return to the landing list.
+@Composable
+private fun SubscreenScaffold(
+    title: String,
+    onBack: () -> Unit,
+    content: LazyListScope.() -> Unit
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 4.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(
+                    painter = IconResources.Navigation.Back(),
+                    contentDescription = "Back"
+                )
+            }
+            Text(text = title, style = MaterialTheme.typography.titleLarge)
+        }
+        LazyColumn(modifier = Modifier.fillMaxSize(), content = content)
+    }
+}
+
+// ── Account ─────────────────────────────────────────────────────────────────
+
+@Composable
+private fun AccountSettingsScreen(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val context = LocalContext.current
+    val authState by viewModel.authState.collectAsState()
+    val serverEnvironment by viewModel.serverEnvironment.collectAsState()
+
+    SubscreenScaffold("Account", onBack) {
         when (val state = authState) {
             is AuthState.SignedIn -> {
                 item {
@@ -123,18 +427,28 @@ fun SettingsScreen(
                 }
             }
         }
+    }
+}
 
-        item { HorizontalDivider() }
+// ── Playback & Audio ────────────────────────────────────────────────────────
 
-        // ── PREFERENCES ──────────────────────────────────────────────
-        item { SectionHeader("Preferences") }
+@Composable
+private fun PlaybackAudioSettingsScreen(
+    viewModel: SettingsViewModel,
+    onBack: () -> Unit,
+    onNavigateToEqualizer: () -> Unit,
+    onNavigateToConnect: () -> Unit
+) {
+    val sourceBadgeStyle by viewModel.sourceBadgeStyle.collectAsState()
+    val playerControlsStyle by viewModel.playerControlsStyle.collectAsState()
+
+    SubscreenScaffold("Playback & Audio", onBack) {
+        item { SectionHeader("Controls") }
 
         item {
-            PreferenceToggleRow(
-                title = "Include shows without recordings",
-                subtitle = "Show concerts even if they have no audio recordings available",
-                checked = includeShowsWithoutRecordings,
-                onCheckedChange = { viewModel.toggleIncludeShowsWithoutRecordings() }
+            PlayerControlsStyleRow(
+                currentStyle = PlayerControlsStyle.fromString(playerControlsStyle),
+                onStyleSelected = { viewModel.setPlayerControlsStyle(it.name) }
             )
         }
 
@@ -145,17 +459,60 @@ fun SettingsScreen(
             )
         }
 
+        item { HorizontalDivider() }
+        item { SectionHeader("Audio") }
+
         item {
-            PlayerControlsStyleRow(
-                currentStyle = PlayerControlsStyle.fromString(playerControlsStyle),
-                onStyleSelected = { viewModel.setPlayerControlsStyle(it.name) }
+            PreferenceRow(
+                title = "Equalizer",
+                subtitle = "Adjust audio profile and presets",
+                leading = { LeadingIcon(IconResources.PlayerControls.Equalizer()) },
+                onClick = onNavigateToEqualizer,
+                trailing = {
+                    Icon(
+                        painter = IconResources.Navigation.ChevronRight(),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             )
         }
 
-        item { HorizontalDivider() }
+        item {
+            PreferenceRow(
+                title = "Connected Devices",
+                subtitle = "View devices connected to your account",
+                leading = { LeadingIcon(IconResources.Content.Cast()) },
+                onClick = onNavigateToConnect,
+                trailing = {
+                    Icon(
+                        painter = IconResources.Navigation.ChevronRight(),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            )
+        }
+    }
+}
 
-        // ── HOME SCREEN ──────────────────────────────────────────────
-        item { SectionHeader("Home Screen") }
+// ── Home Layout ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun HomeLayoutSettingsScreen(viewModel: SettingsViewModel, onBack: () -> Unit) {
+    val homeTrendingWindow by viewModel.homeTrendingWindow.collectAsState()
+    val homeTrendingAboveToday by viewModel.homeTrendingAboveToday.collectAsState()
+    val homeTrendingIncludeAnniversaries by viewModel.homeTrendingIncludeAnniversaries.collectAsState()
+    val homeRecentRows by viewModel.homeRecentRows.collectAsState()
+    val homeTrendingCardSize by viewModel.homeTrendingCardSize.collectAsState()
+    val homeTodayCardSize by viewModel.homeTodayCardSize.collectAsState()
+    val homeCollectionsCardSize by viewModel.homeCollectionsCardSize.collectAsState()
+    val homePopularEnabled by viewModel.homePopularEnabled.collectAsState()
+    val homePopularCardSize by viewModel.homePopularCardSize.collectAsState()
+    val homePopularDecade by viewModel.homePopularDecade.collectAsState()
+
+    SubscreenScaffold("Home Layout", onBack) {
+        item { SectionHeader("Trending") }
 
         item {
             HomeTrendingWindowRow(
@@ -183,18 +540,21 @@ fun SettingsScreen(
         }
 
         item {
-            HomeRecentRowsRow(
-                currentRows = homeRecentRows,
-                onSelected = { viewModel.setHomeRecentRows(it) }
-            )
-        }
-
-        item {
             HomeCardSizeRow(
                 title = "Trending card size",
                 subtitle = "Size of cards in the Trending carousel.",
                 current = homeTrendingCardSize,
                 onSelected = { viewModel.setHomeTrendingCardSize(it) }
+            )
+        }
+
+        item { HorizontalDivider() }
+        item { SectionHeader("Rails") }
+
+        item {
+            HomeRecentRowsRow(
+                currentRows = homeRecentRows,
+                onSelected = { viewModel.setHomeRecentRows(it) }
             )
         }
 
@@ -215,6 +575,9 @@ fun SettingsScreen(
                 onSelected = { viewModel.setHomeCollectionsCardSize(it) }
             )
         }
+
+        item { HorizontalDivider() }
+        item { SectionHeader("Fan Favorites") }
 
         item {
             PreferenceToggleRow(
@@ -241,53 +604,43 @@ fun SettingsScreen(
             )
         }
 
+        item { HorizontalDivider() }
+
         item {
             HomeResetRow(onReset = { viewModel.resetHomePreferences() })
         }
+    }
+}
 
-        item { HorizontalDivider() }
+// ── Library & Data ──────────────────────────────────────────────────────────
 
-        // ── AUDIO ────────────────────────────────────────────────────
-        item { SectionHeader("Audio") }
+@Composable
+private fun LibraryDataSettingsScreen(
+    viewModel: SettingsViewModel,
+    onBack: () -> Unit,
+    onNavigateToDownloads: () -> Unit
+) {
+    val includeShowsWithoutRecordings by viewModel.includeShowsWithoutRecordings.collectAsState()
 
-        item {
-            PreferenceRow(
-                title = "Equalizer",
-                subtitle = "Adjust audio profile and presets",
-                onClick = onNavigateToEqualizer,
-                trailing = {
-                    Icon(
-                        painter = IconResources.Navigation.ChevronRight(),
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            )
-        }
+    SubscreenScaffold("Library & Data", onBack) {
+        item { SectionHeader("Content") }
 
         item {
-            PreferenceRow(
-                title = "Connected Devices",
-                subtitle = "View devices connected to your account",
-                onClick = onNavigateToConnect,
-                trailing = {
-                    Icon(
-                        painter = IconResources.Navigation.ChevronRight(),
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
+            PreferenceToggleRow(
+                title = "Include shows without recordings",
+                subtitle = "Show concerts even if they have no audio recordings available",
+                checked = includeShowsWithoutRecordings,
+                onCheckedChange = { viewModel.toggleIncludeShowsWithoutRecordings() }
             )
         }
 
         item { HorizontalDivider() }
-
-        // ── FAVORITES & DATA ────────────────────────────────────────
-        item { SectionHeader("Favorites & Data") }
+        item { SectionHeader("Downloads") }
 
         item {
             PreferenceRow(
                 title = "Manage Downloads",
+                leading = { LeadingIcon(IconResources.Content.FileDownload()) },
                 onClick = onNavigateToDownloads,
                 trailing = {
                     Icon(
@@ -299,6 +652,9 @@ fun SettingsScreen(
             )
         }
 
+        item { HorizontalDivider() }
+        item { SectionHeader("Favorites Backup") }
+
         item {
             BackupImportExportButtons(viewModel = viewModel)
         }
@@ -306,146 +662,7 @@ fun SettingsScreen(
         item {
             ImportMigrationButton(viewModel = viewModel)
         }
-
-        item { HorizontalDivider() }
-
-        // ── ABOUT ────────────────────────────────────────────────────
-        item { SectionHeader("About") }
-
-        item {
-            PreferenceRow(
-                title = "Version $version",
-                onClick = {
-                    versionTapCount++
-                    val remaining = 7 - versionTapCount
-                    if (remaining <= 0 && !developerModeUnlocked) {
-                        viewModel.unlockDeveloperMode()
-                        Toast.makeText(context, "Developer mode enabled", Toast.LENGTH_SHORT).show()
-                    } else if (remaining in 1..3 && !developerModeUnlocked) {
-                        Toast.makeText(context, "$remaining taps to enable developer mode", Toast.LENGTH_SHORT).show()
-                    }
-                }
-            )
-        }
-
-        item {
-            PreferenceRow(
-                title = "Release Notes",
-                onClick = {
-                    val url = "https://github.com/ds17f/deadly-monorepo/releases/tag/android%2Fv$version"
-                    context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
-                },
-                trailing = {
-                    Icon(
-                        painter = IconResources.Navigation.ChevronRight(),
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            )
-        }
-
-        item {
-            PreferenceRow(
-                title = "Donate to Internet Archive",
-                subtitle = "Help cover hosting and bandwidth costs",
-                onClick = {
-                    context.startActivity(
-                        Intent(Intent.ACTION_VIEW, Uri.parse("https://archive.org/donate/"))
-                    )
-                },
-                trailing = {
-                    Icon(
-                        painter = IconResources.Navigation.ChevronRight(),
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            )
-        }
-
-        item {
-            PreferenceRow(
-                title = "Our Mission",
-                onClick = onNavigateToMission,
-                trailing = {
-                    Icon(
-                        painter = IconResources.Navigation.ChevronRight(),
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            )
-        }
-
-        item {
-            PreferenceRow(
-                title = "Legal & Policies",
-                onClick = onNavigateToLegal,
-                trailing = {
-                    Icon(
-                        painter = IconResources.Navigation.ChevronRight(),
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            )
-        }
-
-        // Community link (decision I). Canonical URL lives in
-        // com.grateful.deadly.notifications.Community; inlined here because
-        // feature:settings can't depend on the app module.
-        item {
-            PreferenceRow(
-                title = "Community (r/thedeadlyapp)",
-                onClick = {
-                    context.startActivity(
-                        Intent(Intent.ACTION_VIEW, Uri.parse("https://www.reddit.com/r/thedeadlyapp"))
-                    )
-                },
-                trailing = {
-                    Icon(
-                        painter = IconResources.Navigation.ChevronRight(),
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            )
-        }
-
-        if (developerModeUnlocked) {
-            item {
-                PreferenceRow(
-                    title = "Developer",
-                    onClick = onNavigateToDeveloper,
-                    trailing = {
-                        Icon(
-                            painter = IconResources.Navigation.ChevronRight(),
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                )
-            }
-        }
-
-        item { HorizontalDivider() }
-
-        item {
-            PreferenceRow(
-                title = "Privacy & Data",
-                onClick = onNavigateToPrivacyData,
-                trailing = {
-                    Icon(
-                        painter = IconResources.Navigation.ChevronRight(),
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            )
-        }
     }
-
 }
 
 // ── Section header ────────────────────────────────────────────────────────────
@@ -470,6 +687,7 @@ private fun PreferenceRow(
     title: String,
     subtitle: String? = null,
     titleColor: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.onSurface,
+    leading: @Composable (() -> Unit)? = null,
     onClick: () -> Unit,
     trailing: @Composable (() -> Unit)? = null
 ) {
@@ -477,14 +695,18 @@ private fun PreferenceRow(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 14.dp),
+            .padding(horizontal = 16.dp, vertical = 16.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
+        if (leading != null) {
+            leading()
+            Spacer(modifier = Modifier.width(16.dp))
+        }
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = title,
-                style = MaterialTheme.typography.bodyLarge,
+                style = MaterialTheme.typography.titleMedium,
                 color = titleColor
             )
             if (subtitle != null) {
@@ -515,12 +737,12 @@ private fun PreferenceToggleRow(
         modifier = Modifier
             .fillMaxWidth()
             .clickable { onCheckedChange(!checked) }
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .padding(horizontal = 16.dp, vertical = 14.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
         Column(modifier = Modifier.weight(1f)) {
-            Text(text = title, style = MaterialTheme.typography.bodyLarge)
+            Text(text = title, style = MaterialTheme.typography.titleMedium)
             if (subtitle != null) {
                 Text(
                     text = subtitle,
@@ -558,11 +780,13 @@ private fun BackupImportExportButtons(viewModel: SettingsViewModel) {
         PreferenceRow(
             title = "Import Favorites",
             subtitle = "Import from a backup file",
+            leading = { LeadingIcon(IconResources.DataManagement.Restore()) },
             onClick = { safLauncher.launch(arrayOf("application/json")) }
         )
         PreferenceRow(
             title = "Export Favorites",
             subtitle = "Export to Downloads folder",
+            leading = { LeadingIcon(IconResources.DataManagement.Backup()) },
             onClick = {
                 viewModel.exportFavorites { result ->
                     result.onSuccess { filename ->
@@ -589,6 +813,7 @@ private fun ImportMigrationButton(viewModel: SettingsViewModel) {
     PreferenceRow(
         title = if (importState is SettingsViewModel.MigrationImportState.Importing) "Importing…" else "Import Favorites from Old App",
         subtitle = "Import your library and play history from the old Dead Archive app",
+        leading = { LeadingIcon(IconResources.DataManagement.SettingsBackupRestore()) },
         onClick = {
             if (importState !is SettingsViewModel.MigrationImportState.Importing) {
                 safLauncher.launch(arrayOf("application/json"))

--- a/iosApp/deadly/Feature/Settings/SettingsScreen.swift
+++ b/iosApp/deadly/Feature/Settings/SettingsScreen.swift
@@ -4,63 +4,18 @@ import SwiftUI
 import UIKit
 import UniformTypeIdentifiers
 
-// MARK: - SettingsScreen
+// MARK: - SettingsScreen (landing)
+//
+// ADR-0014: Settings is a short landing of stable categories, each its own
+// screen — Account · Playback & Audio · Home Layout · Library & Data ·
+// About & Support. The flat "scroll-forever" list is gone; every control now
+// lives behind the category it belongs to, with all home-layout knobs gathered
+// onto one dedicated screen.
 
 struct SettingsScreen: View {
     var onNavigateToDownloads: (() -> Void)? = nil
     var onNavigateToEqualizer: (() -> Void)? = nil
-    @Environment(\.appContainer) private var container
     @Environment(\.openURL) private var openURL
-    @State private var showingFilePicker = false
-    @State private var exportItem: ExportItem?
-    @State private var importResult: BackupImportResult?
-    @State private var importError: String?
-    @State private var showingImportAlert = false
-    @State private var authError: String?
-    @State private var showingAuthError = false
-    private func cardSizePicker(
-        title: String,
-        helper: String,
-        feature: String,
-        get: @escaping () -> String,
-        set: @escaping (String) -> Void
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(title)
-            Picker(title, selection: Binding(
-                get: { CarouselCardSize(preferenceKey: get()) },
-                set: { newSize in
-                    set(newSize.rawValue)
-                    container.analyticsService.track("feature_use", props: [
-                        "feature": feature,
-                        "category": "preference",
-                        "value": newSize.rawValue,
-                    ])
-                }
-            )) {
-                ForEach(CarouselCardSize.allCases) { size in
-                    Text(size.label).tag(size)
-                }
-            }
-            .pickerStyle(.segmented)
-            Text(helper)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-        }
-    }
-
-    private func settingsRow(_ title: String, systemImage: String) -> some View {
-        HStack {
-            Image(systemName: systemImage)
-                .foregroundStyle(DeadlyColors.primary)
-            Text(title)
-                .foregroundStyle(.primary)
-            Spacer()
-            Image(systemName: "chevron.right")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-    }
 
     private var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
@@ -68,8 +23,131 @@ struct SettingsScreen: View {
 
     var body: some View {
         List {
-            // MARK: - Account
-            Section("Account") {
+            NavigationLink {
+                AccountSettingsView()
+            } label: {
+                SettingsLandingRow("Account", systemImage: "person.crop.circle", subtitle: "Sign-in & profile")
+            }
+            NavigationLink {
+                PlaybackAudioSettingsView(onNavigateToEqualizer: onNavigateToEqualizer)
+            } label: {
+                SettingsLandingRow("Playback & Audio", systemImage: "speaker.wave.2", subtitle: "Controls, equalizer, devices")
+            }
+            NavigationLink {
+                HomeLayoutSettingsView()
+            } label: {
+                SettingsLandingRow("Home Layout", systemImage: "square.grid.2x2", subtitle: "Rails, card sizes, trending")
+            }
+            NavigationLink {
+                LibraryDataSettingsView(onNavigateToDownloads: onNavigateToDownloads)
+            } label: {
+                SettingsLandingRow("Library & Data", systemImage: "tray.full", subtitle: "Downloads, import & export")
+            }
+            // About & Support — informational links live right on the root
+            // (low-traffic, no need to bury them behind a category).
+            Section {
+                Link(destination: Community.subredditURL) {
+                    settingsRow("Community (\(Community.subredditHandle))", systemImage: "bubble.left.and.bubble.right")
+                }
+                .foregroundStyle(.primary)
+                Link(destination: URL(string: "https://archive.org/donate/")!) {
+                    settingsRow("Donate to Internet Archive", systemImage: "heart")
+                }
+                .foregroundStyle(.primary)
+                Link(destination: URL(string: "https://buymeacoffee.com/dsilberg")!) {
+                    settingsRow("Buy Me a Coffee", systemImage: "cup.and.saucer.fill")
+                }
+                .foregroundStyle(.primary)
+                NavigationLink {
+                    BugReportView()
+                } label: {
+                    Label("Send Bug Report", systemImage: "ladybug")
+                }
+                NavigationLink("Our Mission") {
+                    MissionView()
+                }
+                NavigationLink("Legal & Policies") {
+                    LegalView()
+                }
+                NavigationLink("Privacy & Data") {
+                    PrivacyDataView()
+                }
+                NavigationLink("Developer") {
+                    DeveloperView()
+                }
+            }
+
+            // Version footer — kept on the root so the build is always visible at
+            // a glance, with Release Notes one tap below it.
+            Section {
+                LabeledContent("Version", value: appVersion)
+                Button {
+                    let urlString = "https://github.com/ds17f/deadly-monorepo/releases/tag/ios%2Fv\(appVersion)"
+                    if let url = URL(string: urlString) { openURL(url) }
+                } label: {
+                    settingsRow("Release Notes", systemImage: "doc.text")
+                }
+                .foregroundStyle(.primary)
+            }
+        }
+        .navigationTitle("Settings")
+    }
+}
+
+// MARK: - Landing row
+
+private struct SettingsLandingRow: View {
+    let title: String
+    let systemImage: String
+    let subtitle: String
+
+    init(_ title: String, systemImage: String, subtitle: String) {
+        self.title = title
+        self.systemImage = systemImage
+        self.subtitle = subtitle
+    }
+
+    var body: some View {
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        } icon: {
+            Image(systemName: systemImage)
+                .foregroundStyle(DeadlyColors.primary)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+// Shared row used for Button-style entries (manual chevron — NavigationLink
+// rows use a plain Label and get the chevron for free).
+private func settingsRow(_ title: String, systemImage: String) -> some View {
+    HStack {
+        Image(systemName: systemImage)
+            .foregroundStyle(DeadlyColors.primary)
+        Text(title)
+            .foregroundStyle(.primary)
+        Spacer()
+        Image(systemName: "chevron.right")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+    }
+}
+
+// MARK: - Account
+
+struct AccountSettingsView: View {
+    @Environment(\.appContainer) private var container
+    @State private var authError: String?
+    @State private var showingAuthError = false
+
+    var body: some View {
+        List {
+            Section {
                 if container.authService.isSignedIn {
                     if let user = container.authService.currentUser {
                         VStack(alignment: .leading, spacing: 4) {
@@ -144,28 +222,26 @@ struct SettingsScreen: View {
                     .buttonStyle(.bordered)
                 }
             }
+        }
+        .navigationTitle("Account")
+        .navigationBarTitleDisplayMode(.inline)
+        .alert("Sign In Error", isPresented: $showingAuthError) {
+            Button("OK") {}
+        } message: {
+            Text(authError ?? "Unknown error.")
+        }
+    }
+}
 
-            // MARK: - Preferences
-            Section("Preferences") {
-                Toggle(isOn: Binding(
-                    get: { container.appPreferences.includeShowsWithoutRecordings },
-                    set: {
-                        container.appPreferences.includeShowsWithoutRecordings = $0
-                        container.analyticsService.track("feature_use", props: [
-                            "feature": "toggle_shows_without_recordings",
-                            "category": "preference",
-                            "enabled": $0,
-                        ])
-                    }
-                )) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Include shows without recordings")
-                        Text("Show concerts even if they have no audio recordings available")
-                            .font(.callout)
-                            .foregroundStyle(.secondary)
-                    }
-                }
+// MARK: - Playback & Audio
 
+struct PlaybackAudioSettingsView: View {
+    var onNavigateToEqualizer: (() -> Void)? = nil
+    @Environment(\.appContainer) private var container
+
+    var body: some View {
+        List {
+            Section("Controls") {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Lock screen & CarPlay controls")
                     Picker("Lock screen & CarPlay controls", selection: Binding(
@@ -212,11 +288,85 @@ struct SettingsScreen: View {
                         .font(.callout)
                         .foregroundStyle(.secondary)
                 }
-
             }
 
-            // MARK: - Home Screen
-            Section("Home Screen") {
+            Section("Audio") {
+                if let onNavigateToEqualizer {
+                    Button { onNavigateToEqualizer() } label: {
+                        settingsRow("Equalizer", systemImage: "slider.vertical.3")
+                    }
+                    .foregroundStyle(.primary)
+                } else {
+                    NavigationLink {
+                        EqualizerView()
+                    } label: {
+                        Label("Equalizer", systemImage: "slider.vertical.3")
+                    }
+                }
+            }
+
+            if container.authService.isSignedIn {
+                Section("Connect") {
+                    NavigationLink {
+                        ConnectScreen()
+                    } label: {
+                        HStack {
+                            settingsRow("Connected Devices", systemImage: "iphone.and.arrow.forward")
+                            if container.connectService.isConnected && !container.connectService.devices.isEmpty {
+                                Text("\(container.connectService.devices.count)")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .foregroundStyle(.primary)
+                }
+            }
+        }
+        .navigationTitle("Playback & Audio")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - Home Layout
+
+struct HomeLayoutSettingsView: View {
+    @Environment(\.appContainer) private var container
+
+    private func cardSizePicker(
+        title: String,
+        helper: String,
+        feature: String,
+        get: @escaping () -> String,
+        set: @escaping (String) -> Void
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+            Picker(title, selection: Binding(
+                get: { CarouselCardSize(preferenceKey: get()) },
+                set: { newSize in
+                    set(newSize.rawValue)
+                    container.analyticsService.track("feature_use", props: [
+                        "feature": feature,
+                        "category": "preference",
+                        "value": newSize.rawValue,
+                    ])
+                }
+            )) {
+                ForEach(CarouselCardSize.allCases) { size in
+                    Text(size.label).tag(size)
+                }
+            }
+            .pickerStyle(.segmented)
+            Text(helper)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    var body: some View {
+        List {
+            Section("Trending") {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Trending window on home")
                     Picker("Trending window on home", selection: Binding(
@@ -278,6 +428,16 @@ struct SettingsScreen: View {
                     }
                 }
 
+                cardSizePicker(
+                    title: "Trending card size",
+                    helper: "Size of cards in the Trending carousel.",
+                    feature: "set_home_trending_card_size",
+                    get: { container.appPreferences.homeTrendingCardSize },
+                    set: { container.appPreferences.homeTrendingCardSize = $0 }
+                )
+            }
+
+            Section("Rails") {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Recently Played rows")
                     Picker("Recently Played rows", selection: Binding(
@@ -302,14 +462,6 @@ struct SettingsScreen: View {
                 }
 
                 cardSizePicker(
-                    title: "Trending card size",
-                    helper: "Size of cards in the Trending carousel.",
-                    feature: "set_home_trending_card_size",
-                    get: { container.appPreferences.homeTrendingCardSize },
-                    set: { container.appPreferences.homeTrendingCardSize = $0 }
-                )
-
-                cardSizePicker(
                     title: "Today in History card size",
                     helper: "Size of cards in the Today in Grateful Dead History carousel.",
                     feature: "set_home_today_card_size",
@@ -324,7 +476,9 @@ struct SettingsScreen: View {
                     get: { container.appPreferences.homeCollectionsCardSize },
                     set: { container.appPreferences.homeCollectionsCardSize = $0 }
                 )
+            }
 
+            Section("Fan Favorites") {
                 Toggle(isOn: Binding(
                     get: { container.appPreferences.homePopularEnabled },
                     set: { newValue in
@@ -374,7 +528,9 @@ struct SettingsScreen: View {
                     get: { container.appPreferences.homePopularCardSize },
                     set: { container.appPreferences.homePopularCardSize = $0 }
                 )
+            }
 
+            Section {
                 Button(role: .destructive) {
                     container.appPreferences.resetHomePreferences()
                     container.analyticsService.track("feature_use", props: [
@@ -385,44 +541,47 @@ struct SettingsScreen: View {
                     Text("Reset Home Screen to Defaults")
                 }
             }
+        }
+        .navigationTitle("Home Layout")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
 
-            // MARK: - Connect
-            if container.authService.isSignedIn {
-                Section("Connect") {
-                    NavigationLink {
-                        ConnectScreen()
-                    } label: {
-                        HStack {
-                            settingsRow("Connected Devices", systemImage: "iphone.and.arrow.forward")
-                            if container.connectService.isConnected && !container.connectService.devices.isEmpty {
-                                Text("\(container.connectService.devices.count)")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
+// MARK: - Library & Data
+
+struct LibraryDataSettingsView: View {
+    var onNavigateToDownloads: (() -> Void)? = nil
+    @Environment(\.appContainer) private var container
+    @State private var showingFilePicker = false
+    @State private var exportItem: ExportItem?
+    @State private var importResult: BackupImportResult?
+    @State private var importError: String?
+    @State private var showingImportAlert = false
+
+    var body: some View {
+        List {
+            Section("Content") {
+                Toggle(isOn: Binding(
+                    get: { container.appPreferences.includeShowsWithoutRecordings },
+                    set: {
+                        container.appPreferences.includeShowsWithoutRecordings = $0
+                        container.analyticsService.track("feature_use", props: [
+                            "feature": "toggle_shows_without_recordings",
+                            "category": "preference",
+                            "enabled": $0,
+                        ])
                     }
-                    .foregroundStyle(.primary)
+                )) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Include shows without recordings")
+                        Text("Show concerts even if they have no audio recordings available")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
 
-            // MARK: - Audio
-            Section("Audio") {
-                if let onNavigateToEqualizer {
-                    Button { onNavigateToEqualizer() } label: {
-                        settingsRow("Equalizer", systemImage: "slider.vertical.3")
-                    }
-                    .foregroundStyle(.primary)
-                } else {
-                    NavigationLink {
-                        EqualizerView()
-                    } label: {
-                        Label("Equalizer", systemImage: "slider.vertical.3")
-                    }
-                }
-            }
-
-            // MARK: - Favorites & Data
-            Section("Favorites & Data") {
+            Section("Downloads") {
                 if let onNavigateToDownloads {
                     Button { onNavigateToDownloads() } label: {
                         settingsRow("Manage Downloads", systemImage: "arrow.down.circle")
@@ -433,6 +592,9 @@ struct SettingsScreen: View {
                         Label("Manage Downloads", systemImage: "arrow.down.circle")
                     }
                 }
+            }
+
+            Section("Favorites Backup") {
                 Button {
                     showingFilePicker = true
                 } label: {
@@ -448,55 +610,9 @@ struct SettingsScreen: View {
                 }
                 .foregroundStyle(.primary)
             }
-
-            // MARK: - Support
-            Section("Support") {
-                NavigationLink {
-                    BugReportView()
-                } label: {
-                    Label("Send Bug Report", systemImage: "ladybug")
-                }
-            }
-
-            // MARK: - About
-            Section("About") {
-                Button {
-                    let urlString = "https://github.com/ds17f/deadly-monorepo/releases/tag/ios%2Fv\(appVersion)"
-                    if let url = URL(string: urlString) { openURL(url) }
-                } label: {
-                    LabeledContent("Version", value: appVersion)
-                }
-                .foregroundStyle(.primary)
-            }
-
-            Section {
-                Link(destination: Community.subredditURL) {
-                    settingsRow("Community (\(Community.subredditHandle))", systemImage: "bubble.left.and.bubble.right")
-                }
-                .foregroundStyle(.primary)
-                Link(destination: URL(string: "https://archive.org/donate/")!) {
-                    settingsRow("Donate to Internet Archive", systemImage: "heart")
-                }
-                .foregroundStyle(.primary)
-                NavigationLink("Our Mission") {
-                    MissionView()
-                }
-                NavigationLink("Legal & Policies") {
-                    LegalView()
-                }
-                NavigationLink("Developer") {
-                    DeveloperView()
-                }
-            }
-
-            Section {
-                NavigationLink("Privacy & Data") {
-                    PrivacyDataView()
-                }
-            }
-
         }
-        .navigationTitle("Settings")
+        .navigationTitle("Library & Data")
+        .navigationBarTitleDisplayMode(.inline)
 
         // MARK: - Favorites File Picker
         .fileImporter(
@@ -543,18 +659,10 @@ struct SettingsScreen: View {
             }
         }
 
-        // MARK: - Auth Error Alert
-        .alert("Sign In Error", isPresented: $showingAuthError) {
-            Button("OK") {}
-        } message: {
-            Text(authError ?? "Unknown error.")
-        }
-
         // MARK: - Favorites Export Share Sheet
         .sheet(item: $exportItem) { item in
             FavoritesExportShareSheet(data: item.data, filename: item.filename)
         }
-
     }
 }
 


### PR DESCRIPTION
Implements the mobile Settings pass of ADR-0014 (iOS + Android), completing the decluttering effort across all platforms.

## What changed
- **Flat scroll-forever Settings → a short landing of categories**, each its own screen: **Account · Playback & Audio · Home Layout · Library & Data**. All home-layout knobs are gathered onto the single Home Layout screen. Every existing control, binding, and analytics event is preserved.
- **About & Support lives on the root** (not behind a category): Community · Donate · Buy Me a Coffee · *(Send Bug Report — iOS only)* · Our Mission · Legal & Policies · Privacy & Data · Developer.
- **Version footer on the root** — version always visible at a glance, Release Notes one row below. On Android, tapping the version 7× still unlocks developer mode.
- **Added "Buy Me a Coffee"** → https://buymeacoffee.com/dsilberg, under Donate to Internet Archive (plain external link).
- **Identical row ordering across platforms** (iOS canonical).
- **Android leading icons + warmer typography** to match the iOS look (accent-tinted icons, `titleMedium` row titles, more breathing room). New `ic_coffee` drawable.

## Implementation notes
- **iOS** (`SettingsScreen.swift`): landing `List` of `NavigationLink`s → subscreen views.
- **Android** (`SettingsScreen.kt`): Settings lives in the nav drawer, so landing→subscreen is a local state drill-down with a back header + `BackHandler`; leaf screens (Equalizer, Connect, Legal, …) stay full-screen routes. The public `SettingsScreen` signature is unchanged, so the nav graph and host are untouched.

## Verification
- iOS: `make ios-remote-build` ✅
- Android: `:feature:settings` + `:app` compile ✅, installed on device and confirmed visually.

## Known platform difference
- iOS has a "Send Bug Report" row (Android has no bug-report screen).
- Developer row: always shown on iOS; gated behind the version-tap unlock on Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)