### PR TITLE
fix(web/admin): keep Connect WS off admin routes

### DIFF
--- a/ui/src/components/connect/ConnectProvider.tsx
+++ b/ui/src/components/connect/ConnectProvider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
+import { usePathname } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { ConnectContext } from "@/contexts/ConnectContext";
 import type { LocalPlaybackSnapshot } from "@/contexts/ConnectContext";
@@ -55,6 +56,12 @@ export default function ConnectProvider({
   children: React.ReactNode;
 }) {
   const { user, isLoading } = useAuth();
+  // Admin pages are a back-office dashboard, not a playback surface — keep the
+  // Connect WS (heartbeat, ownership lease, reconnect loop) out of them so an
+  // admin session never registers as a device. Pathname-gated, so navigating
+  // in tears the socket down and navigating back out re-opens it.
+  const pathname = usePathname();
+  const onAdmin = pathname?.startsWith("/admin") ?? false;
   const [devices, setDevices] = useState<ConnectDevice[]>([]);
   const [connectState, setConnectState] = useState<ConnectState | null>(null);
   const [myDeviceId, setMyDeviceId] = useState<string | null>(null);
@@ -328,13 +335,13 @@ export default function ConnectProvider({
   useEffect(() => {
     if (isLoading) return;
 
-    if (user) {
+    if (user && !onAdmin) {
       log(`User authenticated, starting connect`);
       shouldConnectRef.current = true;
       reconnectAttemptRef.current = 0;
       connect();
     } else {
-      log(`No user, disconnecting`);
+      log(onAdmin ? `On admin route, disconnecting` : `No user, disconnecting`);
       disconnect();
     }
 
@@ -342,7 +349,7 @@ export default function ConnectProvider({
       disconnect();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user, isLoading]);
+  }, [user, isLoading, onAdmin]);
 
   return (
     <ConnectContext.Provider value={{ devices, state: connectState, myDeviceId, connected, sendCommand, activeDeviceVolume, onVolumeMessage, reportVolume, setLocalPlaybackSource, serverTimeOffsetMs }}>


### PR DESCRIPTION
## What

Admin pages (`/admin/*`) no longer open the Connect WebSocket.

Admin is a back-office dashboard, not a playback surface, but it still inherited the global `ConnectProvider` from the root layout — so visiting admin opened the Connect WS (heartbeat, ownership lease, reconnect loop) and registered the admin session as a phantom Connect device in the device list.

## How

Gate the connect effect in `ConnectProvider` on the pathname:

- `usePathname()` → `onAdmin = pathname.startsWith("/admin")`
- Connect only when `user && !onAdmin`
- `onAdmin` added to the effect deps, so the transition is clean both ways: navigating **into** `/admin` tears the socket down via the existing `disconnect()` path; navigating back **out** re-opens it.

No new teardown logic — it reuses the existing disconnect, so heartbeat/reconnect/lease all stop together.

### Why guard, not a structural removal
A route-group refactor (moving player providers out of the root layout) would remove the coupling entirely, but it's a medium mechanical change touching ~9 route folders. Since admin is single-user and the guard is 3 small hunks in one file, we took the lightweight path deliberately. Tradeoff noted: this is a pathname exception rather than a structural boundary.

## Test

`npm run build` → compiled successfully, all 4648 static pages generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)