### PR TITLE
docs(all): mark ADR-0014 UI decluttering shipped across all platforms

### DIFF
--- a/PLANS/ROADMAP.md
+++ b/PLANS/ROADMAP.md
@@ -187,35 +187,30 @@ blocks onboarding for affected users.
   retire: add Settings to `UserMenu`, surface Recent/Reviews in mobile nav, then
   drop the strip. Until that nav exists, leave it.
 
-### 11. UI decluttering — Settings + player/playlist controls (cross-platform) — NEXT UP
-The settings screens (iOS `SettingsScreen.swift`, Android `SettingsScreen.kt`,
-web `/me` SettingsTab) have grown overloaded and are increasingly hard to work in
-— findability is poor and adding a toggle means scanning a long flat list (the
-"When a show ends" / Playback section just landed into this sprawl). Regroup into
-clear sections with better findability; keep it a presentation/IA change, not new
-settings. Independent of any feature — the show-queue plan flags it as
-"Settings cleanup (independent, anytime)." Do it before the settings list grows
-again (shuffle, queue, and source-picker options are all coming).
+### 11. UI decluttering — Settings + player/playlist controls (cross-platform) — ✅ SHIPPED (2026-06-13)
+The settings screens, player, and playlist control surfaces had grown overloaded
+(scroll-forever flat Settings, `∞ Autoplay` crowding the player, playlist action
+rows duplicating into the overflow). Reframed via first principles ("control
+altitude = frequency × reversibility"; "one control, one home"; progressive
+disclosure) and shipped across all platforms.
 
-**Direction (maintainer, 2026-06-11):** master-detail, **all three platforms**.
-The current single complicated screen becomes a **left panel of one-line category
-rows** — `Autoplay >`, `Home Screen >`, etc. — each drilling into its own detail
-pane with only that category's controls. On web this is a literal left list +
-right detail pane; on mobile it's a category list that pushes to a detail screen.
-Collapses the long flat list into a scannable index. The section headers already
-exist (iOS/Android: Account, Playback, Preferences, Home Screen, Audio, Connect,
-Favorites & Data, Support, About) — the work is turning sections into drill-in
-categories, not inventing new groupings. Not started.
+**Delivered:**
+- **Player + playlist** (iOS + Android): unified `⋯`-menu taxonomy (Playback /
+  This Show / Share), Favorite moved to the track-info row, inline/overflow
+  duplication removed, dead stubs deleted. Reusable Autoplay confirmation toast. (#67)
+- **Web**: Autoplay given one home, Favorite + Share added to the expanded player,
+  categorized web Settings (Account · Playback · Community · About). (#67)
+- **Mobile Settings** (iOS + Android): flat list → a scannable landing of
+  categories (Account · Playback & Audio · Home Layout · Library & Data), each its
+  own screen, with all home-layout knobs consolidated onto the Home Layout screen;
+  About/Support + version footer on the root; leading icons + warmer typography. (#68)
 
-**Designed + scope expanded (2026-06-12):** the cleanup now also covers the
-**player and playlist control surfaces** (the `∞ Autoplay` clutter, inline/overflow
-duplication, iOS/Android stub drift), not just Settings. First principles, the
-locked per-surface layouts, the unified `⋯`-menu taxonomy (Playback / This Show /
-Share, mobile only), the web light-touch posture, and the Settings categorized-
-subscreens + consolidated Home Layout direction are all captured in
-**ADR-0014** ([`docs/adr/0014-ui-control-altitude-and-decluttering.md`](../docs/adr/0014-ui-control-altitude-and-decluttering.md));
-execution notes + current-state inventory in
-[`PLANS/ui-decluttering.md`](ui-decluttering.md). Nothing built yet.
+Design of record: **ADR-0014** ([`docs/adr/0014-…`](../docs/adr/0014-ui-control-altitude-and-decluttering.md));
+execution log in [`PLANS/ui-decluttering.md`](ui-decluttering.md).
+
+**Deliberately deferred** (tracked elsewhere, not regressions): `Queue` returns to
+the player inline cluster when the queue feature ships (ADR-0010 / `show-queue-v2`);
+`＋ Add to Playlist` when playlists exist.
 
 ## TECH DEBT
 

--- a/PLANS/ui-decluttering.md
+++ b/PLANS/ui-decluttering.md
@@ -1,15 +1,15 @@
 # UI Decluttering — Settings + Player/Playlist Controls
 
-**Status:** Design in progress (not yet an ADR, not yet built). 2026-06-12.
+**Status:** ✅ DONE — captured as **ADR-0014** (accepted 2026-06-12) and
+**implemented across all platforms** (2026-06-13). Shipped via **#67** (player +
+playlist + Autoplay toast + the full web pass) and **#68** (mobile Settings
+categorization + Home Layout + icons). This doc is retained as the design record /
+execution log; the decision of record is `docs/adr/0014-ui-control-altitude-and-decluttering.md`.
 **Goal:** Reduce UI clutter that's accreted as features shipped. Settings is a
 scroll-forever flat list (nightmare on mobile); the ∞ Autoplay addition crowded
 the player; playlist action rows duplicate everything into the overflow. Be
 deliberate — establish first principles, capture them as an **ADR**, then use it
 to guide implementation across iOS + Android (+ web for Settings parity).
-
-This doc is the recovery point. When the design is settled, it becomes
-**ADR-0014** (next free number in `docs/adr/`; ADR-0010 = auto-advance/queue is
-the relevant neighbor for Queue's eventual return).
 
 ---
 

--- a/docs/adr/0014-ui-control-altitude-and-decluttering.md
+++ b/docs/adr/0014-ui-control-altitude-and-decluttering.md
@@ -2,12 +2,20 @@
 
 ## Status
 
-Accepted (2026-06-12). Design settled across all surfaces. **Phase 1 (player +
-playlist, iOS + Android in parity) implemented 2026-06-12** — see
-`PLANS/ui-decluttering.md` "Phase 1 — implemented" for the per-file change list.
-Still to do: Settings categorization + consolidated Home Layout (iOS + Android),
-the light-touch web pass, and web Settings parity. Working notes and current-state
-inventory (with file paths) live in `PLANS/ui-decluttering.md`.
+Accepted (2026-06-12) — **Implemented across all platforms (2026-06-13).**
+- **Player + playlist** (iOS + Android, unified `⋯` taxonomy + Favorite on the
+  track-info row) and the reusable Autoplay confirmation **toast** — shipped in #67.
+- **Web** (Autoplay given one home, Favorite + Share on the expanded player,
+  categorized web Settings) — shipped in #67.
+- **Mobile Settings** (categorized landing + the consolidated Home Layout screen,
+  iOS + Android, with leading icons) — shipped in #68.
+
+Per-file change list + execution notes live in `PLANS/ui-decluttering.md`.
+
+Deliberately deferred (not regressions, tracked elsewhere): `Queue` returns to the
+player inline cluster when the queue feature ships (ADR-0010 / `show-queue-v2`);
+`＋ Add to Playlist` when playlists exist; web home has no rails/decade concept so
+it intentionally has no "Home Layout" Settings screen.
 
 Related: [ADR-0010](0010-playback-auto-advance-and-show-queue.md) (auto-advance +
 queue — the `∞ Autoplay` toggle and the future `Queue` entry point this ADR


### PR DESCRIPTION
Closes out the docs for the UI decluttering effort now that it's implemented everywhere.

- **ADR-0014**: status → Accepted + Implemented (all platforms), with the per-PR breakdown (#67 player/playlist + toast + web; #68 mobile Settings) and the deliberately-deferred items.
- **PLANS/ui-decluttering.md**: status → DONE, retained as the design/execution log.
- **ROADMAP.md item 11**: NEXT UP → ✅ SHIPPED with the delivered summary.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)