### PR TITLE
fix(mobile): sync recording preferences to the server

### DIFF
--- a/androidApp/app/src/main/java/com/grateful/deadly/DeadlyApplication.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/DeadlyApplication.kt
@@ -49,10 +49,14 @@ class DeadlyApplication : Application(), DeadlyMediaDownloadServiceHost {
         userSyncCoordinator.start()
         notificationCoordinator.start()
 
-        // One-time: push all pre-existing local data (favorites + top recents)
-        // to the server so devices that predate granular push aren't stranded.
-        if (!appPreferences.getLocalBackfilledV1()) {
+        // One-time: push all pre-existing local data (favorites + top recents +
+        // recording prefs) to the server so devices that predate granular push
+        // aren't stranded. V2 re-runs the backfill for users who already cleared
+        // V1 before recording-pref sync existed (idempotent: outbox dedupes and
+        // the server is last-write-wins).
+        if (!appPreferences.getLocalBackfilledV2()) {
             appPreferences.setLocalBackfilledV1(true)
+            appPreferences.setLocalBackfilledV2(true)
             appScope.launch {
                 favoritesPushService.enqueueAllLocalAndFlush()
             }

--- a/androidApp/core/api/usersync/src/main/java/com/grateful/deadly/core/api/usersync/FavoritesPushService.kt
+++ b/androidApp/core/api/usersync/src/main/java/com/grateful/deadly/core/api/usersync/FavoritesPushService.kt
@@ -17,6 +17,10 @@ interface FavoritesPushService {
     /** Enqueue a review change (refId is the showId). The flusher reads the
      *  review row + its player tags at push time; a tombstone becomes DELETE. */
     fun enqueueAndPushReview(showId: String)
+    /** Enqueue a recording-preference change (refId is the showId). The flusher
+     *  reads the recording_preferences row at push time; an absent/tombstoned
+     *  row becomes a DELETE. */
+    fun enqueueAndPushRecordingPref(showId: String)
     /** Enqueue all local favorites (shows + songs) + top recents, then flush.
      *  Backs the one-time startup backfill and a manual "Sync now". */
     suspend fun enqueueAllLocalAndFlush(): List<PushResult>

--- a/androidApp/core/api/usersync/src/main/java/com/grateful/deadly/core/api/usersync/UserSyncService.kt
+++ b/androidApp/core/api/usersync/src/main/java/com/grateful/deadly/core/api/usersync/UserSyncService.kt
@@ -16,4 +16,8 @@ interface UserSyncService {
     suspend fun putReview(review: SyncReviewV3): Result<Unit>
     /** Delete a review (and its player tags) by showId. */
     suspend fun deleteReview(showId: String): Result<Unit>
+    /** Upsert the preferred recording for a show. */
+    suspend fun putRecordingPref(showId: String, recordingId: String): Result<Unit>
+    /** Clear the preferred recording for a show (tombstone). */
+    suspend fun deleteRecordingPref(showId: String): Result<Unit>
 }

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
@@ -53,6 +53,7 @@ class AppPreferences @Inject constructor(
         private const val KEY_LAST_REVIEW_PROMPT_TIME = "last_review_prompt_time"
         private const val KEY_HAS_ADDED_FAVORITE = "has_added_favorite"
         private const val KEY_LOCAL_BACKFILLED_V1 = "local_backfilled_v1"
+        private const val KEY_LOCAL_BACKFILLED_V2 = "local_backfilled_v2"
         private const val KEY_DEVELOPER_MODE_UNLOCKED = "developer_mode_unlocked"
         private const val KEY_PLAYER_CONTROLS_STYLE = "player_controls_style"
         private const val KEY_HOME_TRENDING_WINDOW = "home_trending_window"
@@ -393,6 +394,15 @@ class AppPreferences @Inject constructor(
 
     fun setLocalBackfilledV1(value: Boolean) {
         prefs.edit().putBoolean(KEY_LOCAL_BACKFILLED_V1, value).apply()
+    }
+
+    /** One-time flag: re-run of the backfill that also covers recording
+     *  preferences (V1 predated recording-pref sync, so existing users need
+     *  one more pass to push their local prefs). */
+    fun getLocalBackfilledV2(): Boolean = prefs.getBoolean(KEY_LOCAL_BACKFILLED_V2, false)
+
+    fun setLocalBackfilledV2(value: Boolean) {
+        prefs.edit().putBoolean(KEY_LOCAL_BACKFILLED_V2, value).apply()
     }
 
     private val _developerModeUnlocked = MutableStateFlow(

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/dao/RecordingPreferenceDao.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/dao/RecordingPreferenceDao.kt
@@ -13,17 +13,23 @@ interface RecordingPreferenceDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(preference: RecordingPreferenceEntity)
 
+    /** Includes tombstones — for the sync push/apply paths. */
     @Query("SELECT * FROM recording_preferences WHERE showId = :showId")
     suspend fun get(showId: String): RecordingPreferenceEntity?
 
-    @Query("SELECT recordingId FROM recording_preferences WHERE showId = :showId")
+    @Query("SELECT recordingId FROM recording_preferences WHERE showId = :showId AND deletedAt IS NULL")
     suspend fun getRecordingId(showId: String): String?
 
-    @Query("SELECT recordingId FROM recording_preferences WHERE showId = :showId")
+    @Query("SELECT recordingId FROM recording_preferences WHERE showId = :showId AND deletedAt IS NULL")
     fun getRecordingIdFlow(showId: String): Flow<String?>
 
+    /** Includes tombstones — for the one-time sync backfill. */
     @Query("SELECT * FROM recording_preferences")
     suspend fun getAll(): List<RecordingPreferenceEntity>
+
+    /** Soft-delete so a clear can sync as a tombstone (last-write-wins). */
+    @Query("UPDATE recording_preferences SET deletedAt = :deletedAt, updatedAt = :updatedAt WHERE showId = :showId")
+    suspend fun softDelete(showId: String, deletedAt: Long, updatedAt: Long)
 
     @Query("DELETE FROM recording_preferences WHERE showId = :showId")
     suspend fun delete(showId: String)

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/entities/SyncOutboxEntity.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/entities/SyncOutboxEntity.kt
@@ -36,5 +36,8 @@ data class SyncOutboxEntity(
         /** refId is the showId. The flusher reads the review row + its player
          *  tags at push time; a tombstoned row becomes a DELETE. */
         const val KIND_REVIEW = "review"
+        /** refId is the showId. The flusher reads the recording_preferences
+         *  row at push time; an absent/tombstoned row becomes a DELETE. */
+        const val KIND_RECORDING_PREF = "recording_pref"
     }
 }

--- a/androidApp/core/favorites/src/main/java/com/grateful/deadly/core/favorites/repository/FavoritesRepository.kt
+++ b/androidApp/core/favorites/src/main/java/com/grateful/deadly/core/favorites/repository/FavoritesRepository.kt
@@ -218,17 +218,21 @@ class FavoritesRepository @Inject constructor(
      */
     suspend fun setPreferredRecording(showId: String, recordingId: String?) {
         Log.d(TAG, "setPreferredRecording('$showId', '$recordingId')")
+        val now = System.currentTimeMillis()
         if (recordingId != null) {
             recordingPreferenceDao.upsert(
                 RecordingPreferenceEntity(
                     showId = showId,
                     recordingId = recordingId,
-                    updatedAt = System.currentTimeMillis()
+                    updatedAt = now,
+                    deletedAt = null,
                 )
             )
         } else {
-            recordingPreferenceDao.delete(showId)
+            // Soft-delete so the clear syncs as a tombstone (last-write-wins).
+            recordingPreferenceDao.softDelete(showId, deletedAt = now, updatedAt = now)
         }
+        favoritesPushService.enqueueAndPushRecordingPref(showId)
     }
 
     /**

--- a/androidApp/core/usersync/src/main/java/com/grateful/deadly/core/usersync/FavoritesPushServiceImpl.kt
+++ b/androidApp/core/usersync/src/main/java/com/grateful/deadly/core/usersync/FavoritesPushServiceImpl.kt
@@ -13,6 +13,7 @@ import com.grateful.deadly.core.api.usersync.UserSyncService
 import com.grateful.deadly.core.database.dao.FavoriteSongDao
 import com.grateful.deadly.core.database.dao.FavoritesDao
 import com.grateful.deadly.core.database.dao.RecentShowDao
+import com.grateful.deadly.core.database.dao.RecordingPreferenceDao
 import com.grateful.deadly.core.database.dao.ShowPlayerTagDao
 import com.grateful.deadly.core.database.dao.ShowReviewDao
 import com.grateful.deadly.core.database.dao.SyncOutboxDao
@@ -35,6 +36,7 @@ class FavoritesPushServiceImpl @Inject constructor(
     @AppDatabase private val recentShowDao: RecentShowDao,
     @AppDatabase private val showReviewDao: ShowReviewDao,
     @AppDatabase private val showPlayerTagDao: ShowPlayerTagDao,
+    @AppDatabase private val recordingPreferenceDao: RecordingPreferenceDao,
     private val userSyncService: UserSyncService,
     private val authService: AuthService,
     private val syncCoordinator: UserSyncCoordinator,
@@ -63,6 +65,10 @@ class FavoritesPushServiceImpl @Inject constructor(
         enqueueAndFlush(SyncOutboxEntity.KIND_REVIEW, showId)
     }
 
+    override fun enqueueAndPushRecordingPref(showId: String) {
+        enqueueAndFlush(SyncOutboxEntity.KIND_RECORDING_PREF, showId)
+    }
+
     override suspend fun enqueueAllLocalAndFlush(): List<PushResult> {
         val shows = try { favoritesDao.getAllFavoriteShows() } catch (e: Exception) {
             Log.w(TAG, "getAllFavoriteShows failed", e); emptyList()
@@ -83,6 +89,11 @@ class FavoritesPushServiceImpl @Inject constructor(
             Log.w(TAG, "getAll reviews failed", e); emptyList()
         }
         for (review in reviews) enqueueRow(SyncOutboxEntity.KIND_REVIEW, review.showId)
+
+        val recordingPrefs = try { recordingPreferenceDao.getAll() } catch (e: Exception) {
+            Log.w(TAG, "getAll recording prefs failed", e); emptyList()
+        }
+        for (pref in recordingPrefs) enqueueRow(SyncOutboxEntity.KIND_RECORDING_PREF, pref.showId)
 
         return flushPending()
     }
@@ -128,6 +139,7 @@ class FavoritesPushServiceImpl @Inject constructor(
             results += flushKind(SyncOutboxEntity.KIND_FAVORITE_SONG)
             results += flushKind(SyncOutboxEntity.KIND_RECENT)
             results += flushKind(SyncOutboxEntity.KIND_REVIEW)
+            results += flushKind(SyncOutboxEntity.KIND_RECORDING_PREF)
             if (results.any { it.success && it.operation != "NOOP" }) {
                 syncCoordinator.triggerPull("after_push_flush")
             }
@@ -140,7 +152,8 @@ class FavoritesPushServiceImpl @Inject constructor(
             outbox.pendingCount(SyncOutboxEntity.KIND_FAVORITE_SHOW) +
                 outbox.pendingCount(SyncOutboxEntity.KIND_FAVORITE_SONG) +
                 outbox.pendingCount(SyncOutboxEntity.KIND_RECENT) +
-                outbox.pendingCount(SyncOutboxEntity.KIND_REVIEW)
+                outbox.pendingCount(SyncOutboxEntity.KIND_REVIEW) +
+                outbox.pendingCount(SyncOutboxEntity.KIND_RECORDING_PREF)
         } catch (_: Exception) { 0 }
 
     private suspend fun flushKind(kind: String): List<PushResult> {
@@ -163,6 +176,7 @@ class FavoritesPushServiceImpl @Inject constructor(
             SyncOutboxEntity.KIND_FAVORITE_SONG -> pushFavoriteSong(entry)
             SyncOutboxEntity.KIND_RECENT -> pushRecent(entry)
             SyncOutboxEntity.KIND_REVIEW -> pushReview(entry)
+            SyncOutboxEntity.KIND_RECORDING_PREF -> pushRecordingPref(entry)
             else -> {
                 // Unknown kind — drop it so the queue doesn't get stuck.
                 outbox.delete(entry.id)
@@ -288,6 +302,25 @@ class FavoritesPushServiceImpl @Inject constructor(
                 deletedAt = null,
             )
             userSyncService.putReview(dto)
+                .fold({ success(entry, "PUT") }, { failure(entry, "PUT", it.message ?: it::class.simpleName ?: "error") })
+        }
+    }
+
+    // Recording prefs push by showId. The flusher reads the current row at
+    // push time: a live row is a PUT, an absent or tombstoned row is a DELETE.
+    private suspend fun pushRecordingPref(entry: SyncOutboxEntity): PushResult {
+        val showId = entry.refId
+        val row = try {
+            recordingPreferenceDao.get(showId)
+        } catch (e: Exception) {
+            return failure(entry, "?", "local read failed: ${e.message}")
+        }
+
+        return if (row == null || row.deletedAt != null) {
+            userSyncService.deleteRecordingPref(showId)
+                .fold({ success(entry, "DELETE") }, { failure(entry, "DELETE", it.message ?: it::class.simpleName ?: "error") })
+        } else {
+            userSyncService.putRecordingPref(showId, row.recordingId)
                 .fold({ success(entry, "PUT") }, { failure(entry, "PUT", it.message ?: it::class.simpleName ?: "error") })
         }
     }

--- a/androidApp/core/usersync/src/main/java/com/grateful/deadly/core/usersync/UserSyncApplyServiceImpl.kt
+++ b/androidApp/core/usersync/src/main/java/com/grateful/deadly/core/usersync/UserSyncApplyServiceImpl.kt
@@ -6,16 +6,19 @@ import com.grateful.deadly.core.api.auth.AuthState
 import com.grateful.deadly.core.api.usersync.ApplyResult
 import com.grateful.deadly.core.api.usersync.SyncFavoriteShowV3
 import com.grateful.deadly.core.api.usersync.SyncFavoriteTrackV3
+import com.grateful.deadly.core.api.usersync.SyncRecordingPrefV3
 import com.grateful.deadly.core.api.usersync.SyncReviewV3
 import com.grateful.deadly.core.api.usersync.UserSyncApplyService
 import com.grateful.deadly.core.api.usersync.UserSyncService
 import com.grateful.deadly.core.database.dao.FavoriteSongDao
 import com.grateful.deadly.core.database.dao.FavoritesDao
+import com.grateful.deadly.core.database.dao.RecordingPreferenceDao
 import com.grateful.deadly.core.database.dao.ShowDao
 import com.grateful.deadly.core.database.dao.ShowPlayerTagDao
 import com.grateful.deadly.core.database.dao.ShowReviewDao
 import com.grateful.deadly.core.database.entities.FavoriteShowEntity
 import com.grateful.deadly.core.database.entities.FavoriteSongEntity
+import com.grateful.deadly.core.database.entities.RecordingPreferenceEntity
 import com.grateful.deadly.core.database.entities.ShowPlayerTagEntity
 import com.grateful.deadly.core.database.entities.ShowReviewEntity
 import com.grateful.deadly.core.model.AppDatabase
@@ -31,6 +34,7 @@ class UserSyncApplyServiceImpl @Inject constructor(
     @AppDatabase private val favoriteSongDao: FavoriteSongDao,
     @AppDatabase private val showReviewDao: ShowReviewDao,
     @AppDatabase private val showPlayerTagDao: ShowPlayerTagDao,
+    @AppDatabase private val recordingPreferenceDao: RecordingPreferenceDao,
     @AppDatabase private val showDao: ShowDao,
     private val authService: AuthService,
 ) : UserSyncApplyService {
@@ -50,6 +54,7 @@ class UserSyncApplyServiceImpl @Inject constructor(
                 val shows = applyFavoriteShows(backup.favorites.shows)
                 val songs = applyFavoriteSongs(backup.favorites.tracks)
                 val reviews = applyReviews(backup.reviews)
+                applyRecordingPreferences(backup.recordingPreferences)
                 shows.copy(
                     favoriteSongsScanned = songs.favoriteSongsScanned,
                     favoriteSongsApplied = songs.favoriteSongsApplied,
@@ -262,6 +267,57 @@ class UserSyncApplyServiceImpl @Inject constructor(
             reviewsApplied = applied,
             reviewsSkippedLocalNewer = skippedLocalNewer,
             reviewsSkippedMissingShow = skippedMissingShow,
+        )
+    }
+
+    // Recording prefs are a singleton-per-show row keyed by showId. FK to shows,
+    // so skip prefs for shows not in the local catalog. Last-write-wins on
+    // updatedAt; a remote tombstone soft-deletes the local row.
+    private suspend fun applyRecordingPreferences(remote: List<SyncRecordingPrefV3>) {
+        var applied = 0
+        var skippedLocalNewer = 0
+        var skippedMissingShow = 0
+
+        for (dto in remote) {
+            if (showDao.getShowById(dto.showId) == null) {
+                skippedMissingShow++
+                continue
+            }
+
+            val local = try {
+                recordingPreferenceDao.get(dto.showId)
+            } catch (e: Exception) {
+                Log.w(TAG, "recording pref read failed for ${dto.showId}: ${e.message}")
+                continue
+            }
+
+            val remoteUpdatedMs = dto.updatedAt * 1000
+            if (local != null && local.updatedAt >= remoteUpdatedMs) {
+                skippedLocalNewer++
+                continue
+            }
+
+            try {
+                recordingPreferenceDao.upsert(
+                    RecordingPreferenceEntity(
+                        showId = dto.showId,
+                        recordingId = dto.recordingId,
+                        updatedAt = remoteUpdatedMs,
+                        deletedAt = dto.deletedAt?.let { it * 1000 },
+                    )
+                )
+                applied++
+            } catch (e: android.database.sqlite.SQLiteConstraintException) {
+                skippedMissingShow++
+            } catch (e: Exception) {
+                Log.w(TAG, "apply recording pref ${dto.showId} failed: ${e.message}")
+            }
+        }
+
+        Log.d(
+            TAG,
+            "recording_prefs: scanned=${remote.size} applied=$applied " +
+                "skippedLocalNewer=$skippedLocalNewer skippedMissingShow=$skippedMissingShow"
         )
     }
 

--- a/androidApp/core/usersync/src/main/java/com/grateful/deadly/core/usersync/UserSyncServiceImpl.kt
+++ b/androidApp/core/usersync/src/main/java/com/grateful/deadly/core/usersync/UserSyncServiceImpl.kt
@@ -251,4 +251,63 @@ class UserSyncServiceImpl @Inject constructor(
             Result.failure(e)
         }
     }
+
+    override suspend fun putRecordingPref(showId: String, recordingId: String): Result<Unit> {
+        val token = authService.getAuthToken()
+            ?: return Result.failure(IllegalStateException("Not signed in"))
+        val baseUrl = appPreferences.apiBaseUrl
+        val bodyJson = json.encodeToString(
+            RecordingPrefBody.serializer(), RecordingPrefBody(recordingId)
+        )
+
+        return try {
+            withContext(Dispatchers.IO) {
+                val request = Request.Builder()
+                    .url("$baseUrl/api/user/recordings/$showId")
+                    .addHeader("Authorization", "Bearer $token")
+                    .put(bodyJson.toRequestBody("application/json".toMediaType()))
+                    .build()
+                httpClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        val bodyText = response.body?.string().orEmpty()
+                        throw RuntimeException("HTTP ${response.code}: $bodyText")
+                    }
+                }
+            }
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.w(TAG, "putRecordingPref failed for $showId", e)
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun deleteRecordingPref(showId: String): Result<Unit> {
+        val token = authService.getAuthToken()
+            ?: return Result.failure(IllegalStateException("Not signed in"))
+        val baseUrl = appPreferences.apiBaseUrl
+
+        return try {
+            withContext(Dispatchers.IO) {
+                val request = Request.Builder()
+                    .url("$baseUrl/api/user/recordings/$showId")
+                    .addHeader("Authorization", "Bearer $token")
+                    .delete()
+                    .build()
+                httpClient.newCall(request).execute().use { response ->
+                    // 404 = server already lacks the row, treat as success.
+                    if (!response.isSuccessful && response.code != 404) {
+                        val bodyText = response.body?.string().orEmpty()
+                        throw RuntimeException("HTTP ${response.code}: $bodyText")
+                    }
+                }
+            }
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.w(TAG, "deleteRecordingPref failed for $showId", e)
+            Result.failure(e)
+        }
+    }
 }
+
+@kotlinx.serialization.Serializable
+private data class RecordingPrefBody(val recordingId: String)

--- a/api/src/routes/user.ts
+++ b/api/src/routes/user.ts
@@ -9,7 +9,7 @@ import {
   getFavoriteShows, upsertFavoriteShow, deleteFavoriteShow,
   getFavoriteSongs, upsertFavoriteSong, deleteFavoriteSongByKey,
   getReviews, upsertReview, deleteReview,
-  getRecordingPreferences, upsertRecordingPreference,
+  getRecordingPreferences, upsertRecordingPreference, deleteRecordingPreference,
   getRecentShows, upsertRecentShow,
   getPlaybackPosition, upsertPlaybackPosition,
   getSettings, upsertSettings,
@@ -181,6 +181,15 @@ export async function userRoutes(app: FastifyInstance): Promise<void> {
       const { recordingId } = request.body as { recordingId: string };
       upsertRecordingPreference(request.user!.id, request.params.showId, recordingId);
       return reply.code(200).send({ ok: true });
+    });
+
+  app.delete<{ Params: { showId: string } }>(
+    "/api/user/recordings/:showId", {
+      schema: { tags: ["user"], summary: "Clear recording preference" },
+      preHandler: requireAuth,
+    }, async (request, reply) => {
+      const deleted = deleteRecordingPreference(request.user!.id, request.params.showId);
+      return reply.code(deleted ? 200 : 404).send({ ok: deleted });
     });
 
   // ── Recent Shows ────────────────────────────────────────────────

--- a/iosApp/deadly/App/AppContainer.swift
+++ b/iosApp/deadly/App/AppContainer.swift
@@ -106,6 +106,7 @@ final class AppContainer {
                     recentShowDAO: RecentShowDAO(database: db),
                     showReviewDAO: ShowReviewDAO(database: db),
                     showPlayerTagDAO: ShowPlayerTagDAO(database: db),
+                    recordingPreferenceDAO: RecordingPreferenceDAO(database: db),
                     apiClient: userSync,
                     authService: auth
                 )
@@ -142,6 +143,7 @@ final class AppContainer {
                     favoriteSongDAO: FavoriteSongDAO(database: db),
                     showReviewDAO: ShowReviewDAO(database: db),
                     showPlayerTagDAO: ShowPlayerTagDAO(database: db),
+                    recordingPreferenceDAO: RecordingPreferenceDAO(database: db),
                     showDAO: ShowDAO(database: db),
                     authService: auth
                 )
@@ -212,9 +214,13 @@ final class AppContainer {
             // top recents) so a freshly-synced web profile isn't empty.
             // Best-effort — enqueued rows flush once signed in; the flag stops
             // it re-running. The same routine backs a manual "Sync now".
+            // V2 re-runs the backfill for users who already cleared V1 before
+            // recording-pref sync existed (idempotent: outbox dedupes, server
+            // is last-write-wins).
             MainActor.assumeIsolated {
-                if !prefs.localBackfilledV1 {
+                if !prefs.localBackfilledV2 {
                     prefs.localBackfilledV1 = true
+                    prefs.localBackfilledV2 = true
                     Task { await pushSvc.enqueueAllLocalAndFlush() }
                 }
             }
@@ -270,6 +276,7 @@ final class AppContainer {
                 analyticsService: analytics
             )
             playlistService = playlistSvc
+            MainActor.assumeIsolated { playlistSvc.favoritesPushService = pushSvc }
 
             // PlaybackRestorationService — persists and restores playback position across kills
             let restorationSvc = MainActor.assumeIsolated {

--- a/iosApp/deadly/Core/Database/Records/SyncOutboxRecord.swift
+++ b/iosApp/deadly/Core/Database/Records/SyncOutboxRecord.swift
@@ -24,6 +24,9 @@ struct SyncOutboxRecord: Codable, Sendable, Equatable, FetchableRecord, MutableP
         /// refId is the showId. The flusher reads the review row + its player
         /// tags at push time; a tombstoned row becomes a DELETE.
         static let review = "review"
+        /// refId is the showId. The flusher reads the recording_preferences
+        /// row at push time; an absent row becomes a DELETE.
+        static let recordingPref = "recording_pref"
     }
 
     mutating func didInsert(_ inserted: InsertionSuccess) {

--- a/iosApp/deadly/Core/Network/UserSyncAPIClient.swift
+++ b/iosApp/deadly/Core/Network/UserSyncAPIClient.swift
@@ -265,6 +265,28 @@ struct UserSyncAPIClient {
         try ensureOK(data: data, response: response)
     }
 
+    /// Upsert the preferred recording for a show.
+    func putRecordingPref(showId: String, recordingId: String) async throws {
+        let body = try JSONEncoder().encode(["recordingId": recordingId])
+        let (data, response) = try await request(
+            method: "PUT",
+            path: "/api/user/recordings/\(showId)",
+            body: body
+        )
+        try ensureOK(data: data, response: response)
+    }
+
+    /// Clear the preferred recording for a show (tombstone).
+    func deleteRecordingPref(showId: String) async throws {
+        let (data, response) = try await request(
+            method: "DELETE",
+            path: "/api/user/recordings/\(showId)",
+            body: nil
+        )
+        if let http = response as? HTTPURLResponse, http.statusCode == 404 { return }
+        try ensureOK(data: data, response: response)
+    }
+
     // MARK: - Internals
 
     private func client() throws -> APIClient {

--- a/iosApp/deadly/Core/Service/AppPreferences.swift
+++ b/iosApp/deadly/Core/Service/AppPreferences.swift
@@ -5,6 +5,7 @@ final class AppPreferences {
     private static let includeShowsWithoutRecordingsKey = "include_shows_without_recordings"
     private static let forceOnlineKey = "force_online"
     private static let localBackfilledV1Key = "local_backfilled_v1"
+    private static let localBackfilledV2Key = "local_backfilled_v2"
     private static let favoritesDisplayModeKey = "favorites_display_mode"
     private static let legacyLibraryDisplayModeKey = "library_display_mode"
     private static let eqEnabledKey = "eq_enabled"
@@ -84,6 +85,12 @@ final class AppPreferences {
     /// server, so the one-time startup backfill doesn't re-run.
     var localBackfilledV1: Bool {
         didSet { UserDefaults.standard.set(localBackfilledV1, forKey: Self.localBackfilledV1Key) }
+    }
+
+    /// V2 re-runs the backfill once more to cover recording preferences, which
+    /// V1 predated. Existing users (V1 already set) need this extra pass.
+    var localBackfilledV2: Bool {
+        didSet { UserDefaults.standard.set(localBackfilledV2, forKey: Self.localBackfilledV2Key) }
     }
 
     var favoritesDisplayMode: String {
@@ -206,6 +213,7 @@ final class AppPreferences {
             Self.useBetaModeKey: false,
             Self.forceOnlineKey: false,
             Self.localBackfilledV1Key: false,
+            Self.localBackfilledV2Key: false,
             Self.favoritesDisplayModeKey: "LIST",
             Self.eqEnabledKey: false,
             Self.eqPresetKey: "flat",
@@ -237,6 +245,7 @@ final class AppPreferences {
         }
         forceOnline = UserDefaults.standard.bool(forKey: Self.forceOnlineKey)
         localBackfilledV1 = UserDefaults.standard.bool(forKey: Self.localBackfilledV1Key)
+        localBackfilledV2 = UserDefaults.standard.bool(forKey: Self.localBackfilledV2Key)
         // Read new key first, fall back to legacy key for migration
         favoritesDisplayMode = UserDefaults.standard.string(forKey: Self.favoritesDisplayModeKey)
             ?? UserDefaults.standard.string(forKey: Self.legacyLibraryDisplayModeKey)

--- a/iosApp/deadly/Core/Service/FavoritesPushService.swift
+++ b/iosApp/deadly/Core/Service/FavoritesPushService.swift
@@ -17,6 +17,7 @@ final class FavoritesPushService {
     private let recentShowDAO: RecentShowDAO
     private let showReviewDAO: ShowReviewDAO
     private let showPlayerTagDAO: ShowPlayerTagDAO
+    private let recordingPreferenceDAO: RecordingPreferenceDAO
     private let apiClient: UserSyncAPIClient
     private let authService: AuthService
     /// Set by AppContainer after both services are constructed. Used to fire
@@ -31,6 +32,7 @@ final class FavoritesPushService {
         recentShowDAO: RecentShowDAO,
         showReviewDAO: ShowReviewDAO,
         showPlayerTagDAO: ShowPlayerTagDAO,
+        recordingPreferenceDAO: RecordingPreferenceDAO,
         apiClient: UserSyncAPIClient,
         authService: AuthService
     ) {
@@ -40,6 +42,7 @@ final class FavoritesPushService {
         self.recentShowDAO = recentShowDAO
         self.showReviewDAO = showReviewDAO
         self.showPlayerTagDAO = showPlayerTagDAO
+        self.recordingPreferenceDAO = recordingPreferenceDAO
         self.apiClient = apiClient
         self.authService = authService
     }
@@ -68,6 +71,10 @@ final class FavoritesPushService {
         for review in reviews {
             enqueueRow(kind: SyncOutboxRecord.Kind.review, refId: review.showId)
         }
+        let recordingPrefs = (try? recordingPreferenceDAO.fetchAll()) ?? []
+        for pref in recordingPrefs {
+            enqueueRow(kind: SyncOutboxRecord.Kind.recordingPref, refId: pref.showId)
+        }
         return await flushPending()
     }
 
@@ -95,6 +102,13 @@ final class FavoritesPushService {
     /// becomes a DELETE.
     func enqueueAndPushReview(showId: String) {
         enqueue(kind: SyncOutboxRecord.Kind.review, refId: showId)
+    }
+
+    /// Enqueue a recording-preference change (refId is the showId).
+    /// Fire-and-forget. The flusher reads the row at push time; an absent row
+    /// becomes a DELETE.
+    func enqueueAndPushRecordingPref(showId: String) {
+        enqueue(kind: SyncOutboxRecord.Kind.recordingPref, refId: showId)
     }
 
     private func enqueueRow(kind: String, refId: String) {
@@ -126,6 +140,7 @@ final class FavoritesPushService {
         results.append(contentsOf: await flushKind(SyncOutboxRecord.Kind.favoriteSong))
         results.append(contentsOf: await flushKind(SyncOutboxRecord.Kind.recent))
         results.append(contentsOf: await flushKind(SyncOutboxRecord.Kind.review))
+        results.append(contentsOf: await flushKind(SyncOutboxRecord.Kind.recordingPref))
 
         // Reconcile after pushing — the server may have learned about changes
         // from other devices during our window. Only fire when something
@@ -167,7 +182,8 @@ final class FavoritesPushService {
         let songs = (try? outbox.pendingCount(kind: SyncOutboxRecord.Kind.favoriteSong)) ?? 0
         let recents = (try? outbox.pendingCount(kind: SyncOutboxRecord.Kind.recent)) ?? 0
         let reviews = (try? outbox.pendingCount(kind: SyncOutboxRecord.Kind.review)) ?? 0
-        return shows + songs + recents + reviews
+        let recordingPrefs = (try? outbox.pendingCount(kind: SyncOutboxRecord.Kind.recordingPref)) ?? 0
+        return shows + songs + recents + reviews + recordingPrefs
     }
 
     // MARK: - Internals
@@ -187,8 +203,37 @@ final class FavoritesPushService {
             return await pushRecent(refId: entry.refId)
         case SyncOutboxRecord.Kind.review:
             return await pushReview(refId: entry.refId)
+        case SyncOutboxRecord.Kind.recordingPref:
+            return await pushRecordingPref(refId: entry.refId)
         default:
             return .success(operation: "NOOP")
+        }
+    }
+
+    // Recording prefs push by showId. The flusher reads the current row at
+    // push time: a live row is a PUT, an absent row is a DELETE.
+    private func pushRecordingPref(refId: String) async -> FlushOutcome {
+        let row: RecordingPreferenceRecord?
+        do {
+            row = try recordingPreferenceDAO.fetch(refId)
+        } catch {
+            return .failure(operation: "?", error: "local read failed: \(error.localizedDescription)")
+        }
+
+        if let row {
+            do {
+                try await apiClient.putRecordingPref(showId: row.showId, recordingId: row.recordingId)
+                return .success(operation: "PUT")
+            } catch {
+                return .failure(operation: "PUT", error: error.localizedDescription)
+            }
+        } else {
+            do {
+                try await apiClient.deleteRecordingPref(showId: refId)
+                return .success(operation: "DELETE")
+            } catch {
+                return .failure(operation: "DELETE", error: error.localizedDescription)
+            }
         }
     }
 

--- a/iosApp/deadly/Core/Service/PlaylistServiceImpl.swift
+++ b/iosApp/deadly/Core/Service/PlaylistServiceImpl.swift
@@ -28,6 +28,9 @@ final class PlaylistServiceImpl: PlaylistService {
     private let analyticsService: AnalyticsService?
     let streamPlayer: StreamPlayer
     var connectService: ConnectService?
+    /// Set by AppContainer after construction. Pushes recording-preference
+    /// changes to the server via the sync outbox.
+    weak var favoritesPushService: FavoritesPushService?
     /// When true, playTrack() skips notifying Connect to avoid Connect→load→sendLoad loops.
     var suppressConnectNotify = false
 
@@ -250,6 +253,9 @@ final class PlaylistServiceImpl: PlaylistService {
         try? recordingPreferenceDAO.upsert(RecordingPreferenceRecord(
             showId: showId, recordingId: recording.identifier, updatedAt: now
         ))
+        Task { @MainActor [weak favoritesPushService] in
+            favoritesPushService?.enqueueAndPushRecordingPref(showId: showId)
+        }
         await selectRecording(recording)
     }
 

--- a/iosApp/deadly/Core/Service/UserSyncApplyService.swift
+++ b/iosApp/deadly/Core/Service/UserSyncApplyService.swift
@@ -17,6 +17,7 @@ final class UserSyncApplyService {
     private let favoriteSongDAO: FavoriteSongDAO
     private let showReviewDAO: ShowReviewDAO
     private let showPlayerTagDAO: ShowPlayerTagDAO
+    private let recordingPreferenceDAO: RecordingPreferenceDAO
     private let showDAO: ShowDAO
     private let authService: AuthService
 
@@ -49,6 +50,7 @@ final class UserSyncApplyService {
         favoriteSongDAO: FavoriteSongDAO,
         showReviewDAO: ShowReviewDAO,
         showPlayerTagDAO: ShowPlayerTagDAO,
+        recordingPreferenceDAO: RecordingPreferenceDAO,
         showDAO: ShowDAO,
         authService: AuthService
     ) {
@@ -57,6 +59,7 @@ final class UserSyncApplyService {
         self.favoriteSongDAO = favoriteSongDAO
         self.showReviewDAO = showReviewDAO
         self.showPlayerTagDAO = showPlayerTagDAO
+        self.recordingPreferenceDAO = recordingPreferenceDAO
         self.showDAO = showDAO
         self.authService = authService
     }
@@ -76,6 +79,7 @@ final class UserSyncApplyService {
             let shows = try applyFavoriteShows(backup.favorites.shows)
             let songs = try applyFavoriteSongs(backup.favorites.tracks)
             let reviews = try applyReviews(backup.reviews)
+            applyRecordingPreferences(backup.recordingPreferences)
             return ApplyResult(
                 favoriteShowsScanned: shows.scanned,
                 favoriteShowsApplied: shows.applied,
@@ -263,6 +267,44 @@ final class UserSyncApplyService {
             }
         }
         return c
+    }
+
+    // Recording prefs are one row per show keyed by showId, FK'd to shows.
+    // LWW on updatedAt; a remote tombstone deletes the local row. iOS keeps no
+    // local tombstone column, so a clear is a hard delete.
+    private func applyRecordingPreferences(_ remote: [SyncRecordingPrefV3]) {
+        var applied = 0, skippedLocalNewer = 0, skippedMissingShow = 0
+
+        for dto in remote {
+            if (try? showDAO.fetchById(dto.showId)) == nil {
+                skippedMissingShow += 1
+                continue
+            }
+
+            let local = try? recordingPreferenceDAO.fetch(dto.showId)
+            let remoteUpdatedMs = dto.updatedAt * 1000
+            if let local, local.updatedAt >= remoteUpdatedMs {
+                skippedLocalNewer += 1
+                continue
+            }
+
+            do {
+                if dto.deletedAt != nil {
+                    try recordingPreferenceDAO.delete(dto.showId)
+                } else {
+                    try recordingPreferenceDAO.upsert(RecordingPreferenceRecord(
+                        showId: dto.showId,
+                        recordingId: dto.recordingId,
+                        updatedAt: remoteUpdatedMs
+                    ))
+                }
+                applied += 1
+            } catch {
+                print("[UserSyncApply] apply recording pref \(dto.showId) failed: \(error.localizedDescription)")
+            }
+        }
+        print("[UserSyncApply] recording_prefs: scanned=\(remote.count) applied=\(applied) " +
+              "skippedLocalNewer=\(skippedLocalNewer) skippedMissingShow=\(skippedMissingShow)")
     }
 
     private func makeRecord(from dto: SyncFavoriteShowV3, existing: FavoriteShowRecord?) -> FavoriteShowRecord {


### PR DESCRIPTION
## Problem

Recording preferences (the per-show "set this tape as default" choice) were written to the local DB on both iOS and Android but **never pushed to the server**, and the pull/apply side ignored them too — so the round-trip was broken at *both* ends. The prod `recording_preferences` table sat at **0 rows** despite the feature shipping on all platforms and being actively used.

Root cause: the granular sync outbox only knew four kinds (`favorite_show`, `favorite_song`, `recent`, `review`). There was no recording-preference kind, so `setPreferredRecording` / `setRecordingAsDefault` only ever wrote locally. The server `PUT /api/user/recordings/:showId` endpoint and the `SyncRecordingPrefV3` DTO already existed but had no client callers.

## Fix

Wire recording prefs through the existing sync machinery, identical to favorites/reviews:

- **Server**: add `DELETE /api/user/recordings/:showId` for clears (PUT already existed; uses the existing `deleteRecordingPreference` tombstone).
- **Push** (iOS + Android): new `recording_pref` outbox kind; enqueue on every set/clear; the flusher reads the row at push time → PUT a live row, DELETE an absent/tombstoned one.
- **Apply** (iOS + Android): ingest pulled recording prefs with last-write-wins on `updatedAt`; a remote tombstone removes the local row; FK-guard skips shows not in the local catalog.
- **Backfill** (iOS + Android): recording prefs added to the automatic startup backfill, gated on a **new V2 flag** so existing users (already past the V1 backfill) get one more automatic pass — no button press.
- **Android**: switched to soft-delete so a clear syncs as a tombstone (matches the LWW/tombstone model of the other prefs).

### Behavior parity
- **Ongoing**: every set/clear pushes immediately and individually (forever, not one-time).
- **Historical**: one automatic catch-up on launch via the V2 gate.
- **LWW + tombstones**: yes, same as favorites/reviews. (iOS has no "clear" UI so it never *originates* a tombstone, but it honors remote ones.)

## Verification
- `api` typecheck ✓
- Android `assembleDebug` ✓
- iOS remote build ✓ (verified again after rebase onto current main / PR #72)

🤖 Generated with [Claude Code](https://claude.com/claude-code)