### PR TITLE
feat(mobile/settings): isolate dev builds from prod (gate Developer screen + default debug to custom server)

### DIFF
--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
@@ -423,13 +423,19 @@ class AppPreferences @Inject constructor(
     private val _customDevEmail: MutableStateFlow<String>
 
     init {
+        // Fresh installs with no explicit choice default to "custom" in debug
+        // builds so dev devices never report to prod (analytics, etc.) until a
+        // server is picked in Developer settings; release builds default to prod.
+        val isDebuggable =
+            (context.applicationInfo.flags and android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) != 0
+        val freshDefault = if (isDebuggable) "custom" else "prod"
         // Migrate: read new key first, fall back to legacy beta mode keys
         val env = if (prefs.contains(KEY_SERVER_ENVIRONMENT)) {
             prefs.getString(KEY_SERVER_ENVIRONMENT, "prod")!!
         } else if (prefs.contains(KEY_USE_BETA_MODE)) {
             if (prefs.getBoolean(KEY_USE_BETA_MODE, false)) "beta" else "prod"
         } else {
-            if (prefs.getBoolean(KEY_USE_BETA_SHARE_LINKS, false)) "beta" else "prod"
+            if (prefs.getBoolean(KEY_USE_BETA_SHARE_LINKS, false)) "beta" else freshDefault
         }
         _serverEnvironment = MutableStateFlow(env)
         _customServerUrl = MutableStateFlow(prefs.getString(KEY_CUSTOM_SERVER_URL, "") ?: "")

--- a/iosApp/deadly/Core/Service/AppPreferences.swift
+++ b/iosApp/deadly/Core/Service/AppPreferences.swift
@@ -19,6 +19,7 @@ final class AppPreferences {
     private static let serverEnvironmentKey = "server_environment"
     private static let customServerUrlKey = "custom_server_url"
     private static let customDevEmailKey = "custom_dev_email"
+    private static let developerModeUnlockedKey = "developer_mode_unlocked"
     private static let analyticsEnabledKey = "analytics_enabled"
     private static let installIdKey = "install_id"
     private static let playerControlsStyleKey = "player_controls_style"
@@ -52,6 +53,12 @@ final class AppPreferences {
     /// Email for dev token endpoint on custom server.
     var customDevEmail: String {
         didSet { UserDefaults.standard.set(customDevEmail, forKey: Self.customDevEmailKey) }
+    }
+
+    /// Gates the Developer settings screen behind 7 taps on the version footer,
+    /// matching Android. Persisted so it survives relaunch once unlocked.
+    var developerModeUnlocked: Bool {
+        didSet { UserDefaults.standard.set(developerModeUnlocked, forKey: Self.developerModeUnlockedKey) }
     }
 
     /// Backward-compatible computed property for auth key namespacing.
@@ -235,6 +242,7 @@ final class AppPreferences {
         includeShowsWithoutRecordings = UserDefaults.standard.bool(forKey: Self.includeShowsWithoutRecordingsKey)
         customServerUrl = UserDefaults.standard.string(forKey: Self.customServerUrlKey) ?? ""
         customDevEmail = UserDefaults.standard.string(forKey: Self.customDevEmailKey) ?? ""
+        developerModeUnlocked = UserDefaults.standard.bool(forKey: Self.developerModeUnlockedKey)
         // Migrate: read new key first, fall back to legacy beta mode keys
         if let env = UserDefaults.standard.string(forKey: Self.serverEnvironmentKey) {
             serverEnvironment = env

--- a/iosApp/deadly/Core/Service/AppPreferences.swift
+++ b/iosApp/deadly/Core/Service/AppPreferences.swift
@@ -243,13 +243,22 @@ final class AppPreferences {
         customServerUrl = UserDefaults.standard.string(forKey: Self.customServerUrlKey) ?? ""
         customDevEmail = UserDefaults.standard.string(forKey: Self.customDevEmailKey) ?? ""
         developerModeUnlocked = UserDefaults.standard.bool(forKey: Self.developerModeUnlockedKey)
-        // Migrate: read new key first, fall back to legacy beta mode keys
+        // Migrate: read new key first, fall back to legacy beta mode keys.
+        // Fresh installs with no explicit choice default to "custom" in DEBUG
+        // builds so dev devices never report to prod (analytics, etc.) until a
+        // server is picked in Developer settings; release builds default to prod.
         if let env = UserDefaults.standard.string(forKey: Self.serverEnvironmentKey) {
             serverEnvironment = env
         } else if UserDefaults.standard.object(forKey: Self.useBetaModeKey) != nil {
             serverEnvironment = UserDefaults.standard.bool(forKey: Self.useBetaModeKey) ? "beta" : "prod"
+        } else if UserDefaults.standard.bool(forKey: Self.useBetaShareLinksKey) {
+            serverEnvironment = "beta"
         } else {
-            serverEnvironment = UserDefaults.standard.bool(forKey: Self.useBetaShareLinksKey) ? "beta" : "prod"
+            #if DEBUG
+            serverEnvironment = "custom"
+            #else
+            serverEnvironment = "prod"
+            #endif
         }
         forceOnline = UserDefaults.standard.bool(forKey: Self.forceOnlineKey)
         localBackfilledV1 = UserDefaults.standard.bool(forKey: Self.localBackfilledV1Key)

--- a/iosApp/deadly/Core/Service/AppPreferences.swift
+++ b/iosApp/deadly/Core/Service/AppPreferences.swift
@@ -217,7 +217,11 @@ final class AppPreferences {
     init() {
         UserDefaults.standard.register(defaults: [
             Self.includeShowsWithoutRecordingsKey: false,
-            Self.useBetaModeKey: false,
+            // NB: use_beta_mode is intentionally NOT registered. The server-env
+            // migration below checks `object(forKey:) != nil` to detect a legacy
+            // user who explicitly chose beta; a registered default would make
+            // that check always non-nil, defeating the DEBUG→"custom" fresh
+            // default (mirrors Android's prefs.contains() semantics).
             Self.forceOnlineKey: false,
             Self.localBackfilledV1Key: false,
             Self.localBackfilledV2Key: false,

--- a/iosApp/deadly/Feature/Settings/SettingsScreen.swift
+++ b/iosApp/deadly/Feature/Settings/SettingsScreen.swift
@@ -16,9 +16,26 @@ struct SettingsScreen: View {
     var onNavigateToDownloads: (() -> Void)? = nil
     var onNavigateToEqualizer: (() -> Void)? = nil
     @Environment(\.openURL) private var openURL
+    @Environment(\.appContainer) private var container
+    // Reset to 0 whenever the unlock state flips, mirroring Android.
+    @State private var versionTapCount = 0
 
     private var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+    }
+
+    /// Tap the version footer 7× to reveal the Developer screen, matching
+    /// Android. Shows a toast countdown over the last few taps.
+    private func tapVersion() {
+        guard !container.appPreferences.developerModeUnlocked else { return }
+        versionTapCount += 1
+        let remaining = 7 - versionTapCount
+        if remaining <= 0 {
+            container.appPreferences.developerModeUnlocked = true
+            container.toastPresenter.show("Developer mode enabled")
+        } else if remaining <= 3 {
+            container.toastPresenter.show("\(remaining) tap\(remaining == 1 ? "" : "s") to enable developer mode")
+        }
     }
 
     var body: some View {
@@ -72,15 +89,23 @@ struct SettingsScreen: View {
                 NavigationLink("Privacy & Data") {
                     PrivacyDataView()
                 }
-                NavigationLink("Developer") {
-                    DeveloperView()
+                if container.appPreferences.developerModeUnlocked {
+                    NavigationLink("Developer") {
+                        DeveloperView()
+                    }
                 }
             }
 
             // Version footer — kept on the root so the build is always visible at
-            // a glance, with Release Notes one tap below it.
+            // a glance (and the tap-to-unlock developer mode stays reachable),
+            // with Release Notes one tap below it.
             Section {
-                LabeledContent("Version", value: appVersion)
+                Button {
+                    tapVersion()
+                } label: {
+                    LabeledContent("Version", value: appVersion)
+                }
+                .buttonStyle(.plain)
                 Button {
                     let urlString = "https://github.com/ds17f/deadly-monorepo/releases/tag/ios%2Fv\(appVersion)"
                     if let url = URL(string: urlString) { openURL(url) }


### PR DESCRIPTION
## Why

Creating/removing dev devices was polluting **prod** analytics: each fresh install gets a new `installId`, and debug builds defaulted to the prod server, so every new device counted as a prod install.

## What

Two changes, both scoped so release/TestFlight/App Store builds are **unchanged**:

1. **Default debug builds to the `custom` server** (`feat(mobile/settings): default debug builds to custom server`)
   - Fresh installs with no explicit server choice default to `"custom"` in debug builds, `"prod"` in release.
   - iOS: `#if DEBUG`. Android: `ApplicationInfo.FLAG_DEBUGGABLE` (no gradle/buildConfig plumbing needed).
   - A new dev install starts on the blank custom server → all server traffic (analytics, auth, trending, etc.) fails soft (verified: base-URL force-unwraps stay non-nil with an empty base, no crash) and **never reaches prod**.
   - The persisted in-app Developer toggle flips it back to prod (or to a real URL) without a rebuild.

2. **Gate the iOS Developer screen behind 7 version taps** (`feat(ios/settings): gate Developer screen behind 7 version taps`)
   - Matches Android, which already gated it. iOS previously showed the Developer link unconditionally.
   - New persisted `developerModeUnlocked` pref (same `developer_mode_unlocked` key Android uses); toast counts down over the last 3 taps.

## Verification

- iOS: clean compile via `make ios-build` (debug simulator).
- Android: `:core:database:compileDebugKotlin` clean.

## Notes / behavior to expect

- Affects **existing** debug installs too: any dev install that never explicitly picked a server flips to custom/blank on next launch (offline until a server is chosen). Reversible in Developer settings.
- Not yet device-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)