### PR TITLE
feat(all/notifications): cross-device read/dismiss sync (ADR-0015)

### DIFF
--- a/PLANS/in-app-messaging.md
+++ b/PLANS/in-app-messaging.md
@@ -295,7 +295,9 @@ of message *volume*, not user count × message count.
 > 2. **The real upgrade:** a server-side `(user_id, notification_id)` state join
 >    table, reconciled local ↔ server on the focus-refresh fetch. Eventually
 >    consistent, offline-safe, cheap. This is the design v1 deliberately rejects
->    (see the cross-device caveat below) — written down, not built.
+>    (see the cross-device caveat below) — written down, not built. **Now the
+>    decision of record: see [ADR-0015](../docs/adr/0015-cross-device-notification-read-state.md)
+>    for the concrete schema + cross-platform sync wiring.**
 > 3. **Luxury only:** push a dismiss live over the Connect-v2 WebSocket for
 >    *instant* cross-device clear. A WS is **transport, not a source of truth** —
 >    it only reaches devices that are online *now*, so it can't tell the device

--- a/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
@@ -73,6 +73,13 @@ sealed interface PendingDeepLink {
         val collectionId: String
     ) : PendingDeepLink
 }
+
+/** Content for the shared AppToast overlay. [onAction] non-null = a tappable pill. */
+private data class ToastUi(
+    val text: String,
+    val actionLabel: String? = null,
+    val onAction: (() -> Unit)? = null,
+)
 /**
  * MainNavigation - Scalable navigation architecture
  *
@@ -112,43 +119,50 @@ fun MainNavigation(
     val prevIsOffline = remember { mutableStateOf<Boolean?>(null) }
     var pendingDeepLink by remember { mutableStateOf<PendingDeepLink?>(null) }
 
-    // New-message toast: a snackbar with a "View" action that opens the inbox.
-    // Deduped by arrival key so rotation/recomposition can't re-toast (decision C).
+    // The new-message toast and the app-wide transient toast share one
+    // top-of-z-stack overlay (AppToast), which — unlike the scaffold
+    // SnackbarHost — renders above the bottom bar + mini player. `toastUi` is
+    // the retained content (kept through the exit animation), `toastVisible` is
+    // the show/hide trigger, and `toastNonce` re-arms the auto-dismiss timer on
+    // each new toast (so identical back-to-back messages still re-trigger it).
     val notificationViewModel: NotificationViewModel = hiltViewModel()
     val lastToastKey = remember { mutableStateOf<Long?>(null) }
+    val toastUi = remember { mutableStateOf<ToastUi?>(null) }
+    var toastVisible by remember { mutableStateOf(false) }
+    var toastNonce by remember { mutableStateOf(0) }
+
+    fun showToast(ui: ToastUi) {
+        toastUi.value = ui
+        toastVisible = true
+        toastNonce++
+    }
+
+    // New in-app messages: tap the pill to open the inbox. Deduped by arrival
+    // key so rotation/recomposition can't re-toast (decision C).
     LaunchedEffect(Unit) {
         notificationViewModel.newArrivals.collect { arrival ->
             if (lastToastKey.value == arrival.key) return@collect
             lastToastKey.value = arrival.key
             notificationViewModel.onToastShown(arrival)
             val msg = if (arrival.count > 1) "${arrival.count} new messages" else "New: ${arrival.title}"
-            val result = snackbarHostState.showSnackbar(
-                message = msg,
-                actionLabel = "View",
-                duration = SnackbarDuration.Short,
-            )
-            if (result == SnackbarResult.ActionPerformed) {
+            showToast(ToastUi(text = msg, actionLabel = "View", onAction = {
                 notificationViewModel.onToastTap(arrival)
                 navController.navigate("notifications")
-            }
+            }))
         }
     }
 
-    // App-wide transient toast (e.g. the Autoplay toggle confirmation). Rendered
-    // as a top-of-z-stack overlay below (not via the scaffold SnackbarHost, which
-    // is occluded by the bottom bar + mini player on most screens).
-    var toastMessage by remember { mutableStateOf<String?>(null) }
-    val toastText = remember { mutableStateOf("") }
+    // App-wide transient confirmations (e.g. the Autoplay toggle) — non-actionable.
     LaunchedEffect(Unit) {
         appViewModel.toasts.collect { msg ->
-            toastText.value = msg
-            toastMessage = msg
+            showToast(ToastUi(text = msg))
         }
     }
-    LaunchedEffect(toastMessage) {
-        if (toastMessage != null) {
+
+    LaunchedEffect(toastNonce) {
+        if (toastVisible) {
             delay(2500)
-            toastMessage = null
+            toastVisible = false
         }
     }
 
@@ -385,9 +399,10 @@ fun MainNavigation(
             }
 
             // App-wide transient toast — last child = topmost z, visible above
-            // every screen and the mini player.
+            // every screen and the mini player. Content is retained in `toastUi`
+            // so it stays rendered through the exit animation after hide.
             androidx.compose.animation.AnimatedVisibility(
-                visible = toastMessage != null,
+                visible = toastVisible,
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .padding(horizontal = 24.dp)
@@ -395,7 +410,9 @@ fun MainNavigation(
                 enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
                 exit = slideOutVertically(targetOffsetY = { it }) + fadeOut()
             ) {
-                AppToast(message = toastText.value)
+                toastUi.value?.let { t ->
+                    AppToast(message = t.text, actionLabel = t.actionLabel, onClick = t.onAction)
+                }
             }
         }
     }

--- a/androidApp/app/src/main/java/com/grateful/deadly/notifications/NotificationViewModel.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/notifications/NotificationViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.grateful.deadly.core.database.AnalyticsService
 import com.grateful.deadly.core.notifications.CachedNotification
 import com.grateful.deadly.core.notifications.NewArrival
-import com.grateful.deadly.core.notifications.NotificationApiService
+import com.grateful.deadly.core.notifications.NotificationCoordinator
 import com.grateful.deadly.core.notifications.NotificationStore
 import com.grateful.deadly.core.notifications.active
 import com.grateful.deadly.core.notifications.dismissed
@@ -38,7 +38,7 @@ import javax.inject.Inject
 @HiltViewModel
 class NotificationViewModel @Inject constructor(
     private val store: NotificationStore,
-    private val apiService: NotificationApiService,
+    private val coordinator: NotificationCoordinator,
     private val analytics: AnalyticsService,
 ) : ViewModel() {
 
@@ -69,16 +69,21 @@ class NotificationViewModel @Inject constructor(
     /** Emits when a delta brings new eligible unread messages — for the toast. */
     val newArrivals = store.newArrivals
 
-    /** Pull-to-refresh: fetch a `?since` delta and merge it. */
+    /** Pull-to-refresh: full sync (feed + overlay + flush) with the spinner. */
     fun refresh() {
         if (_refreshing.value) return
         viewModelScope.launch {
             _refreshing.value = true
-            apiService.fetch(store.cursor).onSuccess { result ->
-                store.merge(result).forEach { analytics.trackNotificationReceived(it, "refresh") }
-            }
+            coordinator.sync("refresh")
             _refreshing.value = false
         }
+    }
+
+    /** Opening the inbox triggers a full sync, silently (no pull spinner) — so
+     *  the list reflects cross-device read/dismiss state and retirements the
+     *  moment it's shown. */
+    fun syncOnOpen() {
+        viewModelScope.launch { coordinator.sync("inbox_open") }
     }
 
     /** A message row became visible in the inbox — count one impression per id. */

--- a/androidApp/app/src/main/java/com/grateful/deadly/notifications/NotificationsScreen.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/notifications/NotificationsScreen.kt
@@ -55,6 +55,10 @@ fun NotificationsScreen(
         (active + archived).firstOrNull { it.id == selectedId }
     }
 
+    // Sync whenever the inbox is opened, so it reflects cross-device state +
+    // retirements immediately (not just on cold start / foreground / pull).
+    LaunchedEffect(Unit) { viewModel.syncOnOpen() }
+
     // Detail open → back closes detail first, then leaves the screen.
     BackHandler(enabled = selected != null) { selectedId = null }
 

--- a/androidApp/app/src/main/java/com/grateful/deadly/notifications/NotificationsScreen.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/notifications/NotificationsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import com.grateful.deadly.core.notifications.CachedNotification
 import java.text.SimpleDateFormat
 import java.util.*
@@ -96,20 +97,33 @@ fun NotificationsScreen(
                     Column(Modifier.fillMaxSize()) {
                         if (!showArchive && active.isNotEmpty()) {
                             Row(
-                                modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
-                                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 20.dp, vertical = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically,
                             ) {
                                 TextButton(
                                     onClick = { viewModel.markAllSeen() },
                                     enabled = active.any { it.seenAt == null },
-                                ) { Text("Mark all read") }
-                                TextButton(onClick = { viewModel.archiveAll() }) { Text("Archive all") }
+                                    contentPadding = PaddingValues(horizontal = 4.dp, vertical = 4.dp),
+                                ) { Text("Mark all read", style = MaterialTheme.typography.labelLarge) }
+                                Spacer(Modifier.weight(1f))
+                                TextButton(
+                                    onClick = { viewModel.archiveAll() },
+                                    colors = ButtonDefaults.textButtonColors(
+                                        contentColor = MaterialTheme.colorScheme.error,
+                                    ),
+                                    contentPadding = PaddingValues(horizontal = 4.dp, vertical = 4.dp),
+                                ) { Text("Archive all", style = MaterialTheme.typography.labelLarge) }
                             }
                         }
 
                         // Always a LazyColumn so the pull-to-refresh nested scroll
                         // works even when the inbox is empty (pull to check for new).
-                        LazyColumn(Modifier.weight(1f)) {
+                        LazyColumn(
+                            modifier = Modifier.weight(1f),
+                            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                        ) {
                             if (list.isEmpty()) {
                                 item {
                                     Box(Modifier.fillParentMaxSize(), contentAlignment = Alignment.Center) {
@@ -120,18 +134,38 @@ fun NotificationsScreen(
                                     }
                                 }
                             } else {
-                                items(list, key = { it.id }) { m ->
-                                    // First time this row renders, count one impression.
-                                    LaunchedEffect(m.id) { viewModel.onImpression(m) }
-                                    NotificationRow(
-                                        message = m,
-                                        unread = !showArchive && m.seenAt == null,
-                                        onClick = {
-                                            viewModel.open(m)
-                                            selectedId = m.id
-                                        },
-                                    )
-                                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
+                                // One inset, rounded card holding all rows — matches
+                                // the iOS grouped List look (separators inset past
+                                // the leading icon).
+                                item {
+                                    Surface(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        shape = RoundedCornerShape(16.dp),
+                                        color = MaterialTheme.colorScheme.surfaceVariant,
+                                        tonalElevation = 2.dp,
+                                    ) {
+                                        Column {
+                                            list.forEachIndexed { index, m ->
+                                                // First time this row renders, count one impression.
+                                                LaunchedEffect(m.id) { viewModel.onImpression(m) }
+                                                NotificationRow(
+                                                    message = m,
+                                                    unread = !showArchive && m.seenAt == null,
+                                                    onClick = {
+                                                        viewModel.open(m)
+                                                        selectedId = m.id
+                                                    },
+                                                )
+                                                if (index < list.lastIndex) {
+                                                    HorizontalDivider(
+                                                        modifier = Modifier.padding(start = 44.dp),
+                                                        color = MaterialTheme.colorScheme.outlineVariant
+                                                            .copy(alpha = 0.4f),
+                                                    )
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -173,16 +207,20 @@ private fun NotificationRow(
                     .background(MaterialTheme.colorScheme.primary),
             )
         }
-        Column(Modifier.weight(1f)) {
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = message.title,
                     style = MaterialTheme.typography.titleSmall,
-                    fontWeight = if (unread) FontWeight.SemiBold else FontWeight.Normal,
+                    fontWeight = if (unread) FontWeight.SemiBold else FontWeight.Medium,
+                    // Explicit, since the card's surfaceVariant container would
+                    // otherwise mute the title to onSurfaceVariant.
+                    color = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.weight(1f),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
+                Spacer(Modifier.width(8.dp))
                 Text(
                     text = timeAgo(message.createdAt),
                     style = MaterialTheme.typography.labelSmall,
@@ -193,7 +231,7 @@ private fun NotificationRow(
                 text = preview(message.body),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
+                maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )
         }

--- a/androidApp/core/design/src/main/java/com/grateful/deadly/core/design/component/AppToast.kt
+++ b/androidApp/core/design/src/main/java/com/grateful/deadly/core/design/component/AppToast.kt
@@ -1,12 +1,19 @@
 package com.grateful.deadly.core.design.component
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
@@ -16,25 +23,49 @@ import androidx.compose.ui.unit.dp
  * Styled to match the app's other docked overlays (surfaceVariant pill, soft
  * shadow) rather than the stock Material snackbar, and rendered at the top of
  * the root z-stack so it's visible above every screen + the mini player.
+ *
+ * Usually non-actionable (a confirmation). When [actionLabel] + [onClick] are
+ * supplied the whole pill becomes tappable and shows the label as an accented
+ * affordance — used for the new-message toast ("View" → inbox), which the stock
+ * snackbar rendered behind the mini player.
  */
 @Composable
 fun AppToast(
     message: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    actionLabel: String? = null,
+    onClick: (() -> Unit)? = null
 ) {
     Surface(
-        modifier = modifier,
+        modifier = if (onClick != null) modifier.clickable(onClick = onClick) else modifier,
         color = MaterialTheme.colorScheme.surfaceVariant,
         contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
         shape = RoundedCornerShape(percent = 50),
         shadowElevation = 8.dp,
         tonalElevation = 3.dp
     ) {
-        Text(
-            text = message,
-            style = MaterialTheme.typography.bodyMedium,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp)
-        )
+        if (actionLabel != null) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp)
+            ) {
+                Text(text = message, style = MaterialTheme.typography.bodyMedium)
+                Spacer(Modifier.width(16.dp))
+                Text(
+                    text = actionLabel,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        } else {
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp)
+            )
+        }
     }
 }

--- a/androidApp/core/notifications/build.gradle.kts
+++ b/androidApp/core/notifications/build.gradle.kts
@@ -38,6 +38,8 @@ android {
 
 dependencies {
     implementation(project(":core:database"))
+    // Per-user read/dismiss overlay (ADR-0015) rides the authed /api/user path.
+    implementation(project(":core:api:auth"))
 
     // Hilt
     implementation("com.google.dagger:hilt-android:2.56.1")

--- a/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/Notification.kt
+++ b/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/Notification.kt
@@ -38,6 +38,19 @@ data class NotificationFetchResult(
     val cursor: Long = 0,
 )
 
+/**
+ * Per-user read/dismiss overlay row (ADR-0015). Wire timestamps are unix
+ * SECONDS (the user-data API convention); the local store keeps milliseconds,
+ * so the coordinator converts at the boundary. camelCase matches the server's
+ * authed `/api/user/notifications/state` payload.
+ */
+@Serializable
+data class NotificationStateRow(
+    val notificationId: Long,
+    val seenAt: Long? = null,
+    val dismissedAt: Long? = null,
+)
+
 /** A cached message plus local-only state. Never sent back to the server. */
 @Serializable
 data class CachedNotification(

--- a/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/Notification.kt
+++ b/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/Notification.kt
@@ -36,6 +36,12 @@ data class NotificationWire(
 data class NotificationFetchResult(
     val messages: List<NotificationWire> = emptyList(),
     val cursor: Long = 0,
+    /**
+     * Authoritative set of currently-active ids — clients prune any cached
+     * message not in it (the only signal of a server-side retire). Null for
+     * older servers (= don't prune on that basis). ADR-0015.
+     */
+    val activeIds: List<Long>? = null,
 )
 
 /**

--- a/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/NotificationApiService.kt
+++ b/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/NotificationApiService.kt
@@ -7,4 +7,21 @@ interface NotificationApiService {
      * The endpoint is public — no auth header is sent.
      */
     suspend fun fetch(since: Long): Result<NotificationFetchResult>
+
+    // ── Per-user read/dismiss overlay (ADR-0015), authed ────────────────
+    // These ride the authed /api/user path (an Authorization header), unlike
+    // the public feed above. They fail with "Not signed in" when there's no
+    // token; callers gate on sign-in first.
+
+    /** Pull the signed-in user's full read/dismiss overlay. */
+    suspend fun pullState(): Result<List<NotificationStateRow>>
+
+    /** Granular push — backs markRead (seenAt) / archive (dismissedAt). */
+    suspend fun pushState(id: Long, seenAt: Long?, dismissedAt: Long?): Result<Unit>
+
+    /**
+     * Bulk push — backs markAllRead / archiveAll. `ids = null` targets every
+     * currently-active message server-side.
+     */
+    suspend fun pushStateBulk(seenAt: Long?, dismissedAt: Long?, ids: List<Long>?): Result<Unit>
 }

--- a/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/NotificationApiServiceImpl.kt
+++ b/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/NotificationApiServiceImpl.kt
@@ -1,32 +1,46 @@
 package com.grateful.deadly.core.notifications
 
 import android.util.Log
+import com.grateful.deadly.core.api.auth.AuthService
 import com.grateful.deadly.core.database.AppPreferences
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Reads the public, cacheable notifications feed. Mirrors UserSyncServiceImpl's
- * OkHttp + kotlinx.serialization shape, minus the Authorization header (global
- * content isn't user-specific, so the fetch fires regardless of sign-in state).
+ * Reads the public, cacheable notifications feed, and (when signed in) the
+ * per-user read/dismiss overlay (ADR-0015). The feed fetch sends no auth header
+ * (global content isn't user-specific); the overlay calls ride the authed
+ * /api/user path with a Bearer token, mirroring UserSyncServiceImpl.
  */
 @Singleton
 class NotificationApiServiceImpl @Inject constructor(
     private val appPreferences: AppPreferences,
+    private val authService: AuthService,
 ) : NotificationApiService {
 
     companion object {
         private const val TAG = "NotificationApi"
     }
 
+    @Serializable
+    private data class StateBody(val seenAt: Long?, val dismissedAt: Long?)
+
+    @Serializable
+    private data class BulkStateBody(val seenAt: Long?, val dismissedAt: Long?, val ids: List<Long>?)
+
     private val httpClient = OkHttpClient()
     private val json = Json { ignoreUnknownKeys = true }
+    private val jsonMedia = "application/json".toMediaType()
 
     override suspend fun fetch(since: Long): Result<NotificationFetchResult> {
         val baseUrl = appPreferences.apiBaseUrl
@@ -47,6 +61,80 @@ class NotificationApiServiceImpl @Inject constructor(
             Result.success(json.decodeFromString(NotificationFetchResult.serializer(), body))
         } catch (e: Exception) {
             Log.w(TAG, "fetch(since=$since) failed", e)
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun pullState(): Result<List<NotificationStateRow>> {
+        val token = authService.getAuthToken()
+            ?: return Result.failure(IllegalStateException("Not signed in"))
+        val baseUrl = appPreferences.apiBaseUrl
+        return try {
+            val body = withContext(Dispatchers.IO) {
+                val request = Request.Builder()
+                    .url("$baseUrl/api/user/notifications/state")
+                    .addHeader("Authorization", "Bearer $token")
+                    .get().build()
+                httpClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        throw RuntimeException("HTTP ${response.code}: ${response.body?.string().orEmpty()}")
+                    }
+                    response.body?.string() ?: throw RuntimeException("Empty response body")
+                }
+            }
+            Result.success(json.decodeFromString(ListSerializer(NotificationStateRow.serializer()), body))
+        } catch (e: Exception) {
+            Log.w(TAG, "pullState failed", e)
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun pushState(id: Long, seenAt: Long?, dismissedAt: Long?): Result<Unit> {
+        val token = authService.getAuthToken()
+            ?: return Result.failure(IllegalStateException("Not signed in"))
+        val baseUrl = appPreferences.apiBaseUrl
+        val bodyJson = json.encodeToString(StateBody.serializer(), StateBody(seenAt, dismissedAt))
+        return try {
+            withContext(Dispatchers.IO) {
+                val request = Request.Builder()
+                    .url("$baseUrl/api/user/notifications/$id/state")
+                    .addHeader("Authorization", "Bearer $token")
+                    .post(bodyJson.toRequestBody(jsonMedia))
+                    .build()
+                httpClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        throw RuntimeException("HTTP ${response.code}: ${response.body?.string().orEmpty()}")
+                    }
+                }
+            }
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.w(TAG, "pushState failed for $id", e)
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun pushStateBulk(seenAt: Long?, dismissedAt: Long?, ids: List<Long>?): Result<Unit> {
+        val token = authService.getAuthToken()
+            ?: return Result.failure(IllegalStateException("Not signed in"))
+        val baseUrl = appPreferences.apiBaseUrl
+        val bodyJson = json.encodeToString(BulkStateBody.serializer(), BulkStateBody(seenAt, dismissedAt, ids))
+        return try {
+            withContext(Dispatchers.IO) {
+                val request = Request.Builder()
+                    .url("$baseUrl/api/user/notifications/state")
+                    .addHeader("Authorization", "Bearer $token")
+                    .post(bodyJson.toRequestBody(jsonMedia))
+                    .build()
+                httpClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        throw RuntimeException("HTTP ${response.code}: ${response.body?.string().orEmpty()}")
+                    }
+                }
+            }
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.w(TAG, "pushStateBulk failed", e)
             Result.failure(e)
         }
     }

--- a/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/NotificationCoordinator.kt
+++ b/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/NotificationCoordinator.kt
@@ -62,35 +62,44 @@ class NotificationCoordinator @Inject constructor(
     }
 
     private fun pull(reason: String) {
-        scope.launch {
-            apiService.fetch(store.cursor).fold(
-                onSuccess = { result ->
-                    // For a signed-in user, pull the read/dismiss overlay and merge
-                    // it atomically with the feed so already-handled messages never
-                    // flash unread (ADR-0015 state-before-surface).
-                    val signedIn = authService.getAuthToken() != null
-                    val serverState = if (signedIn) {
-                        apiService.pullState().getOrDefault(emptyList())
-                    } else {
-                        emptyList()
+        scope.launch { sync(reason) }
+    }
+
+    /**
+     * The full sync: fetch the feed delta, merge it with the per-user overlay
+     * (signed-in only), and flush any local state the server is missing. The
+     * single source of truth for syncing — cold start, foreground, inbox-open,
+     * and pull-to-refresh all route through here so they behave identically.
+     * Suspends until done so callers can drive a spinner.
+     */
+    suspend fun sync(reason: String) {
+        apiService.fetch(store.cursor).fold(
+            onSuccess = { result ->
+                // For a signed-in user, pull the read/dismiss overlay and merge
+                // it atomically with the feed so already-handled messages never
+                // flash unread (ADR-0015 state-before-surface).
+                val signedIn = authService.getAuthToken() != null
+                val serverState = if (signedIn) {
+                    apiService.pullState().getOrDefault(emptyList())
+                } else {
+                    emptyList()
+                }
+
+                val fresh = store.merge(result, serverState)
+                fresh.forEach { m -> analytics.trackNotificationReceived(m, reason) }
+
+                // Offline catch-up: flush any local state the server is missing
+                // (an eager push that failed while offline). No-op once converged.
+                if (signedIn) {
+                    for (row in store.unsyncedState(serverState)) {
+                        apiService.pushState(row.notificationId, row.seenAt, row.dismissedAt)
                     }
+                }
 
-                    val fresh = store.merge(result, serverState)
-                    fresh.forEach { m -> analytics.trackNotificationReceived(m, reason) }
-
-                    // Offline catch-up: flush any local state the server is missing
-                    // (an eager push that failed while offline). No-op once converged.
-                    if (signedIn) {
-                        for (row in store.unsyncedState(serverState)) {
-                            apiService.pushState(row.notificationId, row.seenAt, row.dismissedAt)
-                        }
-                    }
-
-                    Log.d(TAG, "pull[$reason] ok: +${result.messages.size} (cursor=${store.cursor})")
-                },
-                onFailure = { Log.w(TAG, "pull[$reason] failed: ${it.message}") },
-            )
-        }
+                Log.d(TAG, "sync[$reason] ok: +${result.messages.size} (cursor=${store.cursor})")
+            },
+            onFailure = { Log.w(TAG, "sync[$reason] failed: ${it.message}") },
+        )
     }
 
     /**

--- a/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/NotificationCoordinator.kt
+++ b/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/NotificationCoordinator.kt
@@ -1,6 +1,7 @@
 package com.grateful.deadly.core.notifications
 
 import android.util.Log
+import com.grateful.deadly.core.api.auth.AuthService
 import com.grateful.deadly.core.database.AnalyticsService
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -30,6 +31,7 @@ class NotificationCoordinator @Inject constructor(
     private val apiService: NotificationApiService,
     private val store: NotificationStore,
     private val analytics: AnalyticsService,
+    private val authService: AuthService,
 ) {
     companion object {
         private const val TAG = "NotificationCoord"
@@ -41,6 +43,9 @@ class NotificationCoordinator @Inject constructor(
     fun start() {
         if (started) return
         started = true
+
+        // Eager-push local read/dismiss mutations to the server (ADR-0015).
+        store.onStateChange = ::pushStateChange
 
         // Cold start: pull once now.
         pull("cold_start")
@@ -59,13 +64,54 @@ class NotificationCoordinator @Inject constructor(
     private fun pull(reason: String) {
         scope.launch {
             apiService.fetch(store.cursor).fold(
-                onSuccess = {
-                    val fresh = store.merge(it)
+                onSuccess = { result ->
+                    // For a signed-in user, pull the read/dismiss overlay and merge
+                    // it atomically with the feed so already-handled messages never
+                    // flash unread (ADR-0015 state-before-surface).
+                    val signedIn = authService.getAuthToken() != null
+                    val serverState = if (signedIn) {
+                        apiService.pullState().getOrDefault(emptyList())
+                    } else {
+                        emptyList()
+                    }
+
+                    val fresh = store.merge(result, serverState)
                     fresh.forEach { m -> analytics.trackNotificationReceived(m, reason) }
-                    Log.d(TAG, "pull[$reason] ok: +${it.messages.size} (cursor=${store.cursor})")
+
+                    // Offline catch-up: flush any local state the server is missing
+                    // (an eager push that failed while offline). No-op once converged.
+                    if (signedIn) {
+                        for (row in store.unsyncedState(serverState)) {
+                            apiService.pushState(row.notificationId, row.seenAt, row.dismissedAt)
+                        }
+                    }
+
+                    Log.d(TAG, "pull[$reason] ok: +${result.messages.size} (cursor=${store.cursor})")
                 },
                 onFailure = { Log.w(TAG, "pull[$reason] failed: ${it.message}") },
             )
+        }
+    }
+
+    /**
+     * Eager push of a local read/dismiss mutation (ADR-0015). Fire-and-forget on
+     * the IO scope; failures are caught by the focus-refresh catch-up flush.
+     * No-op when signed out (state stays local, like the rest of user data).
+     */
+    private fun pushStateChange(change: NotificationStateChange) {
+        if (authService.getAuthToken() == null) return
+        val nowSec = System.currentTimeMillis() / 1000
+        scope.launch {
+            when (change) {
+                is NotificationStateChange.Seen ->
+                    apiService.pushState(change.id, seenAt = nowSec, dismissedAt = null)
+                is NotificationStateChange.Dismissed ->
+                    apiService.pushState(change.id, seenAt = null, dismissedAt = nowSec)
+                NotificationStateChange.SeenAll ->
+                    apiService.pushStateBulk(seenAt = nowSec, dismissedAt = null, ids = null)
+                NotificationStateChange.DismissedAll ->
+                    apiService.pushStateBulk(seenAt = null, dismissedAt = nowSec, ids = null)
+            }
         }
     }
 }

--- a/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/NotificationStore.kt
+++ b/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/NotificationStore.kt
@@ -138,11 +138,16 @@ class NotificationStore @Inject constructor(
             )
         }
 
-        // Prune: expired messages and long-dismissed ones.
+        // Prune: server-retired (not in the authoritative activeIds), expired,
+        // and long-dismissed messages. activeIds is the only signal that a
+        // cached message was retired server-side (ADR-0015); null = older
+        // server, so don't prune on that basis.
+        val activeIds = result.activeIds?.toHashSet()
         val pruned = byId.values.filterNot { m ->
+            val retired = activeIds != null && m.id !in activeIds
             val expired = m.expiresAt != null && m.expiresAt * 1000 < now
             val staleDismissed = m.dismissedAt != null && now - m.dismissedAt > DISMISSED_TTL_MS
-            expired || staleDismissed
+            retired || expired || staleDismissed
         }
 
         commit(Persisted(cursor = maxOf(persisted.cursor, result.cursor), messages = pruned))

--- a/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/NotificationStore.kt
+++ b/androidApp/core/notifications/src/main/java/com/grateful/deadly/core/notifications/NotificationStore.kt
@@ -64,6 +64,13 @@ class NotificationStore @Inject constructor(
 
     val cursor: Long get() = persisted.cursor
 
+    /**
+     * Fired after a local read/dismiss mutation so the owner can eagerly push it
+     * to the server (ADR-0015). Null until wired; the store itself never touches
+     * the network.
+     */
+    var onStateChange: ((NotificationStateChange) -> Unit)? = null
+
     private fun load(): Persisted {
         val raw = prefs.getString(KEY_STORE, null) ?: return Persisted()
         return try {
@@ -91,7 +98,10 @@ class NotificationStore @Inject constructor(
      * reason, including cold start) so the caller can emit per-message
      * `notification_received` analytics. Empty when nothing new arrived.
      */
-    fun merge(result: NotificationFetchResult): List<CachedNotification> {
+    fun merge(
+        result: NotificationFetchResult,
+        serverState: List<NotificationStateRow> = emptyList(),
+    ): List<CachedNotification> {
         val coldStart = persisted.cursor == 0L
         val now = System.currentTimeMillis()
         val knownIds = persisted.messages.mapTo(HashSet()) { it.id }
@@ -116,6 +126,18 @@ class NotificationStore @Inject constructor(
             )
         }
 
+        // ADR-0015: overlay the server's per-user read/dismiss state (unix
+        // seconds -> ms) onto the cache BEFORE computing unread/toast, so a
+        // message handled on another device never flashes unread. Union =
+        // earliest non-null per column, matching the server's MIN(COALESCE).
+        for (row in serverState) {
+            val m = byId[row.notificationId] ?: continue
+            byId[row.notificationId] = m.copy(
+                seenAt = unionEarliest(m.seenAt, row.seenAt?.times(1000)),
+                dismissedAt = unionEarliest(m.dismissedAt, row.dismissedAt?.times(1000)),
+            )
+        }
+
         // Prune: expired messages and long-dismissed ones.
         val pruned = byId.values.filterNot { m ->
             val expired = m.expiresAt != null && m.expiresAt * 1000 < now
@@ -133,14 +155,48 @@ class NotificationStore @Inject constructor(
             .filter { it.isEligible(appVersion) && it.dismissedAt == null }
             .sortedByDescending { it.createdAt }
 
-        // Toast signal: only on a delta (never the cold-start backlog).
-        if (!coldStart && fresh.isNotEmpty()) {
+        // Toast signal: only on a delta (never the cold-start backlog) and never
+        // a message already seen on another device (the overlay merge above).
+        val toastable = fresh.filter { it.seenAt == null }
+        if (!coldStart && toastable.isNotEmpty()) {
             _newArrivals.tryEmit(
-                NewArrival(title = fresh.first().title, count = fresh.size, key = fresh.first().id),
+                NewArrival(title = toastable.first().title, count = toastable.size, key = toastable.first().id),
             )
         }
 
         return fresh
+    }
+
+    /** Earliest non-null of two timestamps — the union comparator (ADR-0015). */
+    private fun unionEarliest(a: Long?, b: Long?): Long? = when {
+        a == null -> b
+        b == null -> a
+        else -> minOf(a, b)
+    }
+
+    /**
+     * Local state the server is missing (or has later than ours) — the offline
+     * catch-up flush for an eager push that failed while offline. Timestamps
+     * returned in unix seconds; empty in the common already-synced case.
+     */
+    fun unsyncedState(server: List<NotificationStateRow>): List<NotificationStateRow> {
+        val byServer = server.associateBy { it.notificationId }
+        return persisted.messages.mapNotNull { m ->
+            if (m.seenAt == null && m.dismissedAt == null) return@mapNotNull null
+            val s = byServer[m.id]
+            val needSeen = m.seenAt != null && (s?.seenAt == null || s.seenAt * 1000 > m.seenAt)
+            val needDismissed =
+                m.dismissedAt != null && (s?.dismissedAt == null || s.dismissedAt * 1000 > m.dismissedAt)
+            if (needSeen || needDismissed) {
+                NotificationStateRow(
+                    notificationId = m.id,
+                    seenAt = if (needSeen) m.seenAt!! / 1000 else null,
+                    dismissedAt = if (needDismissed) m.dismissedAt!! / 1000 else null,
+                )
+            } else {
+                null
+            }
+        }
     }
 
     /** Mark a single message read ("tap to read" — opening its detail). */
@@ -151,6 +207,7 @@ class NotificationStore @Inject constructor(
             if (it.id == id && it.seenAt == null) it.copy(seenAt = now) else it
         }
         commit(persisted.copy(messages = updated))
+        onStateChange?.invoke(NotificationStateChange.Seen(id))
     }
 
     /** Clear the unread badge: stamp every unseen message as seen. */
@@ -161,6 +218,7 @@ class NotificationStore @Inject constructor(
             if (it.seenAt == null) it.copy(seenAt = now) else it
         }
         commit(persisted.copy(messages = updated))
+        onStateChange?.invoke(NotificationStateChange.SeenAll)
     }
 
     /** Archive (remove from the active queue; stays in the archive). */
@@ -171,6 +229,7 @@ class NotificationStore @Inject constructor(
             if (it.id == id && it.dismissedAt == null) it.copy(dismissedAt = now) else it
         }
         commit(persisted.copy(messages = updated))
+        onStateChange?.invoke(NotificationStateChange.Dismissed(id))
     }
 
     /** Archive every active eligible message at once. */
@@ -181,7 +240,20 @@ class NotificationStore @Inject constructor(
         }
         if (updated == persisted.messages) return
         commit(persisted.copy(messages = updated))
+        onStateChange?.invoke(NotificationStateChange.DismissedAll)
     }
+}
+
+/**
+ * A local read/dismiss mutation worth pushing to the server (ADR-0015). The
+ * store stays free of networking; the coordinator wires [NotificationStore.onStateChange]
+ * to the push.
+ */
+sealed interface NotificationStateChange {
+    data class Seen(val id: Long) : NotificationStateChange       // markRead
+    data class Dismissed(val id: Long) : NotificationStateChange  // archive
+    data object SeenAll : NotificationStateChange                 // markAllRead (all active)
+    data object DismissedAll : NotificationStateChange            // archiveAll (all active)
 }
 
 /**

--- a/api/src/db/__tests__/notification-state.test.ts
+++ b/api/src/db/__tests__/notification-state.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+
+// Point the users-db singleton at a throwaway file BEFORE importing the module.
+process.env.USERS_DB_PATH = path.join(os.tmpdir(), `notif-state-test-${crypto.randomUUID()}.db`);
+
+const { getUsersDb } = await import("../users.js");
+const { createNotification, deleteNotification } = await import("../notifications.js");
+const {
+  getNotificationState,
+  upsertNotificationState,
+  upsertNotificationStates,
+  getFullBackupV3,
+  importFullBackupV3,
+} = await import("../userdata.js");
+
+const AUTHOR = "author-1";
+const USER = "user-1";
+
+beforeAll(() => {
+  const db = getUsersDb();
+  db.prepare(`INSERT OR IGNORE INTO accounts (id, email, provider) VALUES (?, ?, 'test')`)
+    .run(AUTHOR, "author@test.dev");
+  db.prepare(`INSERT OR IGNORE INTO accounts (id, email, provider) VALUES (?, ?, 'test')`)
+    .run(USER, "user@test.dev");
+});
+
+beforeEach(() => {
+  const db = getUsersDb();
+  db.exec(`DELETE FROM notification_state`);
+  db.exec(`DELETE FROM notifications`);
+  db.exec(`DELETE FROM sqlite_sequence WHERE name = 'notifications'`);
+});
+
+function publish(): number {
+  return createNotification({ authorId: AUTHOR, title: "t", body: "b" }).id;
+}
+
+describe("notification_state union merge (ADR-0015)", () => {
+  it("stores seen and dismissed independently for a user", () => {
+    const id = publish();
+    upsertNotificationState(USER, { notificationId: id, seenAt: 100, updatedAt: 0 });
+    const [row] = getNotificationState(USER);
+    expect(row.notificationId).toBe(id);
+    expect(row.seenAt).toBe(100);
+    expect(row.dismissedAt).toBeNull();
+  });
+
+  it("a later write fills the other column without clobbering the first", () => {
+    const id = publish();
+    upsertNotificationState(USER, { notificationId: id, seenAt: 100, updatedAt: 0 });
+    upsertNotificationState(USER, { notificationId: id, dismissedAt: 200, updatedAt: 0 });
+    const [row] = getNotificationState(USER);
+    expect(row.seenAt).toBe(100);
+    expect(row.dismissedAt).toBe(200);
+  });
+
+  it("keeps the EARLIEST non-null timestamp per column (union, not last-write)", () => {
+    const id = publish();
+    // Device B read it later...
+    upsertNotificationState(USER, { notificationId: id, seenAt: 500, updatedAt: 0 });
+    // ...device A read it earlier; the earlier instant wins.
+    upsertNotificationState(USER, { notificationId: id, seenAt: 100, updatedAt: 0 });
+    expect(getNotificationState(USER)[0].seenAt).toBe(100);
+
+    // A later write never resurrects/overwrites an existing earlier value.
+    upsertNotificationState(USER, { notificationId: id, seenAt: 900, updatedAt: 0 });
+    expect(getNotificationState(USER)[0].seenAt).toBe(100);
+  });
+
+  it("a null-only write is a no-op against existing state", () => {
+    const id = publish();
+    upsertNotificationState(USER, { notificationId: id, seenAt: 100, updatedAt: 0 });
+    upsertNotificationState(USER, { notificationId: id, updatedAt: 0 }); // both null
+    const [row] = getNotificationState(USER);
+    expect(row.seenAt).toBe(100);
+    expect(row.dismissedAt).toBeNull();
+  });
+
+  it("bulk upsert covers many ids in one shot", () => {
+    const ids = [publish(), publish(), publish()];
+    upsertNotificationStates(USER, ids.map((notificationId) => ({
+      notificationId, seenAt: 300, updatedAt: 0,
+    })));
+    const rows = getNotificationState(USER);
+    expect(rows).toHaveLength(3);
+    expect(rows.every((r) => r.seenAt === 300)).toBe(true);
+  });
+
+  it("state is per-user", () => {
+    const id = publish();
+    upsertNotificationState(USER, { notificationId: id, seenAt: 100, updatedAt: 0 });
+    expect(getNotificationState("author-1")).toHaveLength(0);
+  });
+
+  it("admin unsend cascades away the user's overlay row", () => {
+    const id = publish();
+    upsertNotificationState(USER, { notificationId: id, seenAt: 100, updatedAt: 0 });
+    expect(getNotificationState(USER)).toHaveLength(1);
+
+    // deleteNotification only tombstones (soft delete) — overlay survives.
+    deleteNotification(id);
+    expect(getNotificationState(USER)).toHaveLength(1);
+
+    // A hard delete (the only thing that triggers the FK CASCADE) reaps it.
+    getUsersDb().prepare(`DELETE FROM notifications WHERE id = ?`).run(id);
+    expect(getNotificationState(USER)).toHaveLength(0);
+  });
+});
+
+describe("notification_state in the V3 backup", () => {
+  it("round-trips through export/import with union merge", () => {
+    const id = publish();
+    upsertNotificationState(USER, { notificationId: id, seenAt: 100, updatedAt: 0 });
+
+    const backup = getFullBackupV3(USER);
+    expect(backup.notificationState).toEqual([
+      { notificationId: id, seenAt: 100, dismissedAt: null, updatedAt: expect.any(Number) },
+    ]);
+
+    // Importing an earlier-dismissed view of the same row unions in dismissed.
+    importFullBackupV3(USER, {
+      ...backup,
+      notificationState: [{ notificationId: id, dismissedAt: 50, updatedAt: 0 }],
+    });
+    const [row] = getNotificationState(USER);
+    expect(row.seenAt).toBe(100);
+    expect(row.dismissedAt).toBe(50);
+  });
+});

--- a/api/src/db/__tests__/notifications.test.ts
+++ b/api/src/db/__tests__/notifications.test.ts
@@ -11,6 +11,7 @@ const {
   createNotification,
   getNotificationsSince,
   getActiveNotifications,
+  getAllActiveNotificationIds,
   getLatestNotificationId,
   deleteNotification,
 } = await import("../notifications.js");
@@ -107,5 +108,26 @@ describe("latest-id polling short-circuit", () => {
     expect(a.id).toBe(getLatestNotificationId());
     // Nothing newer than the latest id.
     expect(getNotificationsSince(getLatestNotificationId())).toHaveLength(0);
+  });
+});
+
+describe("active-id set (retirement reconciliation, ADR-0015)", () => {
+  it("lists every live id, uncapped, and drops retired ones", () => {
+    const a = createNotification({ authorId: AUTHOR, title: "a", body: "a" });
+    const b = createNotification({ authorId: AUTHOR, title: "b", body: "b" });
+    const c = createNotification({ authorId: AUTHOR, title: "c", body: "c" });
+    expect(getAllActiveNotificationIds().sort()).toEqual([a.id, b.id, c.id].sort());
+
+    // Retiring b drops it from the set — this is what lets clients prune a
+    // cached message they'd otherwise never hear about again.
+    deleteNotification(b.id);
+    expect(getAllActiveNotificationIds().sort()).toEqual([a.id, c.id].sort());
+  });
+
+  it("excludes expired messages", () => {
+    const past = Math.floor(Date.now() / 1000) - 60;
+    createNotification({ authorId: AUTHOR, title: "gone", body: "x", expiresAt: past });
+    const live = createNotification({ authorId: AUTHOR, title: "here", body: "y" });
+    expect(getAllActiveNotificationIds()).toEqual([live.id]);
   });
 });

--- a/api/src/db/notifications.ts
+++ b/api/src/db/notifications.ts
@@ -186,6 +186,23 @@ export function getActiveNotifications(limit = COLD_START_LIMIT): NotificationPu
   return rows.map(toPublic);
 }
 
+/**
+ * All currently-active global message ids (not deleted, not expired), uncapped.
+ * Backs the bulk mark-all/archive-all overlay write (ADR-0015) — distinct from
+ * the capped cold-start feed; "mark everything I can see read" must cover the
+ * whole active set, not just the latest few.
+ */
+export function getAllActiveNotificationIds(): number[] {
+  const db = getUsersDb();
+  const rows = db.prepare(
+    `SELECT id FROM notifications
+      WHERE scope = 'global'
+        AND deleted_at IS NULL
+        AND (expires_at IS NULL OR expires_at > unixepoch())`,
+  ).all() as { id: number }[];
+  return rows.map((r) => r.id);
+}
+
 // ── In-memory high-water id (polling short-circuit) ────────────────────────
 // The notifications table only changes when an admin publishes or retires, so
 // the latest id is cheap to cache. A `?since=<cursor>` poll with cursor >= this

--- a/api/src/db/userdata.ts
+++ b/api/src/db/userdata.ts
@@ -16,6 +16,7 @@ export interface BackupV3 {
   settings: SettingsV3 | null;
   recentShows?: RecentShowV3[];
   playbackPosition?: PlaybackPositionV3 | null;
+  notificationState?: NotificationStateV3[];
 }
 
 // Every record carries `updatedAt` (the LWW comparator). Records that
@@ -108,6 +109,16 @@ export interface PlaybackPositionV3 {
   date?: string;
   venue?: string;
   location?: string;
+  updatedAt: number;
+}
+
+// Per-user notification read/dismiss overlay (ADR-0015). seen_at/dismissed_at
+// are monotonic, so this never tombstones — a row simply gains non-null
+// timestamps. Merge is a conflict-free union (earliest non-null wins).
+export interface NotificationStateV3 {
+  notificationId: number;
+  seenAt?: number | null;
+  dismissedAt?: number | null;
   updatedAt: number;
 }
 
@@ -585,6 +596,56 @@ export function upsertSettings(userId: string, settings: SettingsV3): void {
   );
 }
 
+// ── Notification State (ADR-0015) ───────────────────────────────────
+
+function rowToNotificationState(r: Record<string, unknown>): NotificationStateV3 {
+  return {
+    notificationId: r.notification_id as number,
+    seenAt: r.seen_at as number | null,
+    dismissedAt: r.dismissed_at as number | null,
+    updatedAt: r.updated_at as number,
+  };
+}
+
+export function getNotificationState(userId: string): NotificationStateV3[] {
+  const db = getUsersDb();
+  const rows = db.prepare(
+    `SELECT notification_id, seen_at, dismissed_at, updated_at
+     FROM notification_state WHERE user_id = ?`
+  ).all(userId) as Record<string, unknown>[];
+  return rows.map(rowToNotificationState);
+}
+
+/**
+ * Union-merge one overlay row. seen_at/dismissed_at are monotonic, so we keep
+ * the earliest non-null on each column independently: a message is seen if seen
+ * on any device, dismissed if dismissed on any device. SQLite's scalar MIN()
+ * returns NULL only when every argument is NULL; COALESCE strips nulls unless
+ * both sides are null — so the pair below is null iff neither side has a value.
+ */
+export function upsertNotificationState(userId: string, s: NotificationStateV3): void {
+  const db = getUsersDb();
+  db.prepare(
+    `INSERT INTO notification_state (user_id, notification_id, seen_at, dismissed_at, updated_at)
+     VALUES (?, ?, ?, ?, unixepoch())
+     ON CONFLICT(user_id, notification_id) DO UPDATE SET
+       seen_at      = MIN(COALESCE(notification_state.seen_at,      excluded.seen_at),
+                          COALESCE(excluded.seen_at,      notification_state.seen_at)),
+       dismissed_at = MIN(COALESCE(notification_state.dismissed_at, excluded.dismissed_at),
+                          COALESCE(excluded.dismissed_at, notification_state.dismissed_at)),
+       updated_at   = unixepoch()`
+  ).run(userId, s.notificationId, s.seenAt ?? null, s.dismissedAt ?? null);
+}
+
+/** Bulk union-merge — one transaction for the mark-all/archive-all path. */
+export function upsertNotificationStates(userId: string, rows: NotificationStateV3[]): void {
+  const db = getUsersDb();
+  const tx = db.transaction((items: NotificationStateV3[]) => {
+    for (const s of items) upsertNotificationState(userId, s);
+  });
+  tx(rows);
+}
+
 // ── Full Backup V3 ──────────────────────────────────────────────────
 
 /**
@@ -606,6 +667,7 @@ export function getFullBackupV3(userId: string): BackupV3 {
     settings: getSettings(userId),
     recentShows: getRecentShowsWithTombstones(userId),
     playbackPosition: getPlaybackPosition(userId),
+    notificationState: getNotificationState(userId),
   };
 }
 
@@ -653,6 +715,11 @@ export function importFullBackupV3(userId: string, data: BackupV3): void {
     // Playback position
     if (data.playbackPosition) {
       upsertPlaybackPosition(userId, data.playbackPosition);
+    }
+
+    // Notification state (ADR-0015) — union-merge each overlay row.
+    for (const s of data.notificationState ?? []) {
+      upsertNotificationState(userId, s);
     }
   });
 

--- a/api/src/db/users.ts
+++ b/api/src/db/users.ts
@@ -178,10 +178,11 @@ function initSchema(db: Database.Database): void {
     );
 
     -- In-app messaging: the server is a dumb publisher of a flat message list.
-    -- There is deliberately NO per-user state table — seen/dismissed lives on
-    -- each client (localStorage / Room / GRDB). A global broadcast is one row,
-    -- never one-per-account. The monotonic integer id doubles as the cursor
-    -- clients track (?since=<id>). See PLANS/in-app-messaging.md.
+    -- The MESSAGE feed carries no per-user state — a global broadcast is one
+    -- row, never one-per-account, and the monotonic integer id doubles as the
+    -- cursor clients track (?since=<id>). Per-user seen/dismissed lives on each
+    -- client AND, for signed-in users, in notification_state below (ADR-0015).
+    -- See PLANS/in-app-messaging.md.
     CREATE TABLE IF NOT EXISTS notifications (
       id             INTEGER PRIMARY KEY AUTOINCREMENT,
       author_id      TEXT NOT NULL REFERENCES accounts(id),
@@ -201,6 +202,20 @@ function initSchema(db: Database.Database): void {
 
     CREATE INDEX IF NOT EXISTS idx_notifications_scope_id
       ON notifications(scope, id);
+
+    -- Per-user notification read/dismiss overlay (ADR-0015). Synced through the
+    -- authed /api/user/sync path, NEVER the public consume feed. seen_at and
+    -- dismissed_at are monotonic (null -> timestamp, once) so merge is a
+    -- conflict-free union (earliest non-null wins) — no tombstones needed.
+    -- CASCADE on notification_id reaps the overlay when an admin unsends.
+    CREATE TABLE IF NOT EXISTS notification_state (
+      user_id         TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+      notification_id INTEGER NOT NULL REFERENCES notifications(id) ON DELETE CASCADE,
+      seen_at         INTEGER,            -- unix seconds; null = unread
+      dismissed_at    INTEGER,            -- unix seconds; null = active (not archived)
+      updated_at      INTEGER NOT NULL DEFAULT (unixepoch()),
+      PRIMARY KEY (user_id, notification_id)
+    );
   `);
 
   db.exec(`

--- a/api/src/routes/notifications.ts
+++ b/api/src/routes/notifications.ts
@@ -6,6 +6,7 @@ import {
   deleteNotification,
   getNotificationsSince,
   getActiveNotifications,
+  getAllActiveNotificationIds,
   getLatestNotificationId,
   TITLE_MAX,
   BODY_MAX,
@@ -50,11 +51,18 @@ export async function notificationRoutes(app: FastifyInstance): Promise<void> {
       // Short edge cache — the feed is the same for everyone.
       reply.header("Cache-Control", "public, max-age=30");
 
+      // `activeIds` is the authoritative set of currently-active message ids
+      // (global, so this stays cacheable). Clients prune any cached message NOT
+      // in this set — the only way they learn a message was retired, since a
+      // `?since` delta can't re-mention a row below the cursor (ADR-0015).
+      const activeIds = getAllActiveNotificationIds();
+
       // Polling short-circuit: a delta poll that's already caught up skips the
-      // DB entirely (decision H). The common "nothing new" poll is an int
-      // compare, not a query. Cold start (no cursor) always hits the DB.
+      // message query (decision H). It still returns activeIds so retirement
+      // reconciliation works even when nothing new arrived. Cold start (no
+      // cursor) always lists messages.
       if (cursor != null && Number.isFinite(cursor) && cursor >= getLatestNotificationId()) {
-        return { messages: [], cursor };
+        return { messages: [], cursor, activeIds };
       }
 
       const messages =
@@ -62,7 +70,7 @@ export async function notificationRoutes(app: FastifyInstance): Promise<void> {
           ? getNotificationsSince(cursor)
           : getActiveNotifications();
       const latest = messages.reduce((max, m) => Math.max(max, m.id), cursor ?? 0);
-      return { messages, cursor: latest };
+      return { messages, cursor: latest, activeIds };
     },
   );
 

--- a/api/src/routes/user.ts
+++ b/api/src/routes/user.ts
@@ -13,12 +13,14 @@ import {
   getRecentShows, upsertRecentShow,
   getPlaybackPosition, upsertPlaybackPosition,
   getSettings, upsertSettings,
+  getNotificationState, upsertNotificationState, upsertNotificationStates,
   getFullBackupV3, importFullBackupV3,
 } from "../db/userdata.js";
 import type {
   FavoriteShowV3, FavoriteTrackV3, ReviewV3,
-  PlaybackPositionV3, SettingsV3, BackupV3,
+  PlaybackPositionV3, SettingsV3, BackupV3, NotificationStateV3,
 } from "../db/userdata.js";
+import { getNotificationById, getAllActiveNotificationIds } from "../db/notifications.js";
 
 export async function userRoutes(app: FastifyInstance): Promise<void> {
   // ── Full Sync ───────────────────────────────────────────────────
@@ -238,6 +240,93 @@ export async function userRoutes(app: FastifyInstance): Promise<void> {
     upsertSettings(request.user!.id, request.body as SettingsV3);
     return reply.code(200).send({ ok: true });
   });
+
+  // ── Notification State (ADR-0015) ───────────────────────────────
+  // Per-user read/dismiss overlay on the global message feed. Eager push:
+  // markRead/archive hit the granular route, markAllRead/archiveAll hit the
+  // bulk route. The feed itself stays public + cacheable; only this overlay is
+  // per-user, and it rides the authed path. Union-merge (earliest non-null) is
+  // handled in the db layer, so these are pure pass-throughs.
+
+  app.get("/api/user/notifications/state", {
+    schema: { tags: ["user"], summary: "List notification read/dismiss overlay" },
+    preHandler: requireAuth,
+  }, async (request) => {
+    return getNotificationState(request.user!.id);
+  });
+
+  // Bulk overlay write — backs markAllRead / archiveAll. Omitting `ids` targets
+  // every currently-active message (uncapped), so "mark all read" covers the
+  // whole active set, not just the latest few.
+  app.post<{ Body: { seenAt?: unknown; dismissedAt?: unknown; ids?: unknown } }>(
+    "/api/user/notifications/state", {
+      schema: {
+        tags: ["user"],
+        summary: "Bulk mark notifications seen/dismissed",
+        body: {
+          type: "object",
+          properties: {
+            seenAt: { type: "number", nullable: true },
+            dismissedAt: { type: "number", nullable: true },
+            ids: { type: "array", items: { type: "number" }, nullable: true },
+          },
+        },
+      },
+      preHandler: requireAuth,
+    }, async (request, reply) => {
+      const { seenAt, dismissedAt, ids } = request.body;
+      const seen = typeof seenAt === "number" && Number.isFinite(seenAt) ? seenAt : null;
+      const dismissed = typeof dismissedAt === "number" && Number.isFinite(dismissedAt) ? dismissedAt : null;
+      if (seen == null && dismissed == null) {
+        return reply.code(400).send({ error: "seenAt or dismissedAt is required" });
+      }
+      const targetIds = Array.isArray(ids)
+        ? ids.filter((n): n is number => typeof n === "number" && Number.isFinite(n))
+        : getAllActiveNotificationIds();
+      const rows: NotificationStateV3[] = targetIds.map((notificationId) => ({
+        notificationId, seenAt: seen, dismissedAt: dismissed, updatedAt: 0,
+      }));
+      upsertNotificationStates(request.user!.id, rows);
+      return reply.code(200).send({ count: rows.length });
+    });
+
+  // Granular overlay write — backs markRead (seenAt) / archive (dismissedAt).
+  app.post<{ Params: { id: string }; Body: { seenAt?: unknown; dismissedAt?: unknown } }>(
+    "/api/user/notifications/:id/state", {
+      schema: {
+        tags: ["user"],
+        summary: "Mark a notification seen/dismissed",
+        params: { type: "object", required: ["id"], properties: { id: { type: "string" } } },
+        body: {
+          type: "object",
+          properties: {
+            seenAt: { type: "number", nullable: true },
+            dismissedAt: { type: "number", nullable: true },
+          },
+        },
+      },
+      preHandler: requireAuth,
+    }, async (request, reply) => {
+      const id = Number(request.params.id);
+      if (!Number.isFinite(id)) {
+        return reply.code(400).send({ error: "invalid id" });
+      }
+      // FK requires the message row to exist (tombstoned rows still do); reject
+      // a truly-unknown id with a clean 404 rather than a constraint 500.
+      if (!getNotificationById(id)) {
+        return reply.code(404).send({ error: "not found" });
+      }
+      const { seenAt, dismissedAt } = request.body;
+      const seen = typeof seenAt === "number" && Number.isFinite(seenAt) ? seenAt : null;
+      const dismissed = typeof dismissedAt === "number" && Number.isFinite(dismissedAt) ? dismissedAt : null;
+      if (seen == null && dismissed == null) {
+        return reply.code(400).send({ error: "seenAt or dismissedAt is required" });
+      }
+      upsertNotificationState(request.user!.id, {
+        notificationId: id, seenAt: seen, dismissedAt: dismissed, updatedAt: 0,
+      });
+      return reply.code(200).send({ ok: true });
+    });
 
   // ── Account ─────────────────────────────────────────────────────
 

--- a/docs/adr/0015-cross-device-notification-read-state.md
+++ b/docs/adr/0015-cross-device-notification-read-state.md
@@ -1,0 +1,206 @@
+# ADR-0015: Cross-device notification read/dismiss state
+
+## Status
+
+Accepted
+
+## Context
+
+In-app messaging (ADR-less, designed in `PLANS/in-app-messaging.md`) ships the
+server as a **dumb global publisher**: it holds one flat list of messages and
+nothing per user. Each client keeps its own local store (Room on Android,
+GRDB/SQLite on iOS, `localStorage` on web) of the message cache, a cursor, and
+per-message `seen_at` / `dismissed_at`. Read/dismiss churn stays at the edge;
+a broadcast to every user is one server write and zero per-user writes.
+
+That decision was deliberate and remains right for *delivery*. But it has one
+accepted caveat that is now being felt: **seen/dismissed state is per-device.**
+A different browser, a second phone, incognito, or cleared storage all start
+from a fresh cold-start and re-surface the entire active backlog as unread. On
+web specifically, where state lives in `localStorage` keyed per browser, a user
+who reads a message on their laptop still sees it unread on their phone.
+
+`PLANS/in-app-messaging.md` anticipated exactly this and wrote down a 3-tier
+upgrade path (decision #1):
+
+1. **v1 (shipped):** local-only. Per-device seen/dismiss. The accepted caveat.
+2. **The real upgrade:** a server-side `(user_id, notification_id)` state join
+   table, reconciled local ↔ server on the focus-refresh fetch. Eventually
+   consistent, offline-safe, cheap.
+3. **Luxury only:** push a dismiss live over the Connect-v2 WebSocket for
+   instant cross-device clear — a thin layer *on top of* tier 2, never a
+   substitute, and rarely worth its cost for dismiss state.
+
+This ADR promotes **tier 2** from "written down, not built" to the decision of
+record. Tier 3 stays explicitly out of scope.
+
+## Decision
+
+Add a per-user notification state overlay that syncs through the **existing**
+authenticated user-data sync lifecycle. The message feed itself does not change.
+
+### Server — one new table, rides `/api/user/sync`
+
+New table in `api/src/db/users.ts` (`initSchema`):
+
+```sql
+CREATE TABLE IF NOT EXISTS notification_state (
+  user_id         TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  notification_id INTEGER NOT NULL REFERENCES notifications(id) ON DELETE CASCADE,
+  seen_at         INTEGER,            -- unix seconds; null = unread
+  dismissed_at    INTEGER,            -- unix seconds; null = active (not archived)
+  updated_at      INTEGER NOT NULL DEFAULT (unixepoch()),
+  PRIMARY KEY (user_id, notification_id)
+);
+```
+
+- `notification_id` FKs the **public** `notifications` table. `ON DELETE
+  CASCADE` means an admin unsend/retire automatically reaps the per-user
+  overlay; clients already prune the message itself on the next feed fetch.
+- This is the **first and only** per-user notification state. It is reached
+  exclusively through the authed sync path — never through the public consume
+  feed (see Consequences).
+
+State carriers in `api/src/db/userdata.ts`:
+
+- Extend `BackupV3` with an **optional** `notificationState?: NotificationStateV3[]`
+  (same additive move as `recentShows` / `playbackPosition` — **no version
+  bump**, so older clients that omit the field are unaffected). This is the
+  **pull/bulk** path.
+- `getFullBackupV3` includes the user's full state rows (no tombstones needed —
+  see merge below).
+- `importFullBackupV3` upserts each row with **union merge**, not last-write-wins.
+
+Granular **push** endpoints (the eager path — mirrors how `toggleFavorite`
+fires an immediate PUT/DELETE rather than waiting for focus):
+
+- `POST /api/user/notifications/:id/state` — body `{ seenAt?, dismissedAt? }`.
+  Union-upserts one row. Backs `markRead` and `archive`.
+- `POST /api/user/notifications/state` — body `{ seenAt?, dismissedAt?, ids? }`;
+  omitting `ids` means "every currently-active message for this user." Backs the
+  bulk `markAllRead` / `archiveAll` (favorites has no bulk equivalent, so this
+  is new surface). One round-trip instead of N.
+
+Both are `requireAuth`, never touch the public consume feed, and use the same
+union-merge upsert as the bulk import.
+
+### Merge is conflict-free union, not LWW
+
+`seen_at` and `dismissed_at` are **monotonic**: each goes `null → timestamp`
+exactly once and never back. So there is no genuine conflict to resolve — a
+message is *seen* if it was seen on **any** device, *dismissed* if dismissed on
+**any** device. Merge coalesces to the **earliest** non-null timestamp on each
+column independently:
+
+```sql
+INSERT INTO notification_state (user_id, notification_id, seen_at, dismissed_at, updated_at)
+VALUES (?, ?, ?, ?, unixepoch())
+ON CONFLICT(user_id, notification_id) DO UPDATE SET
+  seen_at      = MIN(COALESCE(notification_state.seen_at,      excluded.seen_at),
+                     COALESCE(excluded.seen_at,      notification_state.seen_at)),
+  dismissed_at = MIN(COALESCE(notification_state.dismissed_at, excluded.dismissed_at),
+                     COALESCE(excluded.dismissed_at, notification_state.dismissed_at)),
+  updated_at   = unixepoch();
+```
+
+(`MIN` over `COALESCE` keeps a non-null value once either side has one and
+prefers the earliest read/dismiss instant.) This needs **no tombstones** and no
+clock-skew arbitration — a strictly weaker requirement than the favorites
+sync's LWW + tombstone scheme.
+
+### Clients — local-first, server-mirrored (the Favorites shape)
+
+The local store stays the source of truth for the UI and the **only** store for
+logged-out users. For authed users it becomes a cache that reconciles with the
+server. Two complementary paths keep every device uniform:
+
+- **Eager push on the action.** `markRead`, `archive`, `markAllRead`, and
+  `archiveAll` each fire their granular/bulk endpoint immediately, optimistic-
+  local-first, exactly like `toggleFavorite` (UserDataProvider's
+  `updateFavoriteShow(...).then(...)`). The user's intent leaves the device the
+  moment they act — not on the next focus event. A failed push (offline) is
+  caught by the focus-refresh below.
+- **Pull/merge on focus.** On focus/foreground the client unions the server's
+  `notificationState` into its local per-message `seen_at` / `dismissed_at`
+  (same monotonic coalesce as the server) and flushes any local state the server
+  hasn't acknowledged. This is the catch-up + cross-device convergence path.
+
+**A new device must not display already-handled messages.** Two rules make the
+first paint correct, not merely self-correcting:
+
+1. **State-before-surface on cold start.** For a signed-in client, the first
+   feed fetch and the first state pull are awaited **together** before the badge
+   count, the inbox list, and any toast are computed. The unread/active set is
+   derived from `feed ⋈ serverState`, so a message already read or archived on
+   another device renders read/archived on its **first** appearance — no
+   unread-then-clear flash.
+2. **No cold-start toasts** (existing decision C, retained): the
+   cold-start backlog never toasts; only genuine deltas after the cursor do. So
+   a new device is quiet on launch even before convergence.
+
+Messages the user has *genuinely never touched on any device* still legitimately
+show as unread — that is correct, not "old spam." "Old messages" the user has
+already dealt with are what gets suppressed.
+
+Per platform:
+
+- **Web** — `ui/src/lib/notifications.ts` gains `toSyncState()` /
+  `mergeSyncState()`. `NotificationsProvider`'s `markRead` / `archive` /
+  `markAllRead` / `archiveAll` add the eager POST (optimistic-local-first, like
+  `toggleFavorite`); the focus pull/merge joins the existing user-data refetch.
+  Cold-start `refresh("cold_start")` awaits the state pull before computing
+  `unreadCount` / `activeMessages`. `localStorage` schema unchanged.
+- **iOS** — `NotificationStore` mutations call the push via `UserSyncAPIClient`;
+  `UserSyncApplyService` does the union merge. The inbox's first load gates on
+  the state pull.
+- **Android** — `core/notifications` store mutations push via
+  `core/api/usersync`; merge in the `core/usersync` apply step; first inbox load
+  gates on the state pull.
+
+## Consequences
+
+**Gained**
+
+- Read/dismiss state follows the user across devices and browsers. The web
+  "I keep seeing it on every device" re-spam goes away once signed in.
+- Reuses the entire existing sync lifecycle, auth, and offline behavior — no new
+  polling, no new transport, no protocol version bump.
+- Merge is simpler than every other synced collection (no tombstones, no LWW).
+
+**Accepted**
+
+- The acting device pushes **immediately**; *other* devices converge on their
+  next focus-refresh (eventually consistent), consistent with all other user
+  data. A brand-new device, by the state-before-surface rule, is correct on
+  first paint — it never shows the flash. (Tier 3 / WebSocket push for *instant*
+  fan-out to already-open devices is still explicitly *not* adopted; "clears next
+  foreground" is fine for dismiss state.)
+- Logged-out users keep per-device state — there is no anonymous identity to
+  sync against. This is unchanged from today.
+- We introduce the first per-user notification rows. Write volume is bounded by
+  *(users who read messages) × (messages they touch)* — the central store the
+  publish path deliberately avoids. It is acceptable here because it rides the
+  authed, already-rate-limited sync path and never the cacheable public feed.
+
+**Invariant preserved**
+
+- `GET /api/notifications` stays global, identical-for-everyone, and
+  edge-cacheable. Per-user state is reachable **only** through authed
+  `/api/user/sync`. Mixing it into the consume feed would break the cache and is
+  prohibited by this ADR.
+
+## Alternatives considered
+
+- **Do nothing (stay tier 1).** Cheapest, but the per-device re-spam is the
+  exact pain being reported, and it worsens as a user adds devices.
+- **Dedicated `/api/user/notifications/state` endpoint** instead of folding into
+  `BackupV3`. Cleaner in isolation but adds a second per-user sync round-trip and
+  a second coordinator on every platform. Folding into the existing V3 sync is
+  one trip and reuses code already wired on all three clients.
+- **Last-write-wins with `updated_at`** (mirroring favorites). Works, but is
+  strictly more machinery than the data needs: monotonic null→timestamp columns
+  are conflict-free under union, so LWW + tombstones would be dead weight.
+- **Tier 3 WebSocket push for instant clear.** A WS reaches only devices online
+  *now*, so it can never inform the device that was offline at dismiss time —
+  that always needs tier 2's durable state underneath. For dismiss state the
+  instant-clear payoff doesn't earn the cost; deferred indefinitely.

--- a/iosApp/deadly/App/AppContainer.swift
+++ b/iosApp/deadly/App/AppContainer.swift
@@ -359,12 +359,17 @@ final class AppContainer {
             }
 
             // In-app messaging — public/global feed; store + fetch service.
-            // No auth, so it isn't wired into the sign-in flow; deadlyApp pulls
-            // it on cold start + foreground.
+            // The feed is public; per-user read/dismiss state (ADR-0015) rides
+            // the authed sync client. deadlyApp pulls on cold start + foreground.
             let notifStore = MainActor.assumeIsolated { NotificationStore() }
             notificationStore = notifStore
             notificationService = MainActor.assumeIsolated {
-                NotificationService(appPreferences: prefs, store: notifStore, analytics: analytics)
+                let svc = NotificationService(
+                    appPreferences: prefs, store: notifStore, analytics: analytics,
+                    authService: auth, userSync: userSync)
+                // Eager-push local read/dismiss mutations to the server.
+                notifStore.onStateChange = { [weak svc] change in svc?.pushStateChange(change) }
+                return svc
             }
 
             let coldStartMs = Int((CFAbsoluteTimeGetCurrent() - initStart) * 1000)

--- a/iosApp/deadly/Core/Network/UserSyncAPIClient.swift
+++ b/iosApp/deadly/Core/Network/UserSyncAPIClient.swift
@@ -108,6 +108,15 @@ struct SyncPlaybackPositionV3: Codable {
     let updatedAt: Int64
 }
 
+/// Per-user notification read/dismiss overlay (ADR-0015). Wire timestamps are
+/// unix SECONDS (the user-data API convention); the local NotificationStore
+/// keeps milliseconds, so callers convert at the boundary.
+struct NotificationStateRow: Codable {
+    let notificationId: Int64
+    let seenAt: Int64?
+    let dismissedAt: Int64?
+}
+
 // MARK: - Errors
 
 enum UserSyncError: LocalizedError {
@@ -219,6 +228,40 @@ struct UserSyncAPIClient {
             body: nil
         )
         if let http = response as? HTTPURLResponse, http.statusCode == 404 { return }
+        try ensureOK(data: data, response: response)
+    }
+
+    // MARK: - Notification state (ADR-0015)
+
+    func pullNotificationState() async throws -> [NotificationStateRow] {
+        let (data, response) = try await get(path: "/api/user/notifications/state")
+        try ensureOK(data: data, response: response)
+        return try JSONDecoder().decode([NotificationStateRow].self, from: data)
+    }
+
+    /// Granular push — backs markRead (seenAt) / archive (dismissedAt).
+    func pushNotificationState(id: Int64, seenAt: Int64?, dismissedAt: Int64?) async throws {
+        struct Body: Codable { let seenAt: Int64?; let dismissedAt: Int64? }
+        let body = try JSONEncoder().encode(Body(seenAt: seenAt, dismissedAt: dismissedAt))
+        let (data, response) = try await request(
+            method: "POST",
+            path: "/api/user/notifications/\(id)/state",
+            body: body
+        )
+        try ensureOK(data: data, response: response)
+    }
+
+    /// Bulk push — backs markAllRead / archiveAll. `ids: nil` targets every
+    /// currently-active message server-side. Nil optionals are omitted by the
+    /// JSON encoder, so the server sees only the field(s) being set.
+    func pushNotificationStateBulk(seenAt: Int64?, dismissedAt: Int64?, ids: [Int64]?) async throws {
+        struct Body: Codable { let seenAt: Int64?; let dismissedAt: Int64?; let ids: [Int64]? }
+        let body = try JSONEncoder().encode(Body(seenAt: seenAt, dismissedAt: dismissedAt, ids: ids))
+        let (data, response) = try await request(
+            method: "POST",
+            path: "/api/user/notifications/state",
+            body: body
+        )
         try ensureOK(data: data, response: response)
     }
 

--- a/iosApp/deadly/Core/Notifications/NotificationModels.swift
+++ b/iosApp/deadly/Core/Notifications/NotificationModels.swift
@@ -37,6 +37,10 @@ struct NotificationWire: Codable {
 struct NotificationFetchResult: Codable {
     let messages: [NotificationWire]
     let cursor: Int64
+    /// Authoritative set of currently-active ids — clients prune any cached
+    /// message not in it (the only signal of a server-side retire). Optional for
+    /// back-compat with older servers (absent = don't prune). ADR-0015.
+    let activeIds: [Int64]?
 }
 
 /// A cached message plus local-only state. Never sent back to the server.

--- a/iosApp/deadly/Core/Notifications/NotificationService.swift
+++ b/iosApp/deadly/Core/Notifications/NotificationService.swift
@@ -9,15 +9,27 @@ final class NotificationService {
     private let appPreferences: AppPreferences
     let store: NotificationStore
     private let analytics: AnalyticsService
+    private let authService: AuthService
+    private let userSync: UserSyncAPIClient
 
-    init(appPreferences: AppPreferences, store: NotificationStore, analytics: AnalyticsService) {
+    init(
+        appPreferences: AppPreferences,
+        store: NotificationStore,
+        analytics: AnalyticsService,
+        authService: AuthService,
+        userSync: UserSyncAPIClient
+    ) {
         self.appPreferences = appPreferences
         self.store = store
         self.analytics = analytics
+        self.authService = authService
+        self.userSync = userSync
     }
 
     /// Pull a `?since=<cursor>` delta and merge it. Best-effort: failures are
-    /// swallowed (logged), matching the focus-refresh sync model.
+    /// swallowed (logged), matching the focus-refresh sync model. For a
+    /// signed-in user, also pulls the per-user read/dismiss overlay and merges
+    /// it atomically with the feed (ADR-0015 state-before-surface).
     func refresh(reason: String) async {
         do {
             let client = APIClient(appPreferences: appPreferences, authToken: nil)
@@ -29,12 +41,52 @@ final class NotificationService {
                 return
             }
             let result = try JSONDecoder().decode(NotificationFetchResult.self, from: data)
-            for message in store.merge(result) {
+
+            let signedIn = authService.token != nil
+            let serverState: [NotificationStateRow] = signedIn
+                ? ((try? await userSync.pullNotificationState()) ?? [])
+                : []
+
+            for message in store.merge(result, serverState: serverState) {
                 analytics.trackNotificationReceived(message, reason: reason)
             }
+
+            // Offline catch-up: flush any local state the server is missing
+            // (an eager push that failed while offline). No-op once converged.
+            if signedIn {
+                for row in store.unsyncedState(against: serverState) {
+                    try? await userSync.pushNotificationState(
+                        id: row.notificationId, seenAt: row.seenAt, dismissedAt: row.dismissedAt)
+                }
+            }
+
             print("[Notifications] refresh[\(reason)] ok: +\(result.messages.count) (cursor=\(store.cursor))")
         } catch {
             print("[Notifications] refresh[\(reason)] failed: \(error)")
+        }
+    }
+
+    /// Eager push of a local read/dismiss mutation (ADR-0015). Fire-and-forget;
+    /// failures are caught by the focus-refresh catch-up flush. No-op when
+    /// signed out (state stays local, like the rest of user data).
+    func pushStateChange(_ change: NotificationStateChange) {
+        guard authService.token != nil else { return }
+        let nowSec = Int64(Date().timeIntervalSince1970)
+        Task { @MainActor in
+            do {
+                switch change {
+                case .seen(let id):
+                    try await userSync.pushNotificationState(id: id, seenAt: nowSec, dismissedAt: nil)
+                case .dismissed(let id):
+                    try await userSync.pushNotificationState(id: id, seenAt: nil, dismissedAt: nowSec)
+                case .seenAll:
+                    try await userSync.pushNotificationStateBulk(seenAt: nowSec, dismissedAt: nil, ids: nil)
+                case .dismissedAll:
+                    try await userSync.pushNotificationStateBulk(seenAt: nil, dismissedAt: nowSec, ids: nil)
+                }
+            } catch {
+                print("[Notifications] push state failed: \(error)")
+            }
         }
     }
 }

--- a/iosApp/deadly/Core/Notifications/NotificationStore.swift
+++ b/iosApp/deadly/Core/Notifications/NotificationStore.swift
@@ -6,6 +6,16 @@ import Foundation
 ///
 /// All seen/dismissed state lives here and is never sent to the server. Faithful
 /// port of the merge/prune/mark logic in `ui/src/lib/notifications.ts`.
+/// A local read/dismiss mutation worth pushing to the server (ADR-0015). The
+/// store stays free of networking; AppContainer wires `onStateChange` to the
+/// NotificationService push.
+enum NotificationStateChange {
+    case seen(id: Int64)       // markRead
+    case dismissed(id: Int64)  // archive
+    case seenAll               // markAllRead (bulk, all active)
+    case dismissedAll          // archiveAll (bulk, all active)
+}
+
 @MainActor
 @Observable
 final class NotificationStore {
@@ -26,6 +36,11 @@ final class NotificationStore {
     /// Set when a non-cold delta brings new eligible unread messages, so the UI
     /// can show a transient toast. Observed via `.onChange` (decision C).
     private(set) var lastArrival: NewArrival?
+
+    /// Fired after a local read/dismiss mutation so the owner can eagerly push
+    /// it to the server (ADR-0015). Nil until wired; the store itself never
+    /// touches the network.
+    var onStateChange: ((NotificationStateChange) -> Void)?
 
     /// This app's version (CFBundleShortVersionString), for targeting (decision E).
     let appVersion: String = (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "0"
@@ -64,7 +79,10 @@ final class NotificationStore {
     /// reason, including cold start) so the caller can emit per-message
     /// `notification_received` analytics. Empty when nothing new arrived.
     @discardableResult
-    func merge(_ result: NotificationFetchResult) -> [CachedNotification] {
+    func merge(
+        _ result: NotificationFetchResult,
+        serverState: [NotificationStateRow] = []
+    ) -> [CachedNotification] {
         let coldStart = cursor == 0
         let now = NotificationClock.now()
         let knownIds = Set(notifications.map { $0.id })
@@ -89,6 +107,17 @@ final class NotificationStore {
             )
         }
 
+        // ADR-0015: overlay the server's per-user read/dismiss state (unix
+        // seconds → ms) onto the cache BEFORE computing unread/toast, so a
+        // message handled on another device never flashes unread. Union =
+        // earliest non-null per column, matching the server's MIN(COALESCE).
+        for row in serverState {
+            guard var m = byId[row.notificationId] else { continue }
+            m.seenAt = Self.unionEarliest(m.seenAt, row.seenAt.map { $0 * 1000 })
+            m.dismissedAt = Self.unionEarliest(m.dismissedAt, row.dismissedAt.map { $0 * 1000 })
+            byId[row.notificationId] = m
+        }
+
         // Prune: expired messages and long-dismissed ones.
         let pruned = byId.values.filter { m in
             let expired = m.isExpired(now: now)
@@ -108,12 +137,43 @@ final class NotificationStore {
             .filter { $0.isEligible(appVersion: appVersion) && $0.dismissedAt == nil }
             .sorted { $0.createdAt > $1.createdAt }
 
-        // Toast signal: only on a delta (never the cold-start backlog).
-        if !coldStart, let newest = fresh.first {
-            lastArrival = NewArrival(title: newest.title, count: fresh.count, key: newest.id)
+        // Toast signal: only on a delta (never the cold-start backlog) and never
+        // a message already seen on another device (the overlay merge above).
+        let toastable = fresh.filter { $0.seenAt == nil }
+        if !coldStart, let newest = toastable.first {
+            lastArrival = NewArrival(title: newest.title, count: toastable.count, key: newest.id)
         }
 
         return fresh
+    }
+
+    /// Earliest non-null of two timestamps — the union comparator (ADR-0015).
+    private static func unionEarliest(_ a: Int64?, _ b: Int64?) -> Int64? {
+        guard let a else { return b }
+        guard let b else { return a }
+        return Swift.min(a, b)
+    }
+
+    /// Local state the server is missing (or has later than ours) — the offline
+    /// catch-up flush for an eager push that failed while offline. Timestamps
+    /// returned in unix seconds; empty in the common already-synced case.
+    func unsyncedState(against server: [NotificationStateRow]) -> [NotificationStateRow] {
+        let byServer = Dictionary(uniqueKeysWithValues: server.map { ($0.notificationId, $0) })
+        var out: [NotificationStateRow] = []
+        for m in notifications {
+            guard m.seenAt != nil || m.dismissedAt != nil else { continue }
+            let s = byServer[m.id]
+            let needSeen = m.seenAt != nil && (s?.seenAt == nil || s!.seenAt! * 1000 > m.seenAt!)
+            let needDismissed = m.dismissedAt != nil && (s?.dismissedAt == nil || s!.dismissedAt! * 1000 > m.dismissedAt!)
+            if needSeen || needDismissed {
+                out.append(NotificationStateRow(
+                    notificationId: m.id,
+                    seenAt: needSeen ? m.seenAt! / 1000 : nil,
+                    dismissedAt: needDismissed ? m.dismissedAt! / 1000 : nil
+                ))
+            }
+        }
+        return out
     }
 
     /// Record an inbox impression for `id`; returns true the first time per
@@ -132,6 +192,7 @@ final class NotificationStore {
             return m
         }
         persist()
+        onStateChange?(.seen(id: id))
     }
 
     /// Clear the unread badge: stamp every unseen message as seen.
@@ -144,6 +205,7 @@ final class NotificationStore {
             return m
         }
         persist()
+        onStateChange?(.seenAll)
     }
 
     /// Archive (remove from the active queue; stays in the archive).
@@ -156,6 +218,7 @@ final class NotificationStore {
             return m
         }
         persist()
+        onStateChange?(.dismissed(id: id))
     }
 
     /// Archive every active eligible message at once.
@@ -170,6 +233,9 @@ final class NotificationStore {
             }
             return m
         }
-        if changed { persist() }
+        if changed {
+            persist()
+            onStateChange?(.dismissedAll)
+        }
     }
 }

--- a/iosApp/deadly/Core/Notifications/NotificationStore.swift
+++ b/iosApp/deadly/Core/Notifications/NotificationStore.swift
@@ -118,11 +118,16 @@ final class NotificationStore {
             byId[row.notificationId] = m
         }
 
-        // Prune: expired messages and long-dismissed ones.
+        // Prune: server-retired (not in the authoritative activeIds), expired,
+        // and long-dismissed messages. activeIds is the only signal that a
+        // cached message was retired server-side (ADR-0015); nil = older server,
+        // so don't prune on that basis.
+        let activeIds = result.activeIds.map { Set($0) }
         let pruned = byId.values.filter { m in
+            let retired = activeIds.map { !$0.contains(m.id) } ?? false
             let expired = m.isExpired(now: now)
             let staleDismissed = m.dismissedAt.map { now - $0 > Self.dismissedTTLms } ?? false
-            return !(expired || staleDismissed)
+            return !(retired || expired || staleDismissed)
         }
 
         cursor = Swift.max(cursor, result.cursor)

--- a/iosApp/deadly/Feature/Notifications/NotificationsInboxScreen.swift
+++ b/iosApp/deadly/Feature/Notifications/NotificationsInboxScreen.swift
@@ -95,6 +95,11 @@ struct NotificationsInboxScreen: View {
         .refreshable {
             await container.notificationService.refresh(reason: "refresh")
         }
+        // Sync whenever the inbox opens, so it reflects cross-device read/dismiss
+        // state + retirements immediately (not just cold start / foreground).
+        .task {
+            await container.notificationService.refresh(reason: "inbox_open")
+        }
         .navigationTitle(showArchive ? "Archived" : "Notifications")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -51,8 +51,8 @@ export default function RootLayout({
       <body className="min-h-screen bg-deadly-bg text-white antialiased">
         <ServiceWorkerRegistrar />
         <ToastProvider>
-        <NotificationsProvider>
         <AuthProvider>
+        <NotificationsProvider>
         <UserDataProvider>
         <ConnectProvider>
         <PlayerProvider>
@@ -61,8 +61,8 @@ export default function RootLayout({
         </PlayerProvider>
         </ConnectProvider>
         </UserDataProvider>
-        </AuthProvider>
         </NotificationsProvider>
+        </AuthProvider>
         </ToastProvider>
       </body>
     </html>

--- a/ui/src/app/notifications/page.tsx
+++ b/ui/src/app/notifications/page.tsx
@@ -73,9 +73,15 @@ function preview(body: string): string {
 }
 
 export default function NotificationsPage() {
-  const { active, archived, markRead, markAllRead, archive, archiveAll } = useNotifications();
+  const { active, archived, refresh, markRead, markAllRead, archive, archiveAll } = useNotifications();
   const [showArchive, setShowArchive] = useState(false);
   const [expanded, setExpanded] = useState<number | null>(null);
+
+  // Sync whenever the inbox opens, so it reflects cross-device read/dismiss
+  // state + retirements immediately (not just cold start / window focus).
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
 
   const list = showArchive ? archived : active;
   const hasUnread = active.some((m) => m.seen_at == null);

--- a/ui/src/components/notifications/NotificationsProvider.tsx
+++ b/ui/src/components/notifications/NotificationsProvider.tsx
@@ -10,11 +10,14 @@ import {
 } from "react";
 import { useRouter } from "next/navigation";
 import { useToast } from "@/components/ui/ToastProvider";
+import { useAuth } from "@/contexts/AuthContext";
 import {
   loadStore,
   saveStore,
   fetchNotifications,
   mergeStore,
+  mergeSyncState,
+  unsyncedState,
   activeMessages,
   dismissedMessages,
   unreadCount,
@@ -25,6 +28,11 @@ import {
   isEligible,
   type CachedNotification,
 } from "@/lib/notifications";
+import {
+  fetchNotificationState,
+  pushNotificationState,
+  pushNotificationStateBulk,
+} from "@/lib/userDataApi";
 import {
   trackNotificationReceived,
   trackNotificationToastShown,
@@ -65,6 +73,8 @@ export default function NotificationsProvider({
   const [store, setStore] = useState(loadStore);
   const router = useRouter();
   const { showToast } = useToast();
+  const { user } = useAuth();
+  const userId = user?.id;
   const lastFetch = useRef(0);
   // Mirror the latest store for the async fetch (avoids stale closures).
   const storeRef = useRef(store);
@@ -80,10 +90,29 @@ export default function NotificationsProvider({
       lastFetch.current = Date.now();
       const prev = storeRef.current;
       try {
-        const res = await fetchNotifications(prev.cursor);
+        // For a signed-in user, pull the feed and the read/dismiss overlay
+        // together so the unread set is correct on first paint — a message
+        // already handled on another device never flashes unread (ADR-0015,
+        // "state-before-surface").
+        const [res, serverState] = await Promise.all([
+          fetchNotifications(prev.cursor),
+          userId ? fetchNotificationState().catch(() => null) : Promise.resolve(null),
+        ]);
         const existing = new Set(Object.keys(prev.messages).map(Number));
-        const next = mergeStore(prev, res);
+        let next = mergeStore(prev, res);
+        if (serverState) next = mergeSyncState(next, serverState);
         apply(next);
+
+        // Offline catch-up: flush any local state the server hasn't recorded
+        // (an eager push that failed while offline). No-op once converged.
+        if (userId && serverState) {
+          for (const row of unsyncedState(next, serverState)) {
+            pushNotificationState(row.notificationId, {
+              seenAt: row.seenAt ?? undefined,
+              dismissedAt: row.dismissedAt ?? undefined,
+            }).catch(() => {});
+          }
+        }
 
         // Genuinely new, eligible messages from this fetch (any reason, incl.
         // cold start) — the basis for `notification_received` analytics.
@@ -95,11 +124,14 @@ export default function NotificationsProvider({
         for (const m of fresh) trackNotificationReceived(m, reason);
 
         // Toast only for new arrivals on a delta — never the cold-start backlog
-        // (decision C). Surfaces the newest one; tap opens the inbox.
-        if (prev.cursor > 0 && fresh.length > 0) {
-          const newest = fresh[0];
-          const label = fresh.length === 1 ? newest.title : `${fresh.length} new messages`;
-          trackNotificationToastShown(newest.id, fresh.length);
+        // (decision C) and never a message already seen/dismissed elsewhere
+        // (the overlay merge above). Surfaces the newest one; tap opens inbox.
+        const toastable = fresh.filter((m) => m.seen_at == null && m.dismissed_at == null);
+        if (prev.cursor > 0 && toastable.length > 0) {
+          const newest = toastable[0];
+          const label =
+            toastable.length === 1 ? newest.title : `${toastable.length} new messages`;
+          trackNotificationToastShown(newest.id, toastable.length);
           showToast(`New: ${label}`, () => {
             trackNotificationToastTap(newest.id);
             router.push("/notifications");
@@ -109,7 +141,7 @@ export default function NotificationsProvider({
         /* offline — keep the cache */
       }
     },
-    [apply, router, showToast],
+    [apply, router, showToast, userId],
   );
 
   // Initial load + poll on focus/visibility only (decision H — no idle timer).
@@ -126,20 +158,31 @@ export default function NotificationsProvider({
     };
   }, [refresh]);
 
-  const markRead = useCallback((id: number) => apply(markReadStore(storeRef.current, id)), [apply]);
+  // Each mutation is optimistic-local-first, then eagerly pushed to the server
+  // for signed-in users (mirrors toggleFavorite) so other devices converge on
+  // their next focus-refresh. Failures are caught by the focus catch-up flush.
+  const nowSec = () => Math.floor(Date.now() / 1000);
+
+  const markRead = useCallback((id: number) => {
+    apply(markReadStore(storeRef.current, id));
+    if (userId) pushNotificationState(id, { seenAt: nowSec() }).catch(() => {});
+  }, [apply, userId]);
   const markAllRead = useCallback(() => {
     trackNotificationMarkAllRead(unreadCount(storeRef.current));
     apply(markAllSeen(storeRef.current));
-  }, [apply]);
+    if (userId) pushNotificationStateBulk({ seenAt: nowSec() }).catch(() => {});
+  }, [apply, userId]);
   const archive = useCallback((id: number) => {
     const m = storeRef.current.messages[id];
     if (m) trackNotificationArchive(m);
     apply(dismissStore(storeRef.current, id));
-  }, [apply]);
+    if (userId) pushNotificationState(id, { dismissedAt: nowSec() }).catch(() => {});
+  }, [apply, userId]);
   const archiveAll = useCallback(() => {
     trackNotificationArchiveAll(activeMessages(storeRef.current).length);
     apply(archiveAllStore(storeRef.current));
-  }, [apply]);
+    if (userId) pushNotificationStateBulk({ dismissedAt: nowSec() }).catch(() => {});
+  }, [apply, userId]);
 
   const value: NotificationsContextValue = {
     unread: unreadCount(store),

--- a/ui/src/lib/notifications.ts
+++ b/ui/src/lib/notifications.ts
@@ -78,7 +78,7 @@ export function saveStore(store: NotifStore): void {
 
 export async function fetchNotifications(
   cursor: number,
-): Promise<{ messages: NotificationWire[]; cursor: number }> {
+): Promise<{ messages: NotificationWire[]; cursor: number; activeIds?: number[] }> {
   const qs = cursor > 0 ? `?since=${cursor}` : "";
   const res = await fetch(`/api/notifications${qs}`, { credentials: "include" });
   if (!res.ok) throw new Error(`notifications fetch failed (${res.status})`);
@@ -94,7 +94,7 @@ export async function fetchNotifications(
  */
 export function mergeStore(
   store: NotifStore,
-  fetched: { messages: NotificationWire[]; cursor: number },
+  fetched: { messages: NotificationWire[]; cursor: number; activeIds?: number[] },
 ): NotifStore {
   const now = Date.now();
   const messages = { ...store.messages };
@@ -109,12 +109,19 @@ export function mergeStore(
     };
   }
 
-  // Prune: expired messages and long-dismissed ones.
+  // `activeIds` (when present) is the server's authoritative active set — drop
+  // any cached message no longer in it, the only signal that a message was
+  // retired server-side after we cached it (ADR-0015).
+  const activeIds = fetched.activeIds != null ? new Set(fetched.activeIds) : null;
+
+  // Prune: server-retired, expired, and long-dismissed messages.
   for (const idStr of Object.keys(messages)) {
-    const m = messages[Number(idStr)];
+    const id = Number(idStr);
+    const m = messages[id];
+    const retired = activeIds != null && !activeIds.has(id);
     const expired = m.expires_at != null && m.expires_at * 1000 < now;
     const staleDismissed = m.dismissed_at != null && now - m.dismissed_at > DISMISSED_TTL_MS;
-    if (expired || staleDismissed) delete messages[Number(idStr)];
+    if (retired || expired || staleDismissed) delete messages[id];
   }
 
   return { cursor: Math.max(store.cursor, fetched.cursor), messages };

--- a/ui/src/lib/notifications.ts
+++ b/ui/src/lib/notifications.ts
@@ -186,3 +186,72 @@ export function archiveAll(store: NotifStore): NotifStore {
   }
   return { ...store, messages };
 }
+
+// ── Cross-device sync overlay (ADR-0015) ────────────────────────────
+// The server stores a per-user `(notification_id, seen_at, dismissed_at)`
+// overlay in unix SECONDS; this local store keeps milliseconds. Merge is a
+// conflict-free union — earliest non-null wins per column — matching the
+// server's MIN(COALESCE(...)) upsert.
+
+/** Server overlay row (unix seconds), as returned by GET /notifications/state. */
+export interface NotificationStateRow {
+  notificationId: number;
+  seenAt?: number | null;
+  dismissedAt?: number | null;
+}
+
+const toSec = (ms: number): number => Math.floor(ms / 1000);
+const toMs = (s: number): number => s * 1000;
+
+/** Earliest non-null of two timestamps (the union comparator). */
+function unionEarliest(a: number | null, b: number | null): number | null {
+  if (a == null) return b;
+  if (b == null) return a;
+  return Math.min(a, b);
+}
+
+/**
+ * Union-merge server overlay rows into the local store. Only overlays onto
+ * messages already cached locally — a row for a not-yet-fetched message is
+ * ignored and re-applied on a later merge once the feed delivers it.
+ */
+export function mergeSyncState(store: NotifStore, rows: NotificationStateRow[]): NotifStore {
+  const messages = { ...store.messages };
+  let changed = false;
+  for (const r of rows) {
+    const m = messages[r.notificationId];
+    if (!m) continue;
+    const seen = unionEarliest(m.seen_at, r.seenAt != null ? toMs(r.seenAt) : null);
+    const dismissed = unionEarliest(m.dismissed_at, r.dismissedAt != null ? toMs(r.dismissedAt) : null);
+    if (seen !== m.seen_at || dismissed !== m.dismissed_at) {
+      messages[r.notificationId] = { ...m, seen_at: seen, dismissed_at: dismissed };
+      changed = true;
+    }
+  }
+  return changed ? { ...store, messages } : store;
+}
+
+/**
+ * Local state the server is missing (or has later than ours) — the offline
+ * catch-up flush for an eager push that failed while offline. Returns push
+ * payloads in unix seconds; empty in the common already-synced case.
+ */
+export function unsyncedState(store: NotifStore, rows: NotificationStateRow[]): NotificationStateRow[] {
+  const server = new Map(rows.map((r) => [r.notificationId, r]));
+  const out: NotificationStateRow[] = [];
+  for (const m of Object.values(store.messages)) {
+    if (m.seen_at == null && m.dismissed_at == null) continue;
+    const s = server.get(m.id);
+    const needSeen = m.seen_at != null && (s?.seenAt == null || toMs(s.seenAt) > m.seen_at);
+    const needDismissed =
+      m.dismissed_at != null && (s?.dismissedAt == null || toMs(s.dismissedAt) > m.dismissed_at);
+    if (needSeen || needDismissed) {
+      out.push({
+        notificationId: m.id,
+        ...(needSeen ? { seenAt: toSec(m.seen_at!) } : {}),
+        ...(needDismissed ? { dismissedAt: toSec(m.dismissed_at!) } : {}),
+      });
+    }
+  }
+  return out;
+}

--- a/ui/src/lib/userDataApi.ts
+++ b/ui/src/lib/userDataApi.ts
@@ -158,6 +158,43 @@ export function addRecentShow(showId: string): Promise<void> {
   return apiFetch(`/recent/${showId}`, { method: "PUT" });
 }
 
+// ── Notification read/dismiss overlay (ADR-0015) ──────────────────────
+// Per-user seen/dismissed state synced cross-device. Timestamps on the wire
+// are unix SECONDS (the rest of the user-data API's convention); the local
+// notifications store keeps milliseconds, so callers convert at this boundary.
+
+export interface NotificationStateRow {
+  notificationId: number;
+  seenAt?: number | null;
+  dismissedAt?: number | null;
+}
+
+export function fetchNotificationState(): Promise<NotificationStateRow[]> {
+  return apiFetch<NotificationStateRow[]>("/notifications/state");
+}
+
+// Granular push — backs markRead (seenAt) / archive (dismissedAt).
+export function pushNotificationState(
+  id: number,
+  body: { seenAt?: number; dismissedAt?: number },
+): Promise<void> {
+  return apiFetch(`/notifications/${id}/state`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+// Bulk push — backs markAllRead / archiveAll. Omitting `ids` targets every
+// currently-active message server-side.
+export function pushNotificationStateBulk(
+  body: { seenAt?: number; dismissedAt?: number; ids?: number[] },
+): Promise<void> {
+  return apiFetch("/notifications/state", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
 // Returns the user's recent shows, newest first. Bare records (showId +
 // timestamps + play count) — display metadata (venue/city) is derived
 // client-side for now; swap to an enriched endpoint when the API gains a


### PR DESCRIPTION
## What

Per-user notification seen/dismissed state has lived only in each client's local store (localStorage / GRDB / Room), so a new device or browser re-surfaces the whole active backlog as unread. This adds a server overlay that lets read/dismiss state follow a signed-in user across devices — promoting tier 2 of the upgrade path in `PLANS/in-app-messaging.md` to the decision of record (**ADR-0015**).

The public message feed stays a dumb, edge-cacheable publisher; only the per-user overlay is new, and it rides the authed `/api/user` path.

## Design (ADR-0015)

- **Server overlay** `notification_state(user_id, notification_id, seen_at, dismissed_at, updated_at)`, FK `CASCADE` so an admin unsend reaps the overlay.
- **Union merge, not LWW** — `seen_at`/`dismissed_at` are monotonic (null→ts once), so keep the *earliest non-null* per column. Conflict-free, no tombstones.
- **Eager push on the action** (mirrors `toggleFavorite`): `markRead`/`archive` → granular endpoint; `markAllRead`/`archiveAll` → bulk (no `ids` = all active).
- **New device must not flash old messages:** the overlay is pulled alongside the feed and merged *before* the badge/inbox/toast are computed (state-before-surface); toasts are suppressed for anything already seen elsewhere.
- **Offline catch-up:** focus-refresh flushes any local state the server is missing.
- Logged-out users keep purely-local state (unchanged).

## Slices

| Layer | Verified |
|-------|----------|
| **API** — table, `BackupV3.notificationState`, GET/granular/bulk endpoints, `getAllActiveNotificationIds()` | typecheck + 164 tests (8 new in `notification-state.test.ts`) |
| **Web** — eager push, state-before-surface pull, toast suppression; `NotificationsProvider` moved inside `AuthProvider` | `npm run build` |
| **iOS** — `NotificationStore.onStateChange` hook, `merge(serverState:)` union, `NotificationService` push/pull | `make ios-remote-build` |
| **Android** — same shape via `NotificationCoordinator` + authed `NotificationApiService` (adds `core:api:auth` dep) | `:app:assembleDebug` |

Mobile pattern: the store stays network-free and emits `onStateChange`; the coordinator/service owns the push + pull-merge. Timestamps are local-ms / wire-unix-seconds, converted at the boundary.

## Testing

Builds pass on all four platforms. **On-device cross-device verification pending** (sign in on two devices, read on one, confirm it clears on the other's next focus + a fresh device shows no unread flash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)