### PR TITLE
fix(mobile/connect): stop iOS follower self-starting on reconnect + socket re-entrancy guard

### DIFF
--- a/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
+++ b/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
@@ -278,6 +278,14 @@ class ConnectServiceImpl @Inject constructor(
     private fun connect() {
         val token = authService.getAuthToken() ?: return
         if (!shouldConnect) return
+        // Re-entrancy guard: two near-simultaneous triggers (foreground +
+        // network-restored) can both pass their !isConnected gates before
+        // onOpen flips isConnected, opening a second socket. Bail if one
+        // already exists; handleDisconnect nulls webSocket before reconnecting.
+        if (webSocket != null) {
+            Log.d(TAG, "connect: socket already open/in-flight, skipping")
+            return
+        }
 
         val baseUrl = appPreferences.apiBaseUrl
             .replace("https://", "wss://")

--- a/iosApp/deadly/App/AppContainer.swift
+++ b/iosApp/deadly/App/AppContainer.swift
@@ -313,11 +313,16 @@ final class AppContainer {
                 playlistSvc.connectService = connect
                 miniPlayer.connectService = connect
                 restorationSvc.connectService = connect
-                connect.onLoadShow = { [weak playlistSvc, weak player] showId, trackIndex, positionMs, autoPlay in
+                connect.onLoadShow = { [weak playlistSvc, weak player] showId, recordingId, trackIndex, positionMs, autoPlay in
                     guard let svc = playlistSvc else { return }
                     svc.suppressConnectNotify = true
                     defer { svc.suppressConnectNotify = false }
-                    await svc.loadShow(showId)
+                    // Adopt the session's exact recording (mirrors Android passing
+                    // new.recordingId into its load) so localRecordingId converges to
+                    // the server's — otherwise reactToState sees a permanent mismatch
+                    // and re-fires NEW RECORDING on every reconnect. loadShow falls back
+                    // to the show's best recording if this id isn't in the local catalog.
+                    await svc.loadShow(showId, recordingId: recordingId)
                     guard !svc.tracks.isEmpty else { return }
                     let idx = min(trackIndex, svc.tracks.count - 1)
                     let seekPosition = TimeInterval(positionMs) / 1000.0

--- a/iosApp/deadly/Core/Service/ConnectService.swift
+++ b/iosApp/deadly/Core/Service/ConnectService.swift
@@ -280,6 +280,14 @@ final class ConnectService: NSObject {
             logger.warning("connect: bailing — shouldConnect=\(self.shouldConnect, privacy: .public) token=\(self.authService.token != nil ? "present" : "null", privacy: .public)")
             return
         }
+        // Re-entrancy guard: two near-simultaneous triggers (foreground +
+        // network-restored) can both pass their !isConnected gates before
+        // didOpen flips isConnected, opening a second socket. Bail if one
+        // already exists; handleDisconnect nils webSocket before reconnecting.
+        guard webSocket == nil else {
+            logger.info("connect: socket already open/in-flight, skipping")
+            return
+        }
 
         let baseUrl = appPreferences.apiBaseUrl
         let wsBase = baseUrl

--- a/iosApp/deadly/Core/Service/ConnectService.swift
+++ b/iosApp/deadly/Core/Service/ConnectService.swift
@@ -42,8 +42,8 @@ final class ConnectService: NSObject {
     /// Callback to load a show into the local player. Set by PlaylistServiceImpl
     /// to avoid circular dependency. Called when Connect state has a recording
     /// that isn't loaded locally.
-    /// Parameters: (showId, trackIndex, positionMs, autoPlay)
-    var onLoadShow: ((String, Int, Int, Bool) async -> Void)?
+    /// Parameters: (showId, recordingId, trackIndex, positionMs, autoPlay)
+    var onLoadShow: ((String, String, Int, Int, Bool) async -> Void)?
 
     private let appPreferences: AppPreferences
     private let authService: AuthService
@@ -454,7 +454,7 @@ final class ConnectService: NSObject {
             logger.info("reactToState: NEW RECORDING — server=\(recId, privacy: .public) local=\(localRecordingId ?? "nil", privacy: .public) isActive=\(self.isActiveDevice, privacy: .public) autoPlay=\(autoPlay, privacy: .public) track=\(new.trackIndex, privacy: .public)")
             if let onLoadShow {
                 Task {
-                    await onLoadShow(showId, new.trackIndex, new.positionMs, autoPlay)
+                    await onLoadShow(showId, recId, new.trackIndex, new.positionMs, autoPlay)
                 }
             }
             stopPositionReporting()

--- a/iosApp/deadly/Core/Service/PlaylistServiceImpl.swift
+++ b/iosApp/deadly/Core/Service/PlaylistServiceImpl.swift
@@ -291,10 +291,11 @@ final class PlaylistServiceImpl: PlaylistService {
         // If the player already has this recording's queue loaded, skip directly to the index
         // instead of rebuilding the entire queue (avoids redundant network redirect resolution).
         // The observer will emit playback_start/_end via the debounced commit path.
-        // Note: skipTo always starts playback — autoPlay=false only applies when we build a
-        // fresh queue. Restore never hits this branch because nothing is loaded at launch.
+        // Honor autoPlay here too: a Connect reconnect re-issues the load with autoPlay=false
+        // while the queue is already loaded, so a hardcoded autoplay would silently start
+        // playback on a non-active follower (spurious "playing but not in app").
         if streamPlayer.currentTrack?.metadata["recordingId"] == recording.identifier {
-            streamPlayer.skipTo(index: index)
+            streamPlayer.skipTo(index: index, autoplay: autoPlay)
             if !suppressConnectNotify {
                 let durationMs = Int((tracks[index].durationInterval ?? 0) * 1000)
                 connectService?.sendSeek(trackIndex: index, positionMs: 0, durationMs: durationMs)

--- a/tools/ios-log-server/.gitignore
+++ b/tools/ios-log-server/.gitignore
@@ -1,0 +1,2 @@
+# Captured logs are repro scratch, not source.
+*.ndjson

--- a/tools/ios-log-server/README.md
+++ b/tools/ios-log-server/README.md
@@ -1,0 +1,75 @@
+# ios-log-server
+
+A tiny zero-dependency HTTP server for pulling iOS logs off a device on the
+same LAN — no Mac, Xcode console, or USB tether required. You paste a bug-report
+dump (or any text) into a web form on the phone; it lands on this machine as
+NDJSON and is echoed to the console for live reading.
+
+Useful when debugging on-device behavior that only reproduces away from a
+desk — Connect / playback / reconnect issues, backgrounded/locked states, etc.
+
+## Run
+
+From the repo root:
+
+```bash
+python3 tools/ios-log-server/log_server.py
+```
+
+It listens on `0.0.0.0:8088` and writes to `ios-logs.ndjson` in the current
+directory. Override either:
+
+```bash
+PORT=9000 LOGFILE=/tmp/repro.ndjson python3 tools/ios-log-server/log_server.py
+```
+
+Find this machine's LAN IP so you know where to point the phone:
+
+```bash
+ip -4 addr show scope global | grep "inet "
+```
+
+If the phone can't reach it, open the port on the Fedora firewall for the
+session:
+
+```bash
+sudo firewall-cmd --add-port=8088/tcp
+```
+
+## Capture a log
+
+1. On the iPhone (same Wi-Fi), open Safari to `http://<LAN-IP>:8088/`.
+2. Paste the log into the textbox. Optionally tag it in the **label** field
+   (e.g. `connect reconnect repro`) — the label is stored with the record.
+3. Hit **Submit**. The form clears and shows `sent ✓`; the server appends the
+   record and prints it to its console.
+
+You can also POST directly:
+
+```bash
+curl -X POST http://<LAN-IP>:8088/log -H 'X-Label: smoke' -d 'some log text'
+```
+
+## Read the captures
+
+Each line of `ios-logs.ndjson` is one record:
+`{ts, client, path, label, len, body}`. `body` is the parsed JSON if the POST
+was JSON, otherwise the raw text. Quick pretty-print of the latest bug report:
+
+```bash
+python3 - <<'PY'
+import json
+recs = [json.loads(l) for l in open("ios-logs.ndjson") if l.strip()]
+r = recs[-1]
+print(f"=== {r['ts']}  label={r['label']!r}  {r['len']}B ===")
+print(r["body"] if isinstance(r["body"], str) else json.dumps(r["body"], indent=2))
+PY
+```
+
+## Notes
+
+- HTTP only. If you ever POST from in-app `URLSession` (rather than Safari)
+  with ATS enabled, a plain-`http://` host needs an ATS exception — Safari
+  doesn't care, so the paste-in form is the path of least resistance.
+- Captured `*.ndjson` files are git-ignored (see `.gitignore`); they're repro
+  scratch, not source.

--- a/tools/ios-log-server/log_server.py
+++ b/tools/ios-log-server/log_server.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Tiny log-capture server for iOS on-device debugging.
+
+GET  /     -> a dark paste-in web form (open from the phone or desktop).
+POST /log  -> body appended to ios-logs.ndjson (one record per line) and
+              echoed to stdout.
+
+Built for grabbing iOS bug-report dumps off a device on the same LAN
+without a Mac/Xcode console attached. Accepts any content type; JSON
+bodies are pretty-printed to the console, everything else captured raw.
+An optional X-Label header (set via the form's label field) is stored
+alongside each record so you can tag separate repros.
+
+  python3 tools/ios-log-server/log_server.py
+
+Override the port or output file with env vars:
+
+  PORT=9000 LOGFILE=/tmp/repro.ndjson python3 .../log_server.py
+"""
+import datetime
+import json
+import os
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+LOGFILE = os.environ.get("LOGFILE", "ios-logs.ndjson")
+PORT = int(os.environ.get("PORT", "8088"))
+
+PAGE = """<!doctype html>
+<html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>iOS log capture</title>
+<style>
+  body { font-family: -apple-system, system-ui, sans-serif; margin: 0;
+         background: #111; color: #eee; padding: 16px; }
+  h1 { font-size: 16px; font-weight: 600; margin: 0 0 12px; }
+  textarea { width: 100%; box-sizing: border-box; height: 55vh;
+             font-family: ui-monospace, Menlo, monospace; font-size: 13px;
+             background: #1c1c1e; color: #eee; border: 1px solid #333;
+             border-radius: 8px; padding: 10px; }
+  .row { display: flex; gap: 10px; align-items: center; margin-top: 12px; }
+  input[type=text] { flex: 1; background: #1c1c1e; color: #eee;
+             border: 1px solid #333; border-radius: 8px; padding: 8px; font-size: 14px; }
+  button { background: #0a84ff; color: #fff; border: 0; border-radius: 8px;
+           padding: 10px 18px; font-size: 15px; font-weight: 600; }
+  #status { margin-top: 10px; font-size: 13px; color: #8e8e93; }
+</style></head>
+<body>
+  <h1>iOS log capture</h1>
+  <textarea id="log" placeholder="Paste logs here..."></textarea>
+  <div class="row">
+    <input type="text" id="label" placeholder="optional label (e.g. 'iphone auto-advance repro')">
+    <button onclick="send()">Submit</button>
+  </div>
+  <div id="status"></div>
+<script>
+async function send() {
+  const log = document.getElementById('log');
+  const label = document.getElementById('label').value;
+  const status = document.getElementById('status');
+  if (!log.value.trim()) { status.textContent = 'nothing to send'; return; }
+  status.textContent = 'sending...';
+  try {
+    const r = await fetch('/log', {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain', 'X-Label': label },
+      body: log.value,
+    });
+    if (r.ok) {
+      status.textContent = 'sent ✓ (' + new Date().toLocaleTimeString() + ')';
+      log.value = '';
+    } else {
+      status.textContent = 'server error: ' + r.status;
+    }
+  } catch (e) { status.textContent = 'failed: ' + e; }
+}
+</script>
+</body></html>
+"""
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _client(self):
+        return self.client_address[0]
+
+    def do_GET(self):
+        body = PAGE.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length) if length else b""
+        ts = datetime.datetime.now().isoformat(timespec="milliseconds")
+
+        text = raw.decode("utf-8", errors="replace")
+        # Try to parse JSON for nicer console output, but always store raw.
+        parsed = None
+        try:
+            parsed = json.loads(text)
+        except Exception:
+            pass
+
+        label = self.headers.get("X-Label", "")
+        record = {
+            "ts": ts,
+            "client": self._client(),
+            "path": self.path,
+            "label": label,
+            "len": length,
+            "body": parsed if parsed is not None else text,
+        }
+        with open(LOGFILE, "a") as f:
+            f.write(json.dumps(record) + "\n")
+
+        # Console echo
+        sys.stdout.write(f"\n=== {ts}  {self._client()}  {self.path}  ({length}B) ===\n")
+        if parsed is not None:
+            sys.stdout.write(json.dumps(parsed, indent=2) + "\n")
+        else:
+            sys.stdout.write(text + "\n")
+        sys.stdout.flush()
+
+        self.send_response(200)
+        self.send_header("Content-Length", "2")
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+    def log_message(self, *args):
+        pass  # silence default request logging; we do our own
+
+
+if __name__ == "__main__":
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
+    print(f"Listening on 0.0.0.0:{PORT} -> {LOGFILE}")
+    server.serve_forever()


### PR DESCRIPTION
## Summary

Fixes an iOS Connect bug where a **non-active follower could start playing its own local recording after a reconnect** — audio running in the background with nobody owning the session, surfacing only via the OS Now Playing controls ("playing but not in app"). Diagnosed from on-device logs + the local Connect server logs; Android already handled both halves correctly, so the iOS fixes mirror Android.

## The bug (iOS)

Two compounding causes:

1. **Recording never converged.** `onLoadShow` was never given the session's `recordingId`, so it loaded the device's *default* recording instead of the server's. `localRecordingId` never equalled the server's, so `reactToState` saw a permanent mismatch and re-fired the `NEW RECORDING` branch on **every reconnect**.
2. **`autoPlay=false` was silently dropped.** When the queue was already loaded, `playTrack` took a `skipTo(index:)` shortcut that hardcoded autoplay=true, ignoring the caller's `autoPlay=false`. So each reconnect-triggered reload started playback on a follower that should have stayed paused.

## Fixes

- **`fix(ios/connect)`** — thread `recordingId` through `onLoadShow` → `loadShow(recordingId:)` (falls back to the show's best recording if absent locally), and pass `autoplay: autoPlay` into the `skipTo` shortcut. Mirrors Android (`playTrack(recordingId = …)` + forcing `playWhenReady = autoPlay`).
- **`fix(mobile/connect)`** — add a re-entrancy guard to `connect()` on **both platforms** so two near-simultaneous triggers (foreground + network-restored) can't open a redundant second socket. Safe: `handleDisconnect`/`stop` null `webSocket` before reconnecting, so legitimate reconnects still pass.
- **`chore(tools)`** — `tools/ios-log-server`, the zero-dependency paste-in log-capture server used to diagnose this (handy for any on-device iOS debugging without a Mac/Xcode console).

## Verification

- iOS: built on the remote Mac (`** BUILD SUCCEEDED **`). On-device repro re-run: follower lands **paused** on the session's recording (tobin matrix, 24-track), no spurious `skipTo`/playback in the logs.
- Android: `:core:connect:compileDebugKotlin` clean; unaffected by the original bug, only gains the shared re-entrancy guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
