### PR TITLE
feat(android/settings): add Send Bug Report to share recent logs

### DIFF
--- a/androidApp/app/src/main/res/xml/file_paths.xml
+++ b/androidApp/app/src/main/res/xml/file_paths.xml
@@ -6,4 +6,6 @@
     <cache-path name="qr_images" path="qr/" />
     <!-- Cache directory for message share images -->
     <cache-path name="share_images" path="share_images/" />
+    <!-- Cache directory for shared bug-report log files -->
+    <cache-path name="bug_reports" path="bugreports/" />
 </paths>

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/bugreport/BugReportExporter.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/bugreport/BugReportExporter.kt
@@ -1,0 +1,94 @@
+package com.grateful.deadly.feature.settings.screens.bugreport
+
+import android.content.Context
+import android.os.Build
+import com.grateful.deadly.feature.settings.BuildConfig
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Pulls the recent logcat buffer for *this* process and returns it as plain text
+ * suitable for sharing in a bug report — the Android analog of iOS's `LogExport`.
+ *
+ * On Android 4.1+ a third-party app's `logcat` invocation only ever sees its own
+ * process's log entries (no READ_LOGS permission and none needed), so the dump is
+ * already scoped to us — no PID/package filtering required.
+ *
+ * Only logs that were actually written (`Log.i`/`w`/`e`/`d`) are present; the
+ * window is bounded with `-t <time>` so we ship roughly the last hour, mirroring
+ * the iOS export window.
+ */
+object BugReportExporter {
+
+    /** Default lookback window, in seconds, matching the iOS export. */
+    const val DEFAULT_WINDOW_SECONDS = 3600L
+
+    /**
+     * Read the last [windowSeconds] of this process's logcat output, prefixed with
+     * a self-describing header. If [filterContains] is non-null, only lines
+     * containing that substring are kept.
+     */
+    fun exportRecentLogs(
+        windowSeconds: Long = DEFAULT_WINDOW_SECONDS,
+        filterContains: String? = null,
+    ): String {
+        val header = header(windowSeconds)
+
+        val since = SimpleDateFormat("MM-dd HH:mm:ss.SSS", Locale.US)
+            .format(Date(System.currentTimeMillis() - windowSeconds * 1000))
+
+        val body = try {
+            val process = ProcessBuilder(
+                "logcat", "-d", "-v", "threadtime", "-t", since
+            ).redirectErrorStream(true).start()
+
+            process.inputStream.bufferedReader().useLines { lines ->
+                val kept = lines
+                    .filter { filterContains == null || it.contains(filterContains) }
+                    .toList()
+                process.waitFor()
+                if (kept.isEmpty()) "(no log entries in the selected window)"
+                else kept.joinToString("\n")
+            }
+        } catch (e: Exception) {
+            "Couldn't read logs: ${e.message}"
+        }
+
+        val count = if (body.startsWith("(") || body.startsWith("Couldn't")) 0
+        else body.count { it == '\n' } + 1
+
+        return buildString {
+            append(header)
+            append('\n')
+            append(body)
+            append("\n---\nCaptured ")
+            append(count)
+            append(" entries.")
+        }
+    }
+
+    /** Write [text] to a shareable file in the cache and return it. */
+    fun writeToCache(context: Context, text: String): File {
+        val dir = File(context.cacheDir, "bugreports").apply { mkdirs() }
+        val stamp = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).format(Date())
+        val file = File(dir, "deadly-logs-$stamp.txt")
+        file.writeText(text)
+        return file
+    }
+
+    private fun header(windowSeconds: Long): String {
+        val now = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US).format(Date())
+        return buildString {
+            append("=== Deadly Bug Report ===\n")
+            append("Generated: ").append(now).append('\n')
+            append("App: deadly ").append(BuildConfig.VERSION_NAME).append('\n')
+            append("OS: Android ").append(Build.VERSION.RELEASE)
+                .append(" (SDK ").append(Build.VERSION.SDK_INT).append(")\n")
+            append("Device: ").append(Build.MANUFACTURER).append(' ').append(Build.MODEL).append('\n')
+            append("Window: last ").append(windowSeconds).append("s\n")
+            append("---")
+        }
+    }
+}

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/bugreport/BugReportScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/bugreport/BugReportScreen.kt
@@ -1,0 +1,170 @@
+package com.grateful.deadly.feature.settings.screens.bugreport
+
+import android.content.Intent
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.IosShare
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.core.content.FileProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * "Send Bug Report" screen — the Android counterpart to iOS `BugReportView`.
+ * Dumps the last hour of this process's logcat, shows a preview, and offers
+ * Share (as a .txt attachment via FileProvider) + Copy + Refresh.
+ *
+ * Rendered as a local drill-down inside Settings (see [com.grateful.deadly.feature.settings.SettingsScreen]),
+ * so it takes an [onBack] callback and a header bar rather than being a nav route.
+ */
+@Composable
+fun BugReportScreen(
+    onBack: () -> Unit,
+    headerBar: @Composable (title: String, onBack: () -> Unit) -> Unit,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    var logText by remember { mutableStateOf("") }
+    var isLoading by remember { mutableStateOf(true) }
+    var copied by remember { mutableStateOf(false) }
+
+    suspend fun reload() {
+        isLoading = true
+        copied = false
+        logText = withContext(Dispatchers.IO) { BugReportExporter.exportRecentLogs() }
+        isLoading = false
+    }
+
+    LaunchedEffect(Unit) { reload() }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        headerBar("Send Bug Report", onBack)
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .padding(16.dp)
+        ) {
+            Text("Logs from the last hour", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "Tap Share to send these logs to support. They contain URLs of tracks you " +
+                    "played and timing information — no account or personal data.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        HorizontalDivider()
+
+        Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+            if (isLoading) {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    CircularProgressIndicator()
+                    Spacer(Modifier.height(8.dp))
+                    Text("Reading logs…", style = MaterialTheme.typography.bodyMedium)
+                }
+            } else {
+                SelectionContainer {
+                    Text(
+                        text = logText,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .verticalScroll(rememberScrollState())
+                            .padding(16.dp)
+                    )
+                }
+            }
+        }
+
+        HorizontalDivider()
+
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            OutlinedButton(
+                onClick = {
+                    copyToClipboard(context, logText)
+                    copied = true
+                    scope.launch { delay(1500); copied = false }
+                },
+                enabled = !isLoading && logText.isNotEmpty(),
+                modifier = Modifier.weight(1f)
+            ) {
+                Icon(
+                    imageVector = if (copied) Icons.Filled.Check else Icons.Filled.ContentCopy,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(if (copied) "Copied" else "Copy")
+            }
+
+            Button(
+                onClick = { shareLogs(context, logText) },
+                enabled = !isLoading && logText.isNotEmpty(),
+                modifier = Modifier.weight(1f)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.IosShare,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(Modifier.width(6.dp))
+                Text("Share")
+            }
+
+            OutlinedButton(
+                onClick = { scope.launch { reload() } },
+                enabled = !isLoading
+            ) {
+                Icon(Icons.Filled.Refresh, contentDescription = "Refresh")
+            }
+        }
+    }
+}
+
+private fun copyToClipboard(context: Context, text: String) {
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    clipboard.setPrimaryClip(ClipData.newPlainText("Deadly bug report", text))
+}
+
+private fun shareLogs(context: Context, text: String) {
+    val file = BugReportExporter.writeToCache(context, text)
+    val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+    val intent = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_STREAM, uri)
+        putExtra(Intent.EXTRA_SUBJECT, "Deadly bug report")
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
+    context.startActivity(Intent.createChooser(intent, "Send bug report"))
+}

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Message
 import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -26,6 +27,7 @@ import com.grateful.deadly.core.design.resources.IconResources
 import com.grateful.deadly.core.model.PlayerControlsStyle
 import com.grateful.deadly.core.model.SourceBadgeStyle
 import com.grateful.deadly.feature.settings.BuildConfig
+import com.grateful.deadly.feature.settings.screens.bugreport.BugReportScreen
 
 // ADR-0014: Settings is a short landing of stable categories, each its own
 // screen — Account · Playback & Audio · Home Layout · Library & Data ·
@@ -51,7 +53,18 @@ fun SettingsScreen(
     onNavigateToConnect: () -> Unit = {}
 ) {
     var category by remember { mutableStateOf<SettingsCategory?>(null) }
-    BackHandler(enabled = category != null) { category = null }
+    var showBugReport by remember { mutableStateOf(false) }
+    BackHandler(enabled = category != null || showBugReport) {
+        if (showBugReport) showBugReport = false else category = null
+    }
+
+    if (showBugReport) {
+        BugReportScreen(
+            onBack = { showBugReport = false },
+            headerBar = { title, onBack -> SubscreenHeader(title, onBack) }
+        )
+        return
+    }
 
     when (category) {
         null -> SettingsLanding(
@@ -60,7 +73,8 @@ fun SettingsScreen(
             onNavigateToMission = onNavigateToMission,
             onNavigateToLegal = onNavigateToLegal,
             onNavigateToPrivacyData = onNavigateToPrivacyData,
-            onNavigateToDeveloper = onNavigateToDeveloper
+            onNavigateToDeveloper = onNavigateToDeveloper,
+            onShowBugReport = { showBugReport = true }
         )
         SettingsCategory.Account ->
             AccountSettingsScreen(viewModel, onBack = { category = null })
@@ -91,7 +105,8 @@ private fun SettingsLanding(
     onNavigateToMission: () -> Unit,
     onNavigateToLegal: () -> Unit,
     onNavigateToPrivacyData: () -> Unit,
-    onNavigateToDeveloper: () -> Unit
+    onNavigateToDeveloper: () -> Unit,
+    onShowBugReport: () -> Unit
 ) {
     val context = LocalContext.current
     val developerModeUnlocked by viewModel.developerModeUnlocked.collectAsState()
@@ -182,6 +197,20 @@ private fun SettingsLanding(
                         Intent(Intent.ACTION_VIEW, Uri.parse("https://buymeacoffee.com/dsilberg"))
                     )
                 },
+                trailing = {
+                    Icon(
+                        painter = IconResources.Navigation.ChevronRight(),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            )
+        }
+        item {
+            PreferenceRow(
+                title = "Send Bug Report",
+                leading = { LeadingIcon(Icons.Filled.BugReport) },
+                onClick = onShowBugReport,
                 trailing = {
                     Icon(
                         painter = IconResources.Navigation.ChevronRight(),
@@ -335,21 +364,28 @@ private fun SubscreenScaffold(
     content: LazyListScope.() -> Unit
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 4.dp, vertical = 4.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            IconButton(onClick = onBack) {
-                Icon(
-                    painter = IconResources.Navigation.Back(),
-                    contentDescription = "Back"
-                )
-            }
-            Text(text = title, style = MaterialTheme.typography.titleLarge)
-        }
+        SubscreenHeader(title, onBack)
         LazyColumn(modifier = Modifier.fillMaxSize(), content = content)
+    }
+}
+
+// Just the back-bar row, reused by both [SubscreenScaffold] and screens that
+// manage their own (non-LazyColumn) body, like the bug report screen.
+@Composable
+private fun SubscreenHeader(title: String, onBack: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(
+                painter = IconResources.Navigation.Back(),
+                contentDescription = "Back"
+            )
+        }
+        Text(text = title, style = MaterialTheme.typography.titleLarge)
     }
 }
 


### PR DESCRIPTION
## What

Adds a **Send Bug Report** screen to Android Settings — the counterpart to the existing iOS `BugReportView`. Lets users grab recent logs and ship them off-device to support.

## How it works

- **`BugReportExporter`** — dumps the last hour of *this process's* logcat (`logcat -d -v threadtime -t <since>`), prefixed with a self-describing header (app version, OS, device, window). On Android 4.1+ an app's own `logcat` invocation only returns its own process's entries, so no `READ_LOGS` permission is needed. Also writes the text to a cache file for sharing.
- **`BugReportScreen`** — monospace log preview with **Copy** / **Share** / **Refresh**. Share sends a `.txt` attachment through the existing `FileProvider` + `ACTION_SEND` chooser.

## iOS parity

- Placed in **About & Support**, between "Support TheDeadly" and "Our Mission", with a bug icon (Material's analog of iOS's `ladybug`) — same placement and styling as iOS Settings.
- Same preamble copy, monospace preview, and Copy/Share/Refresh button hierarchy as `BugReportView`.

## Notes

- Added a `bugreports/` cache path to `file_paths.xml` so the FileProvider can serve the shared file.
- `exportRecentLogs(filterContains=…)` supports an optional substring filter (e.g. `[PB]`), matching the iOS `filterContains` parameter.
- Built (`assembleDebug`) cleanly; not yet run on a physical device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
