### PR TITLE
feat(mobile/layout): tablet & landscape three-pane layout with contextual side player

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 .PHONY: android-build-release android-build-bundle android-deploy-testing
 .PHONY: android-promote-alpha android-promote-beta android-promote-production
 .PHONY: ios-build-release ios-deploy-testflight ios-promote
-.PHONY: remote-sync ios-remote-unlock ios-remote-build ios-remote-install ios-remote-sim ios-remote-test ios-remote-resolve
+.PHONY: remote-sync ios-remote-unlock ios-remote-build ios-remote-install ios-remote-sim ios-remote-sim-ipad ios-remote-test ios-remote-resolve
 .PHONY: android-remote-build android-remote-install
 .PHONY: android-remote-emulator android-remote-emu-list android-remote-emu-stop android-remote-run-emulator
 .PHONY: android-auto-dhu android-remote-auto-dhu
@@ -256,7 +256,8 @@ help:
 	@echo "  ios-remote-unlock    - Unlock Mac keychain for SSH code signing (once per reboot)"
 	@echo "  ios-remote-build     - Build debug on Mac simulator"
 	@echo "  ios-remote-install   - Build + install to connected device"
-	@echo "  ios-remote-sim       - Build + run on iPhone 17 simulator"
+	@echo "  ios-remote-sim       - Build + run on simulator (default iPhone 17; override IOS_SIM=\"iPad Pro 11-inch (M4)\")"
+	@echo "  ios-remote-sim-ipad  - Build + run on the iPad simulator (override IPAD_SIM=...)"
 	@echo "  ios-remote-test      - Run tests on Mac simulator"
 	@echo "  ios-remote-resolve   - Resolve SPM package dependencies"
 	@echo ""
@@ -457,6 +458,10 @@ REMOTE_PATH    ?= ~/Developer/ai/claude-personal/container-home/workspace/Develo
 REMOTE_IOS     ?= $(REMOTE_PATH)/iosApp
 REMOTE_ANDROID ?= $(REMOTE_PATH)/androidApp
 
+# Simulator device for the *-sim targets. Override to run on an iPad, e.g.
+#   make ios-remote-sim IOS_SIM="iPad Pro 11-inch (M4)"
+IOS_SIM        ?= iPhone 17
+
 # Sync working tree to Mac (rsync, excludes build artifacts).
 # Chained from every Linux→Mac build target so edits land on the Mac before
 # xcodebuild/gradle runs there.
@@ -511,10 +516,29 @@ ios-remote-install: remote-sync
 
 # Build + launch on iPhone 17 simulator
 ios-remote-sim: remote-sync
-	@echo "Building for simulator on $(REMOTE_HOST)..."
-	@ssh $(REMOTE_HOST) "cd $(REMOTE_IOS) && xcodebuild -project deadly.xcodeproj -scheme deadly -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' build 2>&1 | tail -20"
-	@echo "Launching on simulator..."
-	@ssh $(REMOTE_HOST) 'APP_PATH=$$(cd $(REMOTE_IOS) && xcodebuild -project deadly.xcodeproj -scheme deadly -configuration Debug -destination "platform=iOS Simulator,name=iPhone 17" -showBuildSettings 2>/dev/null | grep " BUILT_PRODUCTS_DIR" | head -1 | awk "{print \$$3}")/deadly.app && xcrun simctl boot "iPhone 17" 2>/dev/null; xcrun simctl install booted "$$APP_PATH" && xcrun simctl launch booted com.grateful.deadly && open -a Simulator'
+	@echo "Building for simulator ($(IOS_SIM)) on $(REMOTE_HOST)..."
+	@ssh $(REMOTE_HOST) "cd $(REMOTE_IOS) && xcodebuild -project deadly.xcodeproj -scheme deadly -configuration Debug -destination 'platform=iOS Simulator,name=$(IOS_SIM)' build 2>&1 | tail -20"
+	@echo "Launching on simulator ($(IOS_SIM))..."
+	@# Resolve the device's UDID and target it explicitly — "booted" is ambiguous
+	@# when more than one simulator is running (e.g. a stale iPhone), which would
+	@# install/launch on the wrong device. BUILT_PRODUCTS_DIR is identical for every
+	@# simulator device (Debug-iphonesimulator), so grab the most recently built .app
+	@# rather than asking -showBuildSettings, which emits nothing on stdout for a
+	@# -destination name= it has to resolve.
+	@ssh $(REMOTE_HOST) 'set -e; \
+		DEV_ID=$$(xcrun simctl list devices available | grep -F "$(IOS_SIM) (" | head -1 | grep -oiE "[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}"); \
+		if [ -z "$$DEV_ID" ]; then echo "No available simulator named: $(IOS_SIM)"; exit 1; fi; \
+		APP_PATH=$$(ls -dt ~/Library/Developer/Xcode/DerivedData/deadly-*/Build/Products/Debug-iphonesimulator/deadly.app 2>/dev/null | head -1); \
+		xcrun simctl boot "$$DEV_ID" 2>/dev/null || true; \
+		xcrun simctl install "$$DEV_ID" "$$APP_PATH"; \
+		xcrun simctl launch "$$DEV_ID" com.grateful.deadly; \
+		open -a Simulator'
+
+# Build + run on the iPad simulator (wide/tablet layout). Thin wrapper over
+# ios-remote-sim with an iPad device. Override IPAD_SIM for a different iPad.
+IPAD_SIM ?= iPad Pro 11-inch (M4)
+ios-remote-sim-ipad:
+	@$(MAKE) ios-remote-sim IOS_SIM="$(IPAD_SIM)"
 
 # Run tests on Mac simulator
 ios-remote-test: remote-sync

--- a/Makefile
+++ b/Makefile
@@ -491,7 +491,7 @@ remote-sync:
 # Build debug on Mac
 ios-remote-build: remote-sync
 	@echo "Building on $(REMOTE_HOST)..."
-	@ssh $(REMOTE_HOST) "cd $(REMOTE_IOS) && xcodebuild -project deadly.xcodeproj -scheme deadly -configuration Debug -destination 'generic/platform=iOS Simulator' build 2>&1 | tail -20"
+	@ssh $(REMOTE_HOST) "set -o pipefail; cd $(REMOTE_IOS) && xcodebuild -project deadly.xcodeproj -scheme deadly -configuration Debug -destination 'generic/platform=iOS Simulator' build 2>&1 | tail -20"
 
 # Unlock the Mac's login keychain (required once per reboot for SSH code signing)
 ios-remote-unlock:
@@ -507,7 +507,7 @@ ios-remote-unlock:
 ios-remote-install: remote-sync
 	@if [ -z "$$KEYCHAIN_PASSWORD" ]; then echo "KEYCHAIN_PASSWORD env var must be set." >&2; exit 1; fi
 	@echo "Building on $(REMOTE_HOST)..."
-	@printf '%s\n' "$$KEYCHAIN_PASSWORD" | ssh $(REMOTE_HOST) "IFS= read -r PASS; \
+	@printf '%s\n' "$$KEYCHAIN_PASSWORD" | ssh $(REMOTE_HOST) "set -o pipefail; IFS= read -r PASS; \
 		security unlock-keychain -p \"\$$PASS\" ~/Library/Keychains/login.keychain-db && \
 		unset PASS && \
 		cd $(REMOTE_IOS) && xcodebuild -project deadly.xcodeproj -scheme deadly -configuration Debug -destination 'generic/platform=iOS' -allowProvisioningUpdates build 2>&1 | tail -20"
@@ -516,8 +516,12 @@ ios-remote-install: remote-sync
 
 # Build + launch on iPhone 17 simulator
 ios-remote-sim: remote-sync
-	@echo "Building for simulator ($(IOS_SIM)) on $(REMOTE_HOST)..."
-	@ssh $(REMOTE_HOST) "cd $(REMOTE_IOS) && xcodebuild -project deadly.xcodeproj -scheme deadly -configuration Debug -destination 'platform=iOS Simulator,name=$(IOS_SIM)' build 2>&1 | tail -20"
+	@echo "Building for simulator on $(REMOTE_HOST)..."
+	@# Build with a GENERIC simulator destination, not `name=$(IOS_SIM)`: the
+	@# named form fails to resolve on this Mac (errors to a visionOS placeholder
+	@# and produces no .app). `set -o pipefail` so a build failure piped through
+	@# `tail` actually fails the recipe instead of masking as exit 0.
+	@ssh $(REMOTE_HOST) "set -o pipefail; cd $(REMOTE_IOS) && xcodebuild -project deadly.xcodeproj -scheme deadly -configuration Debug -destination 'generic/platform=iOS Simulator' build 2>&1 | tail -20"
 	@echo "Launching on simulator ($(IOS_SIM))..."
 	@# Resolve the device's UDID and target it explicitly — "booted" is ambiguous
 	@# when more than one simulator is running (e.g. a stale iPhone), which would
@@ -529,6 +533,7 @@ ios-remote-sim: remote-sync
 		DEV_ID=$$(xcrun simctl list devices available | grep -F "$(IOS_SIM) (" | head -1 | grep -oiE "[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}"); \
 		if [ -z "$$DEV_ID" ]; then echo "No available simulator named: $(IOS_SIM)"; exit 1; fi; \
 		APP_PATH=$$(ls -dt ~/Library/Developer/Xcode/DerivedData/deadly-*/Build/Products/Debug-iphonesimulator/deadly.app 2>/dev/null | head -1); \
+		if [ -z "$$APP_PATH" ] || [ ! -d "$$APP_PATH" ]; then echo "No deadly.app found — build did not produce output; refusing to install a stale app."; exit 1; fi; \
 		xcrun simctl boot "$$DEV_ID" 2>/dev/null || true; \
 		xcrun simctl install "$$DEV_ID" "$$APP_PATH"; \
 		xcrun simctl launch "$$DEV_ID" com.grateful.deadly; \

--- a/PLANS/tablet-landscape-layouts.md
+++ b/PLANS/tablet-landscape-layouts.md
@@ -1,223 +1,167 @@
-# Tablet + Landscape Layouts (Responsive Native) — Full Master-Detail
+# Landscape & Tablet Layouts — Icon Rail + Contextual Side Player
 
-> **Status (2026-06-12): PROPOSED — NOT ACCEPTED. Needs review.** This is a
-> draft design captured as a starting point for discussion, **not** an approved
-> plan and **not** something to build or ship as-is. The scope here (full
-> master-detail on both platforms) is one option on the table, not a decision.
-> Treat every "Decision" / "user-confirmed" note below as a *proposal* to be
-> re-litigated, not settled. No code has been written; nothing in `iosApp/` or
-> `androidApp/` has changed. **Do not start implementation off this doc** until
-> the approach is reviewed and explicitly accepted.
->
-> Open questions to resolve before this is actionable:
-> - Is full master-detail the right ambition, or is adaptive chrome (bars→rail)
->   enough for a first pass?
-> - Is the effort justified vs. other roadmap items?
-> - Does the three-tier breakpoint model hold up on real devices?
->
-> - Roadmap item: [`ROADMAP.md`](ROADMAP.md) §6 "Tablet + landscape layouts"
-> - The original worktree/branch (`worktree-tablet-landscape-layouts`) has been
->   removed; this doc was rescued from it and committed to `main` for review.
+> **Status (2026-06-13): ACCEPTED — building.** Branch `tablet-landscape-layouts`.
+> This replaces the earlier "full master-detail" draft, which was discarded.
+> Roadmap: [`ROADMAP.md`](ROADMAP.md) §6.
 
-## Context
+## The problem
 
-Both native apps render a **stretched phone UI** when wide: iOS is **iPhone-only**
-(`TARGETED_DEVICE_FAMILY = 1`, iPad runs in compat scaling); Android has **zero**
-window-size-class adaptivity (it rotates, just stretched). The web shell already
-solved the shape — persistent left **nav rail** · **content (master list)** ·
-contextual **right rail**, collapsing to a bottom tab bar when narrow
-(`ui/src/components/shell/AppShell.tsx` + `RightRail.tsx`).
+Both apps render a **stretched phone UI** when wide. Rotate a phone today and it
+falls apart: the bottom tab bar eats ~1/5 of the (now short) height with 4 buttons
+spread across it; the mini-player sits on top of content and clips it (Home's
+second Recents row gets cut off); every list is one absurdly-wide column. iOS is
+iPhone-only (`TARGETED_DEVICE_FAMILY = 1`, iPad runs scaled); Android has no
+window-size-class adaptivity. Spotify dodges this by **locking to portrait** —
+that's the industry floor and our safety net, but we can do better.
 
-Decision (user-confirmed): **go the distance — full master-detail**, both
-platforms, in this worktree. Not just adaptive chrome (bars→rail): the **content
-itself becomes multi-pane** on wide screens. Tapping a show in a list opens it in
-a **detail pane beside the list** (not a full-screen push), with a **contextual
-right pane** (recordings / setlist / reviews) — the iPad Mail / web-shell model.
-Width-driven so it covers tablet portrait *and* landscape from one mechanism. The
-phone (compact) experience must stay **byte-for-byte today's**.
+## The design — one rule, three zones
 
-## Breakpoint model (THREE tiers — not width-binary)
-
-Triggering full master-detail on raw width is wrong: a **phone in landscape is
-wide but short**, so 3 panes would squish to ~300pt each with no height. Gate on
-*room for two real panes*, which is a three-tier model:
-
-| Tier | Devices | Layout |
-|---|---|---|
-| **Compact** | phones portrait; most phones landscape | **Today's UI** — bottom bar, full-width content, tap-to-push. Unchanged. |
-| **Medium** (~600–840dp) | big phones landscape, small tablets portrait, foldables | **Nav rail + single content pane.** Rail replaces bottom bar; content stays one column; selecting a show pushes/replaces full-width. **No side-by-side.** |
-| **Expanded** (≥840dp) | tablets landscape, large tablets | **Full master-detail** — rail · list · detail (· context). |
+**Rule:** key off **width**, never device model. Narrow → today's UI, byte-for-byte
+unchanged. Wide → a three-zone layout:
 
 ```
-Expanded (≥840dp)                         Medium (phone landscape / small tablet)
-┌────┬──────────┬──────────┬──────────┐   ┌────┬───────────────────────────────┐
-│nav │ master   │ detail   │ context  │   │nav │ single content pane           │
-│rail│ (list)   │(ShowDet/ │(recs/    │   │rail│ (list; show pushes full-width)│
-│    │          │ playlist)│ setlist) │   │    │                               │
-└────┴──────────┴──────────┴──────────┘   └────┴───────────────────────────────┘
-Compact (phone portrait / normal phone landscape): unchanged — bottom bar + push.
+WIDE (phone landscape, tablets)              NARROW (phone portrait) — unchanged
+┌──┬─────────────────────┬──────────┐        ┌─────────────────────┐
+│⌂ │  current screen      │  player  │        │  current screen     │
+│🔍│  (full height)       │  (side)  │        │                     │
+│♥ │                     │  ▶Ⅱ      │        ├─────────────────────┤
+│▦ │                     │          │        │ ▢ Title        ▶Ⅱ ⏭ │ mini
+└──┴─────────────────────┴──────────┘        ├──┬──┬──┬──┬─────────┤
+ icon rail   browse content   side player    │⌂ │🔍│♥ │▦ │         │ bottom bar
 ```
 
-**Why this avoids the squish.** *iOS:* key off `horizontalSizeClass`, NOT raw
-points — Apple reports a normal iPhone in landscape as **compact**, so it keeps
-the phone UI for free; only Plus/Max phones report `.regular` in landscape (they
-have the room), and iPads are always regular. *Android:* `ListDetailPaneScaffold`'s
-default adaptive directive shows **two panes only at Expanded** on its own, so
-Medium (phone landscape) stays single-pane automatically — the dual pane can't
-appear below ~840dp.
+- **Icon-only nav rail (left).** The bottom tab bar stood up vertically, labels
+  dropped → thin. Reclaims the wasted vertical height. **Global** — fixes every
+  screen at once. Cheapest, safest piece; ships alone.
+- **Center = the current screen, full height.** With the rail and player off to
+  the sides, content stops being clipped by the mini-player.
+- **Side player (right) — contextual.** Appears **only when something is playing**;
+  idle, the center takes full width (no empty column). See player sizes below.
 
----
+Because the trigger is **width**, this same layout covers **tablets for free** —
+a tablet is just a roomier wide screen. The only tablet-specific work is one line
+on iOS (`TARGETED_DEVICE_FAMILY = 1,2`) so iPad renders natively instead of
+pixel-doubling. Android tablets, foldables, and DeX get it with zero extra code.
+"Fix phone landscape" and "support tablets" are the **same work**.
 
-## iOS
+## The player has three sizes (not mini-vs-full)
 
-The big enabler: master rows **already** use `NavigationLink(value: show.id)`
-(`HomeScreen.swift:135…`, `SearchScreen`, `FavoritesScreen:462`). Inside a
-`NavigationSplitView`, a content-column `NavigationLink(value:)` **automatically
-populates the detail column** — so the section screens need minimal change.
+```
+MINI (narrow, today)       SIDE (wide, docked — NEW)   FULL-WIDE (wide expand)
+┌──────────────────┐       ┌──────┬────────┐           ┌──────────────┬──────┐
+│ list             │       │ list │ ▢ art  │           │   big cover  │ ▢art │
+├──────────────────┤       │      │ Title  │           │   ▢▢▢▢▢▢     │ Title│
+│ ▢ Title    ▶Ⅱ ⏭ │       │      │ ──●──  │           │   ▢▢▢▢▢▢     │ ──●─ │
+└──────────────────┘       │      │ ◀ ▶Ⅱ ▶ │           │              │ ◀▶Ⅱ▶ │
+                           └──────┴────────┘           └──────────────┴──────┘
+```
 
-### A. Adaptive root (`iosApp/deadly/App/MainNavigation.swift`)
-- iOS has effectively **two** size-class tiers (compact / regular); the Medium
-  tier is implicit — `NavigationSplitView` self-balances column count by
-  available width (shows the sidebar as an overlay / collapses to 2 columns when
-  cramped, e.g. Plus/Max landscape), so we don't hand-roll a Medium breakpoint.
-- Introduce an `AdaptiveRoot` that branches on `@Environment(\.horizontalSizeClass)`:
-  - **compact** → today's `TabView` (the entire current body), unchanged. (A
-    normal iPhone in landscape is compact → no squish.)
-  - **regular** → a `NavigationSplitView` (three columns):
-    - **sidebar**: nav list of `AppTab` cases + a Settings row, bound to
-      `selectedTab` (reuse the existing `AppTab` enum; the `settingsLogoButton`
-      affordance becomes a sidebar row).
-    - **content**: `switch selectedTab` → `HomeScreen` / `SearchScreen` /
-      `FavoritesScreen` / `CollectionsScreen` (the *same* screens).
-    - **detail**: a `NavigationStack(path:)` declaring
-      `.navigationDestination(for: String.self) { ShowDetailScreen(showId:) }`
-      (and `CollectionRoute`). Reuse the existing per-tab path state
-      (`homeStack`/`searchStack`/…) as the **detail** column's stack.
-- Keep `.miniPlayer(...)` + `.offlineBanner(...)` applied around the split view.
+1. **Mini** — today's bottom strip (narrow only). Art + title + play/pause.
+2. **Side** — a **rotated mini plus a scrubber**: art thumbnail, title, scrubber,
+   transport, stacked vertically in the right column. "More than mini, less than
+   full." **This is the keystone** — it's what makes landscape look designed.
+3. **Full-wide** — expanding the player in landscape does **not** go full-screen.
+   The **big cover + scrubber take over the center** (where the list was); the
+   **controls stay in the right column, identical to side mode**. Collapse →
+   list returns. It's a *mode swap of the center pane*, not a new screen — so
+   full-wide is nearly free once side exists. (No full-screen `fullScreenCover`
+   in landscape.)
 
-### B. Contextual right pane (inspector)
-- Add `.inspector(isPresented: $showInspector)` on the **detail** column showing
-  the show's recordings / setlist / reviews. **Reuse existing sheet bodies** —
-  `RecordingPicker.swift`, `SetlistSheet.swift`, `ReviewDetailsSheet.swift` — as
-  inspector panels instead of sheets when regular width. A detail-toolbar button
-  toggles it. (Compact keeps them as sheets.)
+## Behaviors
 
-### C. Player + content width
-- `PlayerScreen` (`fullScreenCover`): at regular width, present centered with a
-  max content width instead of a stretched full screen.
-- Add a `.readableContentFrame()` helper (`Core/Design`) capping master/detail
-  content width so rails/lists don't stretch; apply to the four section screens
-  and `ShowDetailScreen`.
+- **Tap a show while the side player is docked:** the show opens in the **center**
+  (list → detail, same as today's push). Player stays put on the right. Center =
+  "what I'm browsing," right = "what I'm hearing" — independent, like desktop apps.
+- **Narrow stays exactly today's UX** — bottom bar, mini-player, full-screen player,
+  push navigation. Regression gate: compact is byte-for-byte unchanged.
+- **Portrait-lock is the escape valve.** If a specific screen fights landscape, we
+  can lock just that screen to portrait rather than block the whole feature.
 
-### D. iPad target
-- `iosApp/deadly.xcodeproj/project.pbxproj`: `TARGETED_DEVICE_FAMILY = 1,2`
-  (Debug + Release).
-- `iosApp/Info.plist`: add `UISupportedInterfaceOrientations~ipad` (all four);
-  ensure no `UIRequiresFullScreen` force. iPhone orientations unchanged.
+## Phasing (smallest win first, ship incrementally)
 
----
+1. **Icon rail** when wide — global chrome change. Fixes the wasted-height eyesore
+   on every screen. *Shippable alone.* — **DONE (both platforms, compiles).**
+   Android width ≥600dp; iOS width ≥600pt + iPad target flipped
+   (`TARGETED_DEVICE_FAMILY = 1,2`). Device verification pending.
+2. **Side player** + center reclaiming full height. The real win; landscape now
+   looks intentional. *Shippable here.* — **NEXT.**
+3. **Full-wide expand** (big cover center + controls right). Pure polish; defer
+   until 1–2 feel right on a device.
+4. Per-screen landscape polish (Home rows → grid, artwork sizing, etc.).
 
-## Android
+## Phase 1 notes & follow-ups (device-verified 2026-06-13 — rail works)
 
-Multi-module (`core/design`, `feature/*`). Show detail is the
-`playlist/{showId}` destination (`feature/playlist/.../PlaylistNavigation.kt`),
-reached via `navController.navigateToPlaylist(...)`.
+Observations from the shipped rail, to revisit (most are Phase 2 fodder):
 
-### A. Dependency
-- Add `androidx.compose.material3.adaptive:adaptive`, `:adaptive-layout`,
-  `:adaptive-navigation` (versions matching the project's Compose BOM) to
-  `androidApp/gradle/libs.versions.toml` + the `:app` and `:core:design`
-  `build.gradle.kts`. Provides `currentWindowAdaptiveInfo()`,
-  `NavigableListDetailPaneScaffold`, and `rememberListDetailPaneScaffoldNavigator`.
+- **Toast / overlay positioning is inconsistent across platforms in wide mode.**
+  Android renders the offline banner, auto-advance card, and app toast *inside*
+  the content pane (right of the rail), so they're centered in the content, not
+  the window. iOS attaches those overlays to the full-window `GeometryReader`, so
+  they span the whole width *including over the rail*. Pick one (likely: confine
+  to the content pane on both) when polishing. Low priority — both are legible.
+- **Mini player is still a bottom strip** within the content pane in wide mode
+  (AppScaffold renders it at the bottom). This is exactly what Phase 2's side
+  player replaces — the docked right player supersedes the bottom mini when wide.
+- **Rail has no Settings entry**; Settings is still reached via the logo button in
+  each screen's top toolbar (unchanged from compact). Fine; revisit if the toolbar
+  logo feels out of place in the wide layout.
+- **Rail is visually plain** — icon + selected tint, no active-pill/indicator
+  animation. Cosmetic polish deferred.
+- **iOS rotation compact↔wide** preserves per-tab nav stacks (they're parent
+  `@State`, shared by both layouts) — verified smooth on device.
 
-### B. Nav rail (chrome) in the shared scaffold
-- `androidApp/core/design/.../scaffold/AppScaffold.kt` (the BarConfiguration
-  overload used by `MainNavigation`): add
-  `navigationRailContent: (@Composable () -> Unit)? = null` + `useSideNav: Boolean`.
-  When `useSideNav`, wrap the inner `Box` in
-  `Row { navigationRailContent(); Box { Scaffold … } }`; caller passes
-  `bottomNavigationContent = null`. The existing bottom mini-player `Column`
-  stays (mini-player remains a bottom bar).
-- `androidApp/.../MainNavigation.kt`: compute `useSideNav` from
-  `currentWindowAdaptiveInfo().windowSizeClass` width ≥ **MEDIUM** (~600dp) — so
-  the rail appears at Medium (phone landscape / small tablet) while the **panes
-  do not** (see C: the pane directive gates dual-pane to Expanded). Add a
-  `NavigationRailBar` mirroring the existing private `BottomNavigationBar` /
-  `BottomNavItem`, iterating `BottomNavDestination.destinations`, reusing
-  `onNavigateToDestination` + offline-redirect logic.
+## Platform mechanics
 
-### C. List-detail panes (content)
-- In `MainNavigation.kt`, host the show-browsing flow in
-  `NavigableListDetailPaneScaffold`:
-  - **listPane**: the current top-level NavHost destinations
-    (home/search/favorites/collections) — keep the NavHost for these.
-  - **detailPane**: the existing playlist/show screen composable, hosted in the
-    pane instead of a full-screen route.
-  - **extraPane**: recordings / setlist (contextual rail).
-- Selecting a show calls `scaffoldNavigator.navigateTo(Detail, showId)` instead
-  of `navigateToPlaylist`. Keep the **default** `calculatePaneScaffoldDirective`
-  so dual-pane appears **only at Expanded (≥840dp)**; at Compact/Medium the
-  scaffold is single-pane (selecting a show shows a full-width detail, back
-  returns to the list — today's behavior). The extra (context) pane is gated to
-  Expanded with sufficient room.
-- Keep the existing `playlist/{showId}` NavHost route for **compact** /
-  deep-link / back-compat; the pane scaffold path is the wide one. (Reuse the
-  same screen composable in both — no fork.)
-- The detail pane's recordings/setlist UI already exists in the playlist feature;
-  surface it in the extraPane when expanded.
+### iOS (builds on remote Mac — `make ios-remote-install`)
+- **Width signal:** `GeometryReader` width ≥ 600pt (NOT `horizontalSizeClass`).
+  Decided to gate on width so a **regular iPhone in landscape** — which reports
+  `.compact` — still gets the wide rail (it reads ~844–956pt wide). Portrait
+  phones (~390–430pt) stay below the threshold → today's TabView, unchanged.
+- **Root (`iosApp/deadly/App/MainNavigation.swift`):** branch the body —
+  compact → today's `TabView` unchanged; wide → an `HStack` of [icon rail bound to
+  `selectedTab`] · [the current section screen] · [side player when a track is
+  loaded]. Reuse the existing `AppTab` enum and per-tab `NavigationStack` paths.
+- **Side player:** a new compact player view (reuse `PlayerScreen` subviews /
+  view-model); not the `fullScreenCover`. Full-wide = swap the center for a hero
+  cover view while the side controls persist.
+- **iPad target:** `project.pbxproj` `TARGETED_DEVICE_FAMILY = 1,2` (all 6 configs);
+  `Info.plist` allow all iPad orientations, no `UIRequiresFullScreen` lock.
 
-### D. App already rotates (no manifest orientation lock found) — no change needed.
-
----
-
-## Sequencing (land + verify incrementally)
-1. **Chrome**: iOS sidebar branch + Android `NavigationRail` (the frame).
-2. **iPad target** enablement (iOS) so wide layouts render natively.
-3. **List-detail panes**: iOS `NavigationSplitView` detail column + Android
-   `ListDetailPaneScaffold` — wire one section first (**Search**), then
-   Favorites/Home/Collections.
-4. **Contextual right pane**: iOS `.inspector` + Android `extraPane`
-   (recordings/setlist/reviews — reuse existing UI).
-5. **Player + content width** adaptation.
-6. **Docs**: ADR-0011, this file, ROADMAP §6 status.
-
-## Docs / tracking
-- **ADR-0011** `docs/adr/0011-tablet-landscape-layouts.md` (0010 = unmerged
-  show-queue branch): width-driven master-detail; `NavigationSplitView` +
-  `.inspector` (iOS) and `ListDetailPaneScaffold` (Android); iPad-target
-  enablement; reuse of existing detail/sheet UI; compact path unchanged.
-- This file = handoff/status (mirrors the other `PLANS/*.md`).
-- Update `PLANS/ROADMAP.md` §6 status when phases land.
-
-## Commits (conventional, per repo scope rules)
-- `build(android): add material3-adaptive (window size class + list-detail)`
-- `feat(ios/layout): adaptive split-view master-detail + iPad target (ADR-0011)`
-- `feat(ios/layout): contextual inspector for recordings/setlist/reviews`
-- `feat(android/layout): nav rail + list-detail pane scaffold (ADR-0011)`
-- `feat(android/layout): contextual extra pane for recordings/setlist`
-- `docs(mobile/layout): ADR-0011 + roadmap for tablet/landscape master-detail`
+### Android (builds locally — `make android-install`)
+- **Width signal:** `currentWindowAdaptiveInfo().windowSizeClass` from
+  `androidx.compose.material3.adaptive:adaptive` (add to `libs.versions.toml` +
+  `:app`/`:core:design`). Wide = width ≥ MEDIUM (~600dp).
+- **Icon rail:** extend `core/design/.../scaffold/AppScaffold.kt` with a
+  `navigationRailContent` + `useSideNav` path: when wide, wrap the content in
+  `Row { rail(); content }` and pass `bottomNavigationContent = null`. Add a
+  `NavigationRailBar` mirroring the private `BottomNavigationBar`, iterating
+  `BottomNavDestination.destinations`, icons only.
+- **Side player:** in `MainNavigation.kt`, when wide and a track is loaded, render
+  the side player as the right element of the `Row`. Reuse player feature UI.
+- **Show nav stays the existing `playlist/{showId}` NavHost route** — don't thread
+  pane navigation through feature modules (Collections/Downloads navigate by raw
+  `navController.navigate("playlist/$showId")` strings). Center just hosts the
+  NavHost as today.
+- No manifest orientation lock exists — app already rotates.
 
 ## Verification
-- **Android**: `make android-install` (build locally per repo convention — the
-  remote agent is iOS-only). On a tablet AVD (Pixel Tablet) + phone landscape:
-  confirm rail replaces bottom bar; list+detail side-by-side at Expanded;
-  selecting a show fills the detail pane (not a full-screen push); extra pane
-  shows recordings/setlist; system back collapses panes correctly; mini-player +
-  offline redirect intact. Phone **portrait**: identical to today.
-- **iOS**: `make ios-remote-install` (remote Mac; keychain pw note in memory).
-  iPad simulator (portrait + landscape) + iPhone (portrait + landscape): sidebar
-  at regular width; tapping a show fills the detail column; inspector toggles
-  recordings/setlist/reviews; player centered not stretched. iPhone **portrait**:
-  today's TabView + push nav, unchanged.
-- Regression gate on both: **compact must be byte-for-byte the current UX.**
+- **Android:** `make android-install`; phone landscape + tablet AVD: icon rail
+  replaces bottom bar, content full height (Home second row not clipped), side
+  player appears on play and is gone when idle, tapping a show fills center. Phone
+  **portrait** identical to today.
+- **iOS:** `make ios-remote-install` (keychain pw in memory); iPhone landscape +
+  iPad sim: rail at regular width, side player docks right, no full-screen player
+  in landscape. iPhone **portrait** unchanged.
+- **Regression gate both:** narrow = byte-for-byte today's UX.
 
-## Risk / notes
-- Largest risk is the **content restructure** (panes), not the chrome. Mitigated
-  by keeping compact on the existing code paths and reusing the same screen
-  composables/views in both modes (no forks).
-- iOS: `NavigationLink(value:)` driving the split-view detail column is the
-  load-bearing assumption — **verify early on one section** before fanning out.
-- Android: hosting the playlist screen in both a NavHost route (compact) and a
-  pane (wide) — keep it one composable to avoid divergence.
-- Worktree build gotchas (per memory): copy gitignored `Secrets.swift` for iOS;
-  older Makefile may use bare `gradle` — run `./gradlew` directly if so.
+## Docs / tracking
+- ADR-0011 `docs/adr/0011-landscape-tablet-layouts.md`: width-driven icon rail +
+  contextual side player + three player sizes; iPad target enablement; compact
+  unchanged; portrait-lock fallback.
+- Update `PLANS/ROADMAP.md` §6 status as phases land.
+
+## Commits (conventional, per repo scope rules)
+- `feat(android/layout): icon nav rail when wide`
+- `feat(ios/layout): icon nav rail + iPad target when wide`
+- `feat(mobile/player): contextual side player in landscape`
+- `docs(mobile/layout): ADR-0011 landscape + tablet layouts`

--- a/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.filled.WifiOff
 import androidx.activity.compose.BackHandler
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -239,80 +240,26 @@ fun MainNavigation(
         }
     )
 
-    BackHandler(enabled = drawerState.isOpen) {
-        scope.launch { drawerState.close() }
+    // Landscape/tablet: when the window is wide, the bottom tab bar (which eats
+    // ~1/5 of the short landscape height) is replaced by a vertical icon-only
+    // nav rail on the left. Keyed off width, not device — so phone landscape,
+    // tablets, foldables and DeX all get it. Narrow stays today's bottom bar.
+    val isWide = LocalConfiguration.current.screenWidthDp >= WIDE_BREAKPOINT_DP
+    val useSideNav = isWide && barConfig.bottomBar?.visible == true
+
+    // Shared tab-navigation action used by both the bottom bar and the rail.
+    val onNavigateToDestination: (String) -> Unit = { route ->
+        val target = if (isOffline && route != "downloads") "downloads" else route
+        navController.navigate(target) {
+            popUpTo(navController.graph.startDestinationId) { saveState = true }
+            launchSingleTop = true
+            restoreState = true
+        }
     }
 
-    ModalNavigationDrawer(
-        drawerState = drawerState,
-        gesturesEnabled = drawerState.isOpen,
-        drawerContent = {
-            ModalDrawerSheet {
-                SettingsScreen(
-                    onNavigateToDownloads = {
-                        scope.launch { drawerState.close() }
-                        navController.navigate("downloads")
-                    },
-                    onNavigateToEqualizer = {
-                        scope.launch { drawerState.close() }
-                        navController.navigate("equalizer")
-                    },
-                    onNavigateToLegal = {
-                        scope.launch { drawerState.close() }
-                        navController.navigate("legal")
-                    },
-                    onNavigateToMission = {
-                        scope.launch { drawerState.close() }
-                        navController.navigate("mission")
-                    },
-                    onNavigateToDeveloper = {
-                        scope.launch { drawerState.close() }
-                        navController.navigate("developer")
-                    },
-                    onNavigateToPrivacyData = {
-                        scope.launch { drawerState.close() }
-                        navController.navigate("privacy_data")
-                    },
-                    onNavigateToConnect = {
-                        scope.launch { drawerState.close() }
-                        navController.navigate(CONNECT_ROUTE)
-                    }
-                )
-            }
-        }
-    ) {
-    AppScaffold(
-        topBarConfig = augmentedTopBar,
-        bottomBarConfig = barConfig.bottomBar,
-        bottomNavigationContent = if (barConfig.bottomBar?.visible == true) {
-            {
-                BottomNavigationBar(
-                    currentRoute = currentRoute,
-                    onNavigateToDestination = { route ->
-                        val target = if (isOffline && route != "downloads") "downloads" else route
-                        navController.navigate(target) {
-                            popUpTo(navController.graph.startDestinationId) { saveState = true }
-                            launchSingleTop = true
-                            restoreState = true
-                        }
-                    }
-                )
-            }
-        } else null,
-        miniPlayerConfig = barConfig.miniPlayer,
-        miniPlayerContent = {
-            MiniPlayerScreen(
-                onTapToExpand = { _ ->
-                    Log.d("MainNavigation", "MiniPlayer tapped - navigating to player")
-                    navController.navigate("player")
-                }
-            )
-        },
-        onNavigationClick = {
-            navController.popBackStack()
-        },
-        snackbarHostState = snackbarHostState
-    ) { paddingValues ->
+    // Defined outside the wide-layout Row below so RowScope doesn't leak into
+    // the overlay AnimatedVisibility calls (which need the top-level overload).
+    val scaffoldContent: @Composable (PaddingValues) -> Unit = { paddingValues ->
         Box(modifier = Modifier.fillMaxSize()) {
             val autoAdvanceCountdown by appViewModel.autoAdvanceCountdown.collectAsState()
 
@@ -416,6 +363,85 @@ fun MainNavigation(
             }
         }
     }
+
+    BackHandler(enabled = drawerState.isOpen) {
+        scope.launch { drawerState.close() }
+    }
+
+    ModalNavigationDrawer(
+        drawerState = drawerState,
+        gesturesEnabled = drawerState.isOpen,
+        drawerContent = {
+            ModalDrawerSheet {
+                SettingsScreen(
+                    onNavigateToDownloads = {
+                        scope.launch { drawerState.close() }
+                        navController.navigate("downloads")
+                    },
+                    onNavigateToEqualizer = {
+                        scope.launch { drawerState.close() }
+                        navController.navigate("equalizer")
+                    },
+                    onNavigateToLegal = {
+                        scope.launch { drawerState.close() }
+                        navController.navigate("legal")
+                    },
+                    onNavigateToMission = {
+                        scope.launch { drawerState.close() }
+                        navController.navigate("mission")
+                    },
+                    onNavigateToDeveloper = {
+                        scope.launch { drawerState.close() }
+                        navController.navigate("developer")
+                    },
+                    onNavigateToPrivacyData = {
+                        scope.launch { drawerState.close() }
+                        navController.navigate("privacy_data")
+                    },
+                    onNavigateToConnect = {
+                        scope.launch { drawerState.close() }
+                        navController.navigate(CONNECT_ROUTE)
+                    }
+                )
+            }
+        }
+    ) {
+    Row(modifier = Modifier.fillMaxSize()) {
+        if (useSideNav) {
+            NavigationRailBar(
+                currentRoute = currentRoute,
+                onNavigateToDestination = onNavigateToDestination
+            )
+        }
+    AppScaffold(
+        modifier = Modifier.weight(1f),
+        topBarConfig = augmentedTopBar,
+        bottomBarConfig = barConfig.bottomBar,
+        bottomNavigationContent = if (!useSideNav && barConfig.bottomBar?.visible == true) {
+            {
+                BottomNavigationBar(
+                    currentRoute = currentRoute,
+                    onNavigateToDestination = onNavigateToDestination
+                )
+            }
+        } else null,
+        miniPlayerConfig = barConfig.miniPlayer,
+        miniPlayerContent = {
+            MiniPlayerScreen(
+                onTapToExpand = { _ ->
+                    Log.d("MainNavigation", "MiniPlayer tapped - navigating to player")
+                    navController.navigate("player")
+                }
+            )
+        },
+        onNavigationClick = {
+            navController.popBackStack()
+        },
+        snackbarHostState = snackbarHostState
+    ) { paddingValues ->
+        scaffoldContent(paddingValues)
+    }
+    } // Row
     } // ModalNavigationDrawer
 
     // ── In-App Review ────────────────────────────────────────────────
@@ -524,6 +550,74 @@ private fun OfflineBanner() {
             text = "Offline mode",
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+/** Width (dp) at/above which the bottom tab bar becomes a left icon rail. */
+private const val WIDE_BREAKPOINT_DP = 600
+
+/**
+ * Vertical icon-only navigation rail — the wide-layout replacement for the
+ * bottom bar (phone landscape, tablets). Mirrors [BottomNavigationBar]'s
+ * destinations and selection logic; drops the labels to stay thin and to
+ * reclaim the vertical height the bottom bar wastes in landscape.
+ */
+@Composable
+private fun NavigationRailBar(
+    currentRoute: String?,
+    onNavigateToDestination: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier.fillMaxHeight(),
+        color = MaterialTheme.colorScheme.surface,
+        shadowElevation = 8.dp
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxHeight()
+                .systemBarsPadding()
+                .padding(vertical = 12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically)
+        ) {
+            BottomNavDestination.destinations.forEach { destination ->
+                NavigationRailItem(
+                    destination = destination,
+                    isSelected = currentRoute == destination.route,
+                    onClick = { onNavigateToDestination(destination.route) }
+                )
+            }
+        }
+    }
+}
+
+/** Individual icon-only rail item. */
+@Composable
+private fun NavigationRailItem(
+    destination: BottomNavDestination,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    val contentColor = if (isSelected) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+    }
+
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .clickable { onClick() }
+            .padding(12.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            painter = if (isSelected) destination.selectedIcon() else destination.unselectedIcon(),
+            contentDescription = destination.title,
+            tint = contentColor,
+            modifier = Modifier.size(24.dp)
         )
     }
 }

--- a/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
@@ -57,6 +57,7 @@ import com.grateful.deadly.feature.playlist.navigation.playlistGraph
 import com.grateful.deadly.feature.playlist.navigation.navigateToPlaylist
 import com.grateful.deadly.feature.player.navigation.playerScreen
 import com.grateful.deadly.feature.player.navigation.PLAYER_ROUTE
+import com.grateful.deadly.feature.player.screens.main.PlayerSidePanel
 import com.grateful.deadly.feature.miniplayer.screens.main.MiniPlayerScreen
 import com.grateful.deadly.feature.favorites.navigation.favoritesNavigation
 import com.grateful.deadly.feature.collections.navigation.collectionsGraph
@@ -246,6 +247,9 @@ fun MainNavigation(
     // tablets, foldables and DeX all get it. Narrow stays today's bottom bar.
     val isWide = LocalConfiguration.current.screenWidthDp >= WIDE_BREAKPOINT_DP
     val useSideNav = isWide && barConfig.bottomBar?.visible == true
+    // On wide tabbed screens the bottom mini player is replaced by a docked
+    // side player in the right column (contextual — only when a track plays).
+    val showSidePlayer = useSideNav && barConfig.miniPlayer?.visible == true
 
     // Shared tab-navigation action used by both the bottom bar and the rail.
     val onNavigateToDestination: (String) -> Unit = { route ->
@@ -426,13 +430,15 @@ fun MainNavigation(
             }
         } else null,
         miniPlayerConfig = barConfig.miniPlayer,
-        miniPlayerContent = {
-            MiniPlayerScreen(
-                onTapToExpand = { _ ->
-                    Log.d("MainNavigation", "MiniPlayer tapped - navigating to player")
-                    navController.navigate("player")
-                }
-            )
+        miniPlayerContent = if (showSidePlayer) null else {
+            {
+                MiniPlayerScreen(
+                    onTapToExpand = { _ ->
+                        Log.d("MainNavigation", "MiniPlayer tapped - navigating to player")
+                        navController.navigate("player")
+                    }
+                )
+            }
         },
         onNavigationClick = {
             navController.popBackStack()
@@ -441,6 +447,9 @@ fun MainNavigation(
     ) { paddingValues ->
         scaffoldContent(paddingValues)
     }
+        if (showSidePlayer) {
+            PlayerSidePanel(onTapToExpand = { navController.navigate("player") })
+        }
     } // Row
     } // ModalNavigationDrawer
 

--- a/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
@@ -594,6 +594,9 @@ private fun NavigationRailBar(
             modifier = Modifier
                 .fillMaxHeight()
                 .systemBarsPadding()
+                // Keep the icons clear of the camera cutout — in landscape the
+                // notch sits on the side edge the rail occupies.
+                .displayCutoutPadding()
                 .padding(vertical = 12.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(8.dp)

--- a/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
@@ -414,7 +414,8 @@ fun MainNavigation(
         if (useSideNav) {
             NavigationRailBar(
                 currentRoute = currentRoute,
-                onNavigateToDestination = onNavigateToDestination
+                onNavigateToDestination = onNavigateToDestination,
+                onOpenSettings = { scope.launch { drawerState.open() } }
             )
         }
     AppScaffold(
@@ -581,6 +582,7 @@ private const val WIDE_BREAKPOINT_DP = 600
 private fun NavigationRailBar(
     currentRoute: String?,
     onNavigateToDestination: (String) -> Unit,
+    onOpenSettings: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Surface(
@@ -594,13 +596,32 @@ private fun NavigationRailBar(
                 .systemBarsPadding()
                 .padding(vertical = 12.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically)
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
+            // Tab icons pinned to the top of the rail.
             BottomNavDestination.destinations.forEach { destination ->
                 NavigationRailItem(
                     destination = destination,
                     isSelected = currentRoute == destination.route,
                     onClick = { onNavigateToDestination(destination.route) }
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // Settings pinned to the bottom of the rail.
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(12.dp))
+                    .clickable { onOpenSettings() }
+                    .padding(12.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    painter = IconResources.Navigation.Settings(),
+                    contentDescription = "Settings",
+                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                    modifier = Modifier.size(24.dp)
                 )
             }
         }

--- a/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
@@ -448,7 +448,12 @@ fun MainNavigation(
         scaffoldContent(paddingValues)
     }
         if (showSidePlayer) {
-            PlayerSidePanel(onTapToExpand = { navController.navigate("player") })
+            PlayerSidePanel(
+                onTapToExpand = { navController.navigate("player") },
+                onNavigateToPlaylist = { showId, recordingId, openSheet ->
+                    navController.navigateToPlaylist(showId, recordingId, openSheet = openSheet)
+                }
+            )
         }
     } // Row
     } // ModalNavigationDrawer

--- a/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/MainNavigation.kt
@@ -415,12 +415,17 @@ fun MainNavigation(
             NavigationRailBar(
                 currentRoute = currentRoute,
                 onNavigateToDestination = onNavigateToDestination,
+                onOpenNotifications = { navController.navigate("notifications") },
                 onOpenSettings = { scope.launch { drawerState.open() } }
             )
         }
     AppScaffold(
         modifier = Modifier.weight(1f),
-        topBarConfig = augmentedTopBar,
+        // Wide layout: drop the top bar entirely. Its title ("Home"/"Search"/…)
+        // is redundant next to the selected rail icon, and removing it reclaims
+        // the scarce vertical height in landscape. The bell + settings it carried
+        // live on the rail instead.
+        topBarConfig = if (useSideNav) null else augmentedTopBar,
         bottomBarConfig = barConfig.bottomBar,
         bottomNavigationContent = if (!useSideNav && barConfig.bottomBar?.visible == true) {
             {
@@ -582,6 +587,7 @@ private const val WIDE_BREAKPOINT_DP = 600
 private fun NavigationRailBar(
     currentRoute: String?,
     onNavigateToDestination: (String) -> Unit,
+    onOpenNotifications: () -> Unit,
     onOpenSettings: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -611,6 +617,10 @@ private fun NavigationRailBar(
             }
 
             Spacer(modifier = Modifier.weight(1f))
+
+            // Notifications bell pinned just above settings — the wide layout's
+            // home for the bell that lives in the top bar on narrow screens.
+            NotificationBell(onClick = onOpenNotifications)
 
             // Settings pinned to the bottom of the rail.
             Box(

--- a/androidApp/core/design/src/main/res/drawable/ic_skip_previous.xml
+++ b/androidApp/core/design/src/main/res/drawable/ic_skip_previous.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24" android:tint="?attr/colorControlNormal">
-  <path android:fillColor="#000000" android:pathData="M6 6h2v12H6zm3.5 6l8.5 6V6z"/>
+  <!-- Two separate absolute paths (no relative 'm' after 'z'): the combined
+       relative form crashed the legacy vector parser on old Fire OS, collapsing
+       the triangle into a slanted line. -->
+  <path android:fillColor="#000000" android:pathData="M6,6 L8,6 L8,18 L6,18 Z"/>
+  <path android:fillColor="#000000" android:pathData="M18,6 L18,18 L9.5,12 Z"/>
 </vector>

--- a/androidApp/feature/favorites/src/main/java/com/grateful/deadly/feature/favorites/screens/main/FavoritesScreen.kt
+++ b/androidApp/feature/favorites/src/main/java/com/grateful/deadly/feature/favorites/screens/main/FavoritesScreen.kt
@@ -9,8 +9,10 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import android.content.res.Configuration
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import com.grateful.deadly.core.design.resources.IconResources
 import androidx.compose.ui.text.font.FontWeight
@@ -62,7 +64,27 @@ fun FavoritesScreen(
     var sortBy by remember { mutableStateOf(FavoritesSortOption.DATE_ADDED) }
     var songSortBy by remember { mutableStateOf(FavoritesSongSortOption.DATE_ADDED) }
     var sortDirection by remember { mutableStateOf(FavoritesSortDirection.DESCENDING) }
-    val displayMode by viewModel.displayMode.collectAsState()
+
+    // Landscape reclaims horizontal space, so default the shows tab to the grid
+    // there — but keep it a transient override (not the persisted preference) so
+    // a toggle sticks only until the next rotation, and portrait keeps the user's
+    // saved choice untouched.
+    val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+    val persistedDisplayMode by viewModel.displayMode.collectAsState()
+    var landscapeDisplayOverride by remember { mutableStateOf<FavoritesDisplayMode?>(null) }
+    LaunchedEffect(isLandscape) {
+        if (!isLandscape) landscapeDisplayOverride = null
+    }
+    val displayMode = if (isLandscape) {
+        landscapeDisplayOverride ?: FavoritesDisplayMode.GRID
+    } else {
+        persistedDisplayMode
+    }
+    val onDisplayModeChanged: (FavoritesDisplayMode) -> Unit = { mode ->
+        if (isLandscape) landscapeDisplayOverride = mode else viewModel.setDisplayMode(mode)
+    }
+    // Tighter vertical rhythm in landscape where height is scarce.
+    val headerVPad = if (isLandscape) 4.dp else 8.dp
     var showAddBottomSheet by remember { mutableStateOf(false) }
     var showSortBottomSheet by remember { mutableStateOf(false) }
     var showSongSortBottomSheet by remember { mutableStateOf(false) }
@@ -82,14 +104,14 @@ fun FavoritesScreen(
                 onSelectionChanged = { filterPath = it },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 8.dp, vertical = 8.dp)
+                    .padding(horizontal = 8.dp, vertical = headerVPad)
             )
 
             // Tab Picker
             SingleChoiceSegmentedButtonRow(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 8.dp, vertical = 4.dp)
+                    .padding(horizontal = 8.dp, vertical = if (isLandscape) 2.dp else 4.dp)
             ) {
                 FavoritesTab.entries.forEachIndexed { index, tab ->
                     SegmentedButton(
@@ -128,9 +150,9 @@ fun FavoritesScreen(
                     sortDirection = sortDirection,
                     displayMode = displayMode,
                     onSortSelectorClick = { showSortBottomSheet = true },
-                    onDisplayModeChanged = { viewModel.setDisplayMode(it) },
+                    onDisplayModeChanged = onDisplayModeChanged,
                     count = showsCount,
-                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp)
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = headerVPad)
                 )
             } else {
                 SongSortControls(
@@ -138,7 +160,7 @@ fun FavoritesScreen(
                     sortDirection = sortDirection,
                     onSortSelectorClick = { showSongSortBottomSheet = true },
                     count = songsCount,
-                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp)
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = headerVPad)
                 )
             }
 

--- a/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerSidePanel.kt
+++ b/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerSidePanel.kt
@@ -3,52 +3,88 @@ package com.grateful.deadly.feature.player.screens.main
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.grateful.deadly.feature.player.screens.main.components.PlayerCoverArt
+import com.grateful.deadly.core.design.component.QrCodeDisplay
+import com.grateful.deadly.core.design.component.ShareChooserSheet
+import com.grateful.deadly.core.design.component.ShowActionsMenuSheet
+import com.grateful.deadly.core.design.component.ShowArtwork
+import com.grateful.deadly.core.design.resources.IconResources
 import com.grateful.deadly.feature.player.screens.main.components.PlayerEnhancedControls
+import com.grateful.deadly.feature.player.screens.main.components.PlayerEqualizerSheet
 import com.grateful.deadly.feature.player.screens.main.components.PlayerProgressControl
-import com.grateful.deadly.feature.player.screens.main.components.PlayerTrackInfoRow
 import com.grateful.deadly.feature.player.screens.main.models.PlayerViewModel
+import com.grateful.deadly.feature.settings.screens.connect.ConnectSheet
 
 /**
  * Side player for wide layouts (landscape phones, tablets) — the docked
  * right-column "more than mini, less than full" player from the tablet/landscape
- * design. A vertical compact arrangement reusing the full player's components:
- * cover art, track info (+favorite), a seekable scrubber, and transport.
+ * design.
+ *
+ * Sized to fit a single landscape screen without scrolling. Layout (top →
+ * bottom): a mini-player-style header (small thumbnail + track info + favorite),
+ * a seekable scrubber, then — pushed to the bottom — a secondary action row
+ * (Connect · Share · Equalizer · ⋯ overflow) above the primary transport
+ * controls, which stay pinned at the bottom.
  *
  * Contextual: renders nothing when no track is loaded, so the column collapses
  * and the content pane takes the full width when idle. Reuses [PlayerViewModel]
  * (which observes the shared playback service), so it stays in sync with the
  * mini and full players.
  *
- * @param onTapToExpand tapping the cover opens the full player (Phase 3 will make
+ * @param onTapToExpand tapping the header opens the full player (Phase 3 will make
  *   this the in-place "full-wide" expand instead of the full-screen route).
+ * @param onNavigateToPlaylist target for the "⋯" menu's This Show / Choose
+ *   Recording actions (the playlist is their home).
  */
 @Composable
 fun PlayerSidePanel(
     onTapToExpand: () -> Unit,
+    onNavigateToPlaylist: (showId: String, recordingId: String?, openSheet: String?) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PlayerViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val isFavorite by viewModel.isCurrentTrackFavorite.collectAsState()
+    val equalizerState by viewModel.equalizerState.collectAsState()
+    val connectRemoteDeviceName by viewModel.connectRemoteDeviceName.collectAsState()
+    val autoAdvanceEnabled by viewModel.autoAdvanceEnabled.collectAsState()
+    val showCollectionsCount by viewModel.showCollectionsCount.collectAsState()
+
+    var showTrackActionsBottomSheet by remember { mutableStateOf(false) }
+    var showQrCode by remember { mutableStateOf(false) }
+    var showShareChooser by remember { mutableStateOf(false) }
+    var showEqualizerBottomSheet by remember { mutableStateOf(false) }
+    var showConnectSheet by remember { mutableStateOf(false) }
 
     // No track loaded → emit nothing so the content pane is full width.
     if (uiState.navigationInfo.showId == null) return
@@ -62,31 +98,74 @@ fun PlayerSidePanel(
             modifier = Modifier
                 .width(320.dp)
                 .fillMaxHeight()
-                .verticalScroll(rememberScrollState())
                 .systemBarsPadding()
-                .padding(horizontal = 20.dp, vertical = 16.dp),
-            verticalArrangement = Arrangement.Center
+                .padding(horizontal = 20.dp, vertical = 20.dp)
         ) {
-            PlayerCoverArt(
-                recordingId = uiState.trackDisplayInfo.recordingId,
-                imageUrl = uiState.trackDisplayInfo.coverImageUrl,
+            // Mini-player-style header: thumbnail + title/subtitle + favorite.
+            Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .aspectRatio(1f)
-                    .clickable { onTapToExpand() }
-            )
+                    .clickable { onTapToExpand() },
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Card(
+                    modifier = Modifier
+                        .size(56.dp)
+                        .clip(RoundedCornerShape(8.dp)),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer
+                    )
+                ) {
+                    ShowArtwork(
+                        recordingId = uiState.trackDisplayInfo.recordingId,
+                        imageUrl = uiState.trackDisplayInfo.coverImageUrl,
+                        contentDescription = "Album Art",
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
 
-            Spacer(modifier = Modifier.height(16.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = uiState.trackDisplayInfo.title,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = uiState.trackDisplayInfo.showDate,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    if (uiState.trackDisplayInfo.venue.isNotEmpty()) {
+                        Text(
+                            text = uiState.trackDisplayInfo.venue,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
 
-            PlayerTrackInfoRow(
-                trackTitle = uiState.trackDisplayInfo.title,
-                showDate = uiState.trackDisplayInfo.showDate,
-                venue = uiState.trackDisplayInfo.venue,
-                isFavorite = isFavorite,
-                onFavoriteClick = { viewModel.toggleCurrentTrackFavorite() }
-            )
+                IconButton(
+                    onClick = { viewModel.toggleCurrentTrackFavorite() },
+                    modifier = Modifier.size(40.dp)
+                ) {
+                    Icon(
+                        painter = if (isFavorite) IconResources.Content.Favorite() else IconResources.Content.FavoriteBorder(),
+                        contentDescription = if (isFavorite) "Remove from Favorites" else "Add to Favorites",
+                        tint = if (isFavorite) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(26.dp)
+                    )
+                }
+            }
 
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(20.dp))
 
             PlayerProgressControl(
                 currentTime = uiState.progressDisplayInfo.currentPosition,
@@ -95,8 +174,70 @@ fun PlayerSidePanel(
                 onSeek = viewModel::onSeek
             )
 
+            // Flexible space between the jog and the bottom-pinned controls.
+            Spacer(modifier = Modifier.weight(1f))
+
+            // Secondary actions: Connect (left) · Share · Equalizer · ⋯ (right).
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .height(40.dp)
+                        .clip(RoundedCornerShape(20.dp))
+                        .clickable { showConnectSheet = true }
+                        .padding(horizontal = 8.dp)
+                ) {
+                    Icon(
+                        painter = IconResources.Content.Cast(),
+                        contentDescription = "Connect",
+                        tint = if (connectRemoteDeviceName != null) MaterialTheme.colorScheme.primary
+                               else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    if (connectRemoteDeviceName != null) {
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            text = connectRemoteDeviceName!!,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.widthIn(max = 80.dp)
+                        )
+                    }
+                }
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    IconButton(onClick = { showShareChooser = true }, modifier = Modifier.size(40.dp)) {
+                        Icon(
+                            painter = IconResources.Content.Share(),
+                            contentDescription = "Share",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    IconButton(onClick = { showEqualizerBottomSheet = true }, modifier = Modifier.size(40.dp)) {
+                        Icon(
+                            painter = IconResources.PlayerControls.Equalizer(),
+                            contentDescription = "Equalizer",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    IconButton(onClick = { showTrackActionsBottomSheet = true }, modifier = Modifier.size(40.dp)) {
+                        Icon(
+                            painter = IconResources.Navigation.MoreVertical(),
+                            contentDescription = "More options",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+
             Spacer(modifier = Modifier.height(8.dp))
 
+            // Primary transport — pinned at the bottom.
             PlayerEnhancedControls(
                 isPlaying = uiState.isPlaying,
                 isLoading = uiState.isLoading,
@@ -106,5 +247,82 @@ fun PlayerSidePanel(
                 onNext = viewModel::onNextClicked
             )
         }
+    }
+
+    // Bottom sheets (mirrors PlayerScreen).
+    if (showTrackActionsBottomSheet) {
+        val navShowId = uiState.navigationInfo.showId
+        val navRecordingId = uiState.navigationInfo.recordingId
+        ShowActionsMenuSheet(
+            recordingId = navRecordingId,
+            title = uiState.trackDisplayInfo.title,
+            showDate = uiState.trackDisplayInfo.showDate,
+            venue = uiState.trackDisplayInfo.venue,
+            isAutoplayEnabled = autoAdvanceEnabled,
+            collectionsCount = showCollectionsCount,
+            onChooseRecording = navShowId?.let { sid -> { onNavigateToPlaylist(sid, navRecordingId, "recording") } },
+            onAutoplay = { viewModel.toggleAutoAdvance() },
+            onSetlist = navShowId?.let { sid -> { onNavigateToPlaylist(sid, navRecordingId, "setlist") } },
+            onCollections = navShowId?.let { sid -> { onNavigateToPlaylist(sid, navRecordingId, "collections") } },
+            onDownload = { viewModel.downloadCurrentShow() },
+            onDismiss = { showTrackActionsBottomSheet = false },
+        )
+    }
+
+    if (showShareChooser) {
+        ShareChooserSheet(
+            onMessageShare = {
+                showShareChooser = false
+                viewModel.shareAsMessage()
+            },
+            onQrShare = {
+                showShareChooser = false
+                showQrCode = true
+            },
+            onDismiss = { showShareChooser = false }
+        )
+    }
+
+    if (showQrCode) {
+        val showId = uiState.navigationInfo.showId
+        val recordingId = uiState.navigationInfo.recordingId
+        if (showId != null) {
+            val url = if (recordingId != null) {
+                buildString {
+                    append("${viewModel.appPreferences.shareBaseUrl}/shows/$showId/recording/$recordingId")
+                    val trackNumber = uiState.navigationInfo.trackNumber
+                    if (trackNumber != null) append("/track/$trackNumber")
+                }
+            } else {
+                "${viewModel.appPreferences.shareBaseUrl}/shows/$showId"
+            }
+            QrCodeDisplay(
+                url = url,
+                showDate = uiState.trackDisplayInfo.showDate,
+                venue = uiState.trackDisplayInfo.venue,
+                location = "",
+                recordingId = uiState.navigationInfo.recordingId,
+                coverImageUrl = uiState.trackDisplayInfo.coverImageUrl,
+                songTitle = uiState.trackDisplayInfo.title,
+                onDismiss = { showQrCode = false }
+            )
+        }
+    }
+
+    if (showEqualizerBottomSheet) {
+        PlayerEqualizerSheet(
+            state = equalizerState,
+            onDismiss = { showEqualizerBottomSheet = false },
+            onToggleEnabled = viewModel::setEqualizerEnabled,
+            onPresetSelected = viewModel::selectEqualizerPreset,
+            onBandLevelChanged = viewModel::setEqualizerBandLevel,
+            onReset = viewModel::resetEqualizer
+        )
+    }
+
+    if (showConnectSheet) {
+        ConnectSheet(
+            onDismiss = { showConnectSheet = false }
+        )
     }
 }

--- a/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerSidePanel.kt
+++ b/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerSidePanel.kt
@@ -104,13 +104,38 @@ fun PlayerSidePanel(
         shadowElevation = 8.dp
     ) {
         BoxWithConstraints {
-            // Art grows with the column height so the upper block fills the
-            // space (small on a short landscape phone, large on a tall tablet).
-            // Capped by the height left after reserving room for the title,
-            // scrubber, and the bottom-pinned controls, so transport is never
-            // pushed off-screen on short landscape phones.
-            val cap = minOf(180.dp, this.maxHeight - 280.dp).coerceAtLeast(56.dp)
-            val coverSize = (this.maxHeight * 0.22f).coerceIn(56.dp, cap)
+            // Branch on available HEIGHT: a tall column (tablet, any
+            // orientation) stacks the show text under the cover like the full
+            // player; a short column (landscape phone) keeps cover + text
+            // side-by-side so the title, scrubber, and bottom-pinned transport
+            // still fit without scrolling.
+            val isTall = this.maxHeight >= 620.dp
+            val coverSize = if (isTall) {
+                (this.maxHeight * 0.28f).coerceIn(120.dp, 280.dp)
+            } else {
+                val cap = minOf(180.dp, this.maxHeight - 280.dp).coerceAtLeast(56.dp)
+                (this.maxHeight * 0.22f).coerceIn(56.dp, cap)
+            }
+
+            // Cover art — shared by both header arrangements.
+            val cover: @Composable () -> Unit = {
+                Card(
+                    modifier = Modifier
+                        .size(coverSize)
+                        .clip(RoundedCornerShape(12.dp))
+                        .clickable { onTapToExpand() },
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer
+                    )
+                ) {
+                    ShowArtwork(
+                        recordingId = uiState.trackDisplayInfo.recordingId,
+                        imageUrl = uiState.trackDisplayInfo.coverImageUrl,
+                        contentDescription = "Album Art",
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+            }
 
             Column(
                 modifier = Modifier
@@ -120,45 +145,60 @@ fun PlayerSidePanel(
                     .padding(horizontal = 20.dp)
                     .padding(top = 20.dp, bottom = 12.dp)
             ) {
-                // Header card: album art + date / venue beside it.
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(14.dp)
-                ) {
-                    Card(
-                        modifier = Modifier
-                            .size(coverSize)
-                            .clip(RoundedCornerShape(12.dp))
-                            .clickable { onTapToExpand() },
-                        colors = CardDefaults.cardColors(
-                            containerColor = MaterialTheme.colorScheme.primaryContainer
-                        )
+                if (isTall) {
+                    // Tablet: cover on top, show date + venue centered beneath it.
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        ShowArtwork(
-                            recordingId = uiState.trackDisplayInfo.recordingId,
-                            imageUrl = uiState.trackDisplayInfo.coverImageUrl,
-                            contentDescription = "Album Art",
-                            modifier = Modifier.fillMaxSize()
-                        )
-                    }
-
-                    Column(modifier = Modifier.weight(1f)) {
+                        cover()
+                        Spacer(modifier = Modifier.height(16.dp))
                         Text(
                             text = uiState.trackDisplayInfo.showDate,
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.SemiBold,
                             color = MaterialTheme.colorScheme.onSurface,
                             maxLines = 2,
-                            overflow = TextOverflow.Ellipsis
+                            overflow = TextOverflow.Ellipsis,
+                            textAlign = TextAlign.Center
                         )
                         Spacer(modifier = Modifier.height(4.dp))
                         Text(
                             text = uiState.trackDisplayInfo.venue,
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 3,
-                            overflow = TextOverflow.Ellipsis
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                            textAlign = TextAlign.Center
                         )
+                    }
+                } else {
+                    // Landscape phone: cover + date / venue side-by-side to stay
+                    // compact against the short height.
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(14.dp)
+                    ) {
+                        cover()
+
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = uiState.trackDisplayInfo.showDate,
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                color = MaterialTheme.colorScheme.onSurface,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                text = uiState.trackDisplayInfo.venue,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 3,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
                     }
                 }
 

--- a/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerSidePanel.kt
+++ b/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerSidePanel.kt
@@ -100,14 +100,19 @@ fun PlayerSidePanel(
         BoxWithConstraints {
             // Art grows with the column height so the upper block fills the
             // space (small on a short landscape phone, large on a tall tablet).
-            val coverSize = (this.maxHeight * 0.34f).coerceIn(96.dp, 220.dp)
+            // Capped by the height left after reserving room for the title,
+            // scrubber, and the bottom-pinned controls, so transport is never
+            // pushed off-screen on short landscape phones.
+            val cap = minOf(180.dp, this.maxHeight - 280.dp).coerceAtLeast(56.dp)
+            val coverSize = (this.maxHeight * 0.22f).coerceIn(56.dp, cap)
 
             Column(
                 modifier = Modifier
                     .width(320.dp)
                     .fillMaxHeight()
                     .systemBarsPadding()
-                    .padding(horizontal = 20.dp, vertical = 20.dp)
+                    .padding(horizontal = 20.dp)
+                    .padding(top = 20.dp, bottom = 12.dp)
             ) {
                 // Header card: album art + date / venue beside it.
                 Row(

--- a/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerSidePanel.kt
+++ b/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerSidePanel.kt
@@ -108,7 +108,7 @@ fun PlayerSidePanel(
 
             Column(
                 modifier = Modifier
-                    .width(320.dp)
+                    .width(360.dp)
                     .fillMaxHeight()
                     .systemBarsPadding()
                     .padding(horizontal = 20.dp)

--- a/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerSidePanel.kt
+++ b/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerSidePanel.kt
@@ -2,10 +2,12 @@ package com.grateful.deadly.feature.player.screens.main
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -50,18 +52,19 @@ import com.grateful.deadly.feature.settings.screens.connect.ConnectSheet
  * right-column "more than mini, less than full" player from the tablet/landscape
  * design.
  *
- * Sized to fit a single landscape screen without scrolling. Layout (top →
- * bottom): a mini-player-style header (small thumbnail + track info + favorite),
- * a seekable scrubber, then — pushed to the bottom — a secondary action row
- * (Connect · Share · Equalizer · ⋯ overflow) above the primary transport
- * controls, which stay pinned at the bottom.
+ * Layout (top → bottom): a header card — album art with the show date + venue
+ * stacked beside it — then the song title and a seekable scrubber. The art
+ * scales with the column height so the upper block fills the available space
+ * instead of leaving a gap. A secondary action row (Connect · Share ·
+ * Equalizer · ⋯ overflow) sits above the primary transport controls, which
+ * stay pinned at the bottom.
  *
  * Contextual: renders nothing when no track is loaded, so the column collapses
  * and the content pane takes the full width when idle. Reuses [PlayerViewModel]
  * (which observes the shared playback service), so it stays in sync with the
  * mini and full players.
  *
- * @param onTapToExpand tapping the header opens the full player (Phase 3 will make
+ * @param onTapToExpand tapping the cover opens the full player (Phase 3 will make
  *   this the in-place "full-wide" expand instead of the full-screen route).
  * @param onNavigateToPlaylist target for the "⋯" menu's This Show / Choose
  *   Recording actions (the playlist is their home).
@@ -94,158 +97,171 @@ fun PlayerSidePanel(
         color = MaterialTheme.colorScheme.surface,
         shadowElevation = 8.dp
     ) {
-        Column(
-            modifier = Modifier
-                .width(320.dp)
-                .fillMaxHeight()
-                .systemBarsPadding()
-                .padding(horizontal = 20.dp, vertical = 20.dp)
-        ) {
-            // Mini-player-style header: thumbnail + title/subtitle + favorite.
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { onTapToExpand() },
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                Card(
-                    modifier = Modifier
-                        .size(56.dp)
-                        .clip(RoundedCornerShape(8.dp)),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.primaryContainer
-                    )
-                ) {
-                    ShowArtwork(
-                        recordingId = uiState.trackDisplayInfo.recordingId,
-                        imageUrl = uiState.trackDisplayInfo.coverImageUrl,
-                        contentDescription = "Album Art",
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                }
+        BoxWithConstraints {
+            // Art grows with the column height so the upper block fills the
+            // space (small on a short landscape phone, large on a tall tablet).
+            val coverSize = (this.maxHeight * 0.34f).coerceIn(96.dp, 220.dp)
 
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = uiState.trackDisplayInfo.title,
-                        style = MaterialTheme.typography.titleSmall,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                    Text(
-                        text = uiState.trackDisplayInfo.showDate,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                    if (uiState.trackDisplayInfo.venue.isNotEmpty()) {
+            Column(
+                modifier = Modifier
+                    .width(320.dp)
+                    .fillMaxHeight()
+                    .systemBarsPadding()
+                    .padding(horizontal = 20.dp, vertical = 20.dp)
+            ) {
+                // Header card: album art + date / venue beside it.
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(14.dp)
+                ) {
+                    Card(
+                        modifier = Modifier
+                            .size(coverSize)
+                            .clip(RoundedCornerShape(12.dp))
+                            .clickable { onTapToExpand() },
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.primaryContainer
+                        )
+                    ) {
+                        ShowArtwork(
+                            recordingId = uiState.trackDisplayInfo.recordingId,
+                            imageUrl = uiState.trackDisplayInfo.coverImageUrl,
+                            contentDescription = "Album Art",
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    }
+
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = uiState.trackDisplayInfo.showDate,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
                         Text(
                             text = uiState.trackDisplayInfo.venue,
-                            style = MaterialTheme.typography.bodySmall,
+                            style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
+                            maxLines = 3,
                             overflow = TextOverflow.Ellipsis
                         )
                     }
                 }
 
-                IconButton(
-                    onClick = { viewModel.toggleCurrentTrackFavorite() },
-                    modifier = Modifier.size(40.dp)
-                ) {
-                    Icon(
-                        painter = if (isFavorite) IconResources.Content.Favorite() else IconResources.Content.FavoriteBorder(),
-                        contentDescription = if (isFavorite) "Remove from Favorites" else "Add to Favorites",
-                        tint = if (isFavorite) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(26.dp)
-                    )
-                }
-            }
+                Spacer(modifier = Modifier.height(16.dp))
 
-            Spacer(modifier = Modifier.height(20.dp))
-
-            PlayerProgressControl(
-                currentTime = uiState.progressDisplayInfo.currentPosition,
-                totalTime = uiState.progressDisplayInfo.totalDuration,
-                progress = uiState.progressDisplayInfo.progressPercentage,
-                onSeek = viewModel::onSeek
-            )
-
-            // Flexible space between the jog and the bottom-pinned controls.
-            Spacer(modifier = Modifier.weight(1f))
-
-            // Secondary actions: Connect (left) · Share · Equalizer · ⋯ (right).
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
+                // Song title + favorite.
                 Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .height(40.dp)
-                        .clip(RoundedCornerShape(20.dp))
-                        .clickable { showConnectSheet = true }
-                        .padding(horizontal = 8.dp)
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Icon(
-                        painter = IconResources.Content.Cast(),
-                        contentDescription = "Connect",
-                        tint = if (connectRemoteDeviceName != null) MaterialTheme.colorScheme.primary
-                               else MaterialTheme.colorScheme.onSurfaceVariant
+                    Text(
+                        text = uiState.trackDisplayInfo.title,
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f)
                     )
-                    if (connectRemoteDeviceName != null) {
-                        Spacer(Modifier.width(8.dp))
-                        Text(
-                            text = connectRemoteDeviceName!!,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.primary,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.widthIn(max = 80.dp)
+                    IconButton(
+                        onClick = { viewModel.toggleCurrentTrackFavorite() },
+                        modifier = Modifier.size(40.dp)
+                    ) {
+                        Icon(
+                            painter = if (isFavorite) IconResources.Content.Favorite() else IconResources.Content.FavoriteBorder(),
+                            contentDescription = if (isFavorite) "Remove from Favorites" else "Add to Favorites",
+                            tint = if (isFavorite) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(26.dp)
                         )
                     }
                 }
 
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    IconButton(onClick = { showShareChooser = true }, modifier = Modifier.size(40.dp)) {
+                Spacer(modifier = Modifier.height(18.dp))
+
+                PlayerProgressControl(
+                    currentTime = uiState.progressDisplayInfo.currentPosition,
+                    totalTime = uiState.progressDisplayInfo.totalDuration,
+                    progress = uiState.progressDisplayInfo.progressPercentage,
+                    onSeek = viewModel::onSeek
+                )
+
+                // Absorbs any residual height above the bottom-pinned controls.
+                Spacer(modifier = Modifier.weight(1f))
+
+                // Secondary actions: Connect (left) · Share · Equalizer · ⋯ (right).
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .height(40.dp)
+                            .clip(RoundedCornerShape(20.dp))
+                            .clickable { showConnectSheet = true }
+                            .padding(horizontal = 8.dp)
+                    ) {
                         Icon(
-                            painter = IconResources.Content.Share(),
-                            contentDescription = "Share",
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            painter = IconResources.Content.Cast(),
+                            contentDescription = "Connect",
+                            tint = if (connectRemoteDeviceName != null) MaterialTheme.colorScheme.primary
+                                   else MaterialTheme.colorScheme.onSurfaceVariant
                         )
+                        if (connectRemoteDeviceName != null) {
+                            Spacer(Modifier.width(8.dp))
+                            Text(
+                                text = connectRemoteDeviceName!!,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.primary,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.widthIn(max = 80.dp)
+                            )
+                        }
                     }
-                    IconButton(onClick = { showEqualizerBottomSheet = true }, modifier = Modifier.size(40.dp)) {
-                        Icon(
-                            painter = IconResources.PlayerControls.Equalizer(),
-                            contentDescription = "Equalizer",
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                    IconButton(onClick = { showTrackActionsBottomSheet = true }, modifier = Modifier.size(40.dp)) {
-                        Icon(
-                            painter = IconResources.Navigation.MoreVertical(),
-                            contentDescription = "More options",
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        IconButton(onClick = { showShareChooser = true }, modifier = Modifier.size(40.dp)) {
+                            Icon(
+                                painter = IconResources.Content.Share(),
+                                contentDescription = "Share",
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        IconButton(onClick = { showEqualizerBottomSheet = true }, modifier = Modifier.size(40.dp)) {
+                            Icon(
+                                painter = IconResources.PlayerControls.Equalizer(),
+                                contentDescription = "Equalizer",
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        IconButton(onClick = { showTrackActionsBottomSheet = true }, modifier = Modifier.size(40.dp)) {
+                            Icon(
+                                painter = IconResources.Navigation.MoreVertical(),
+                                contentDescription = "More options",
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
                     }
                 }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // Primary transport — pinned at the bottom.
+                PlayerEnhancedControls(
+                    isPlaying = uiState.isPlaying,
+                    isLoading = uiState.isLoading,
+                    hasNext = uiState.hasNext,
+                    onPlayPause = viewModel::onPlayPauseClicked,
+                    onPrevious = viewModel::onPreviousClicked,
+                    onNext = viewModel::onNextClicked
+                )
             }
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Primary transport — pinned at the bottom.
-            PlayerEnhancedControls(
-                isPlaying = uiState.isPlaying,
-                isLoading = uiState.isLoading,
-                hasNext = uiState.hasNext,
-                onPlayPause = viewModel::onPlayPauseClicked,
-                onPrevious = viewModel::onPreviousClicked,
-                onNext = viewModel::onNextClicked
-            )
         }
     }
 

--- a/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerSidePanel.kt
+++ b/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerSidePanel.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -89,8 +90,13 @@ fun PlayerSidePanel(
     var showEqualizerBottomSheet by remember { mutableStateOf(false) }
     var showConnectSheet by remember { mutableStateOf(false) }
 
-    // No track loaded → emit nothing so the content pane is full width.
-    if (uiState.navigationInfo.showId == null) return
+    // No track loaded → keep the column present with a quiet placeholder so the
+    // wide layout's three-pane balance holds on first launch (instead of the
+    // content pane snapping to full width).
+    if (uiState.navigationInfo.showId == null) {
+        SidePlayerEmpty(modifier)
+        return
+    }
 
     Surface(
         modifier = modifier.fillMaxHeight(),
@@ -345,5 +351,49 @@ fun PlayerSidePanel(
         ConnectSheet(
             onDismiss = { showConnectSheet = false }
         )
+    }
+}
+
+/**
+ * Idle placeholder for the side player column. Keeps the wide layout's three-pane
+ * balance (rail · content · player) before anything is playing, matching the live
+ * panel's width and surface so the player drops straight in once a track loads.
+ */
+@Composable
+private fun SidePlayerEmpty(modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier.fillMaxHeight(),
+        color = MaterialTheme.colorScheme.surface,
+        shadowElevation = 8.dp
+    ) {
+        Column(
+            modifier = Modifier
+                .width(360.dp)
+                .fillMaxHeight()
+                .systemBarsPadding()
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                painter = IconResources.PlayerControls.Play(),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f),
+                modifier = Modifier.size(48.dp)
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = "Nothing playing",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Pick a show to start listening",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+        }
     }
 }

--- a/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerSidePanel.kt
+++ b/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerSidePanel.kt
@@ -1,0 +1,110 @@
+package com.grateful.deadly.feature.player.screens.main
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.grateful.deadly.feature.player.screens.main.components.PlayerCoverArt
+import com.grateful.deadly.feature.player.screens.main.components.PlayerEnhancedControls
+import com.grateful.deadly.feature.player.screens.main.components.PlayerProgressControl
+import com.grateful.deadly.feature.player.screens.main.components.PlayerTrackInfoRow
+import com.grateful.deadly.feature.player.screens.main.models.PlayerViewModel
+
+/**
+ * Side player for wide layouts (landscape phones, tablets) — the docked
+ * right-column "more than mini, less than full" player from the tablet/landscape
+ * design. A vertical compact arrangement reusing the full player's components:
+ * cover art, track info (+favorite), a seekable scrubber, and transport.
+ *
+ * Contextual: renders nothing when no track is loaded, so the column collapses
+ * and the content pane takes the full width when idle. Reuses [PlayerViewModel]
+ * (which observes the shared playback service), so it stays in sync with the
+ * mini and full players.
+ *
+ * @param onTapToExpand tapping the cover opens the full player (Phase 3 will make
+ *   this the in-place "full-wide" expand instead of the full-screen route).
+ */
+@Composable
+fun PlayerSidePanel(
+    onTapToExpand: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: PlayerViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val isFavorite by viewModel.isCurrentTrackFavorite.collectAsState()
+
+    // No track loaded → emit nothing so the content pane is full width.
+    if (uiState.navigationInfo.showId == null) return
+
+    Surface(
+        modifier = modifier.fillMaxHeight(),
+        color = MaterialTheme.colorScheme.surface,
+        shadowElevation = 8.dp
+    ) {
+        Column(
+            modifier = Modifier
+                .width(320.dp)
+                .fillMaxHeight()
+                .verticalScroll(rememberScrollState())
+                .systemBarsPadding()
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.Center
+        ) {
+            PlayerCoverArt(
+                recordingId = uiState.trackDisplayInfo.recordingId,
+                imageUrl = uiState.trackDisplayInfo.coverImageUrl,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(1f)
+                    .clickable { onTapToExpand() }
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            PlayerTrackInfoRow(
+                trackTitle = uiState.trackDisplayInfo.title,
+                showDate = uiState.trackDisplayInfo.showDate,
+                venue = uiState.trackDisplayInfo.venue,
+                isFavorite = isFavorite,
+                onFavoriteClick = { viewModel.toggleCurrentTrackFavorite() }
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            PlayerProgressControl(
+                currentTime = uiState.progressDisplayInfo.currentPosition,
+                totalTime = uiState.progressDisplayInfo.totalDuration,
+                progress = uiState.progressDisplayInfo.progressPercentage,
+                onSeek = viewModel::onSeek
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            PlayerEnhancedControls(
+                isPlaying = uiState.isPlaying,
+                isLoading = uiState.isLoading,
+                hasNext = uiState.hasNext,
+                onPlayPause = viewModel::onPlayPauseClicked,
+                onPrevious = viewModel::onPreviousClicked,
+                onNext = viewModel::onNextClicked
+            )
+        }
+    }
+}

--- a/iosApp/deadly.xcodeproj/project.pbxproj
+++ b/iosApp/deadly.xcodeproj/project.pbxproj
@@ -434,7 +434,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				XROS_DEPLOYMENT_TARGET = 2.5;
 			};
 			name = Debug;
@@ -467,7 +467,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				XROS_DEPLOYMENT_TARGET = 2.5;
 			};
 			name = Release;
@@ -489,7 +489,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/deadly.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/deadly";
 				XROS_DEPLOYMENT_TARGET = 2.5;
 			};
@@ -512,7 +512,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/deadly.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/deadly";
 				XROS_DEPLOYMENT_TARGET = 2.5;
 			};
@@ -534,7 +534,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = deadly;
 				XROS_DEPLOYMENT_TARGET = 2.5;
 			};
@@ -556,7 +556,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = deadly;
 				XROS_DEPLOYMENT_TARGET = 2.5;
 			};

--- a/iosApp/deadly/App/MainNavigation.swift
+++ b/iosApp/deadly/App/MainNavigation.swift
@@ -195,7 +195,7 @@ struct MainNavigation: View {
             // plus a contextual docked side player that replaces the bottom mini
             // bar whenever a track is loaded.
             HStack(spacing: 0) {
-                NavSidebar(selectedTab: tabSelection)
+                NavSidebar(selectedTab: tabSelection, onSettings: { showingSettings = true })
                 Divider()
                 sectionContent(for: selectedTab)
                 if container.miniPlayerService.isVisible {
@@ -391,6 +391,7 @@ enum AppTab: String, Hashable, CaseIterable {
 /// bar. Drives the same `selectedTab` the TabView uses.
 private struct NavSidebar: View {
     @Binding var selectedTab: AppTab
+    var onSettings: () -> Void
 
     var body: some View {
         VStack(spacing: 8) {
@@ -410,7 +411,21 @@ private struct NavSidebar: View {
                 }
                 .accessibilityLabel(tab.title)
             }
+
             Spacer()
+
+            // Settings pinned to the bottom of the rail (uses the otherwise
+            // empty vertical space the wide rail frees up).
+            Button {
+                onSettings()
+            } label: {
+                Image(systemName: "gearshape")
+                    .font(.title2)
+                    .frame(width: 44, height: 44)
+                    .foregroundStyle(Color.secondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Settings")
         }
         .padding(.vertical, 12)
         .frame(width: 72)

--- a/iosApp/deadly/App/MainNavigation.swift
+++ b/iosApp/deadly/App/MainNavigation.swift
@@ -509,7 +509,9 @@ private struct SettingsDrawer: View {
                             }
                         }
                 }
-                .frame(width: UIScreen.main.bounds.width * 0.82)
+                // Cap the width so the drawer reads as a left panel rather than
+                // (nearly) the whole screen on a wide landscape / tablet layout.
+                .frame(width: min(UIScreen.main.bounds.width * 0.82, 400))
                 .offset(x: min(0, dragOffset))
                 .gesture(
                     DragGesture()

--- a/iosApp/deadly/App/MainNavigation.swift
+++ b/iosApp/deadly/App/MainNavigation.swift
@@ -195,7 +195,14 @@ struct MainNavigation: View {
             // plus a contextual docked side player that replaces the bottom mini
             // bar whenever a track is loaded.
             HStack(spacing: 0) {
-                NavSidebar(selectedTab: tabSelection, onSettings: { showingSettings = true })
+                NavSidebar(
+                    selectedTab: tabSelection,
+                    onSettings: { showingSettings = true },
+                    onNotifications: {
+                        selectedTab = .home
+                        homeStack.append(NotificationRoute.inbox)
+                    }
+                )
                 Divider()
                 sectionContent(for: selectedTab)
                 if container.miniPlayerService.isVisible {
@@ -236,20 +243,24 @@ struct MainNavigation: View {
         // Wide layout: the bottom mini player is replaced by the docked side
         // player, so suppress it inside each section.
         switch tab {
-        case .home: homeSection(suppressMini: true)
-        case .search: searchSection(suppressMini: true)
-        case .favorites: favoritesSection(suppressMini: true)
-        case .collections: collectionsSection(suppressMini: true)
+        case .home: homeSection(suppressMini: true, wide: true)
+        case .search: searchSection(suppressMini: true, wide: true)
+        case .favorites: favoritesSection(suppressMini: true, wide: true)
+        case .collections: collectionsSection(suppressMini: true, wide: true)
         }
     }
 
-    private func homeSection(suppressMini: Bool = false) -> some View {
+    private func homeSection(suppressMini: Bool = false, wide: Bool = false) -> some View {
         NavigationStack(path: $homeStack) {
             HomeScreen()
-                .settingsLogoButton($showingSettings, title: "Home")
+                .settingsLogoButton($showingSettings, title: "Home", wide: wide)
                 .toolbar {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        NotificationBell()
+                    // Bell lives on the rail in the wide layout, so drop it from
+                    // the (now hidden) nav bar there to avoid a duplicate.
+                    if !wide {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            NotificationBell()
+                        }
                     }
                 }
                 .navigationDestination(for: String.self) { showId in
@@ -269,10 +280,10 @@ struct MainNavigation: View {
         .offlineBanner(isConnected: container.networkMonitor.isConnected, isRetrying: container.streamPlayer.isRetrying, errorMessage: playbackBannerError)
     }
 
-    private func searchSection(suppressMini: Bool = false) -> some View {
+    private func searchSection(suppressMini: Bool = false, wide: Bool = false) -> some View {
         NavigationStack(path: $searchStack) {
             SearchScreen(resetToken: searchResetToken)
-                .settingsLogoButton($showingSettings, title: "Search")
+                .settingsLogoButton($showingSettings, title: "Search", wide: wide)
                 .navigationDestination(for: String.self) { showId in
                     ShowDetailScreen(showId: showId, pendingSheet: $pendingShowSheet)
                 }
@@ -281,10 +292,10 @@ struct MainNavigation: View {
         .offlineBanner(isConnected: container.networkMonitor.isConnected, isRetrying: container.streamPlayer.isRetrying, errorMessage: playbackBannerError)
     }
 
-    private func favoritesSection(suppressMini: Bool = false) -> some View {
+    private func favoritesSection(suppressMini: Bool = false, wide: Bool = false) -> some View {
         NavigationStack(path: $favoritesStack) {
             FavoritesScreen()
-                .settingsLogoButton($showingSettings, title: "Favorites")
+                .settingsLogoButton($showingSettings, title: "Favorites", wide: wide)
                 .navigationDestination(for: String.self) { showId in
                     ShowDetailScreen(showId: showId, pendingSheet: $pendingShowSheet)
                 }
@@ -299,10 +310,10 @@ struct MainNavigation: View {
         .offlineBanner(isConnected: container.networkMonitor.isConnected, isRetrying: container.streamPlayer.isRetrying, errorMessage: playbackBannerError)
     }
 
-    private func collectionsSection(suppressMini: Bool = false) -> some View {
+    private func collectionsSection(suppressMini: Bool = false, wide: Bool = false) -> some View {
         NavigationStack(path: $collectionsStack) {
             CollectionsScreen()
-                .settingsLogoButton($showingSettings, title: "Collections")
+                .settingsLogoButton($showingSettings, title: "Collections", wide: wide)
                 .navigationDestination(for: CollectionRoute.self) { route in
                     switch route {
                     case .detail(let id):
@@ -390,8 +401,10 @@ enum AppTab: String, Hashable, CaseIterable {
 /// Icon-only vertical rail shown at regular width in place of the bottom tab
 /// bar. Drives the same `selectedTab` the TabView uses.
 private struct NavSidebar: View {
+    @Environment(\.appContainer) private var container
     @Binding var selectedTab: AppTab
     var onSettings: () -> Void
+    var onNotifications: () -> Void
 
     var body: some View {
         VStack(spacing: 8) {
@@ -414,6 +427,10 @@ private struct NavSidebar: View {
 
             Spacer()
 
+            // Notifications bell just above settings — the wide layout's home for
+            // the bell that sits in the nav bar on narrow screens.
+            notificationsButton
+
             // Settings pinned to the bottom of the rail (uses the otherwise
             // empty vertical space the wide rail frees up).
             Button {
@@ -431,6 +448,35 @@ private struct NavSidebar: View {
         .frame(width: 72)
         .frame(maxHeight: .infinity)
         .background(.bar)
+    }
+
+    /// Rail bell with the unread badge. Unlike the nav-bar `NotificationBell`
+    /// (a NavigationLink), the rail has no NavigationStack, so this drives the
+    /// home stack via the `onNotifications` closure instead.
+    private var notificationsButton: some View {
+        let store = container.notificationStore
+        let unread = store.notifications.unreadCount(appVersion: store.appVersion)
+        return Button {
+            onNotifications()
+        } label: {
+            ZStack(alignment: .topTrailing) {
+                Image(systemName: "bell")
+                    .font(.title2)
+                    .frame(width: 44, height: 44)
+                    .foregroundStyle(Color.secondary)
+                if unread > 0 {
+                    Text(unread > 99 ? "99+" : "\(unread)")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(Color.red, in: Capsule())
+                        .offset(x: -4, y: 4)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(unread > 0 ? "Notifications, \(unread) unread" : "Notifications")
     }
 }
 
@@ -464,24 +510,32 @@ struct PlaceholderScreen: View {
 // MARK: - Settings Logo Button
 
 private extension View {
-    func settingsLogoButton(_ showingSettings: Binding<Bool>, title: String) -> some View {
-        self.navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button { showingSettings.wrappedValue = true } label: {
-                        HStack(spacing: 8) {
-                            Image("deadly_logo")
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 28, height: 28)
-                            Text(title)
-                                .font(.title3)
-                                .fontWeight(.bold)
-                                .foregroundColor(.white)
+    @ViewBuilder
+    func settingsLogoButton(_ showingSettings: Binding<Bool>, title: String, wide: Bool = false) -> some View {
+        if wide {
+            // Wide layout: the rail carries settings + the bell and the selected
+            // icon already names the section, so the nav bar (with its "Home"/
+            // "Search"/… title) is pure overhead. Hide it to reclaim the height.
+            self.toolbar(.hidden, for: .navigationBar)
+        } else {
+            self.navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button { showingSettings.wrappedValue = true } label: {
+                            HStack(spacing: 8) {
+                                Image("deadly_logo")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 28, height: 28)
+                                Text(title)
+                                    .font(.title3)
+                                    .fontWeight(.bold)
+                                    .foregroundColor(.white)
+                            }
                         }
                     }
                 }
-            }
+        }
     }
 }
 

--- a/iosApp/deadly/App/MainNavigation.swift
+++ b/iosApp/deadly/App/MainNavigation.swift
@@ -191,19 +191,25 @@ struct MainNavigation: View {
     @ViewBuilder
     private func rootLayout(isWide: Bool) -> some View {
         if isWide {
-            // Wide (iPad, any phone in landscape): icon rail + selected section.
+            // Wide (iPad, any phone in landscape): icon rail + selected section,
+            // plus a contextual docked side player that replaces the bottom mini
+            // bar whenever a track is loaded.
             HStack(spacing: 0) {
                 NavSidebar(selectedTab: tabSelection)
                 Divider()
                 sectionContent(for: selectedTab)
+                if container.miniPlayerService.isVisible {
+                    Divider()
+                    SidePlayerView(service: container.miniPlayerService, showFullPlayer: $showFullPlayer)
+                }
             }
         } else {
             // Compact (phone portrait): byte-for-byte today's TabView UX.
             TabView(selection: tabSelection) {
-                Tab("Home", systemImage: "house", value: .home) { homeSection }
-                Tab("Search", systemImage: "magnifyingglass", value: .search) { searchSection }
-                Tab("Favorites", systemImage: "heart.fill", value: .favorites) { favoritesSection }
-                Tab("Collections", systemImage: "square.stack", value: .collections) { collectionsSection }
+                Tab("Home", systemImage: "house", value: .home) { homeSection() }
+                Tab("Search", systemImage: "magnifyingglass", value: .search) { searchSection() }
+                Tab("Favorites", systemImage: "heart.fill", value: .favorites) { favoritesSection() }
+                Tab("Collections", systemImage: "square.stack", value: .collections) { collectionsSection() }
             }
         }
     }
@@ -212,15 +218,17 @@ struct MainNavigation: View {
 
     @ViewBuilder
     private func sectionContent(for tab: AppTab) -> some View {
+        // Wide layout: the bottom mini player is replaced by the docked side
+        // player, so suppress it inside each section.
         switch tab {
-        case .home: homeSection
-        case .search: searchSection
-        case .favorites: favoritesSection
-        case .collections: collectionsSection
+        case .home: homeSection(suppressMini: true)
+        case .search: searchSection(suppressMini: true)
+        case .favorites: favoritesSection(suppressMini: true)
+        case .collections: collectionsSection(suppressMini: true)
         }
     }
 
-    private var homeSection: some View {
+    private func homeSection(suppressMini: Bool = false) -> some View {
         NavigationStack(path: $homeStack) {
             HomeScreen()
                 .settingsLogoButton($showingSettings, title: "Home")
@@ -242,11 +250,11 @@ struct MainNavigation: View {
                     NotificationsInboxScreen()
                 }
         }
-        .miniPlayer(miniPlayerService: container.miniPlayerService, showFullPlayer: $showFullPlayer)
+        .miniPlayer(miniPlayerService: container.miniPlayerService, showFullPlayer: $showFullPlayer, enabled: !suppressMini)
         .offlineBanner(isConnected: container.networkMonitor.isConnected, isRetrying: container.streamPlayer.isRetrying, errorMessage: playbackBannerError)
     }
 
-    private var searchSection: some View {
+    private func searchSection(suppressMini: Bool = false) -> some View {
         NavigationStack(path: $searchStack) {
             SearchScreen(resetToken: searchResetToken)
                 .settingsLogoButton($showingSettings, title: "Search")
@@ -254,11 +262,11 @@ struct MainNavigation: View {
                     ShowDetailScreen(showId: showId, pendingSheet: $pendingShowSheet)
                 }
         }
-        .miniPlayer(miniPlayerService: container.miniPlayerService, showFullPlayer: $showFullPlayer)
+        .miniPlayer(miniPlayerService: container.miniPlayerService, showFullPlayer: $showFullPlayer, enabled: !suppressMini)
         .offlineBanner(isConnected: container.networkMonitor.isConnected, isRetrying: container.streamPlayer.isRetrying, errorMessage: playbackBannerError)
     }
 
-    private var favoritesSection: some View {
+    private func favoritesSection(suppressMini: Bool = false) -> some View {
         NavigationStack(path: $favoritesStack) {
             FavoritesScreen()
                 .settingsLogoButton($showingSettings, title: "Favorites")
@@ -272,11 +280,11 @@ struct MainNavigation: View {
                     }
                 }
         }
-        .miniPlayer(miniPlayerService: container.miniPlayerService, showFullPlayer: $showFullPlayer)
+        .miniPlayer(miniPlayerService: container.miniPlayerService, showFullPlayer: $showFullPlayer, enabled: !suppressMini)
         .offlineBanner(isConnected: container.networkMonitor.isConnected, isRetrying: container.streamPlayer.isRetrying, errorMessage: playbackBannerError)
     }
 
-    private var collectionsSection: some View {
+    private func collectionsSection(suppressMini: Bool = false) -> some View {
         NavigationStack(path: $collectionsStack) {
             CollectionsScreen()
                 .settingsLogoButton($showingSettings, title: "Collections")
@@ -290,7 +298,7 @@ struct MainNavigation: View {
                     ShowDetailScreen(showId: showId, pendingSheet: $pendingShowSheet)
                 }
         }
-        .miniPlayer(miniPlayerService: container.miniPlayerService, showFullPlayer: $showFullPlayer)
+        .miniPlayer(miniPlayerService: container.miniPlayerService, showFullPlayer: $showFullPlayer, enabled: !suppressMini)
         .offlineBanner(isConnected: container.networkMonitor.isConnected, isRetrying: container.streamPlayer.isRetrying, errorMessage: playbackBannerError)
     }
 

--- a/iosApp/deadly/App/MainNavigation.swift
+++ b/iosApp/deadly/App/MainNavigation.swift
@@ -34,78 +34,14 @@ struct MainNavigation: View {
         return nil
     }
 
+    /// Width (pt) at/above which the bottom TabView becomes a left icon rail.
+    /// Gated on width (not `horizontalSizeClass`) so a regular iPhone in
+    /// landscape — which reports `.compact` — still gets the wide layout.
+    private static let wideBreakpoint: CGFloat = 600
+
     var body: some View {
-        TabView(selection: tabSelection) {
-            Tab("Home", systemImage: "house", value: .home) {
-                NavigationStack(path: $homeStack) {
-                    HomeScreen()
-                        .settingsLogoButton($showingSettings, title: "Home")
-                        .toolbar {
-                            ToolbarItem(placement: .topBarTrailing) {
-                                NotificationBell()
-                            }
-                        }
-                        .navigationDestination(for: String.self) { showId in
-                            ShowDetailScreen(showId: showId, pendingSheet: $pendingShowSheet)
-                        }
-                        .navigationDestination(for: CollectionRoute.self) { route in
-                            switch route {
-                            case .detail(let id):
-                                CollectionDetailScreen(collectionId: id)
-                            }
-                        }
-                        .navigationDestination(for: NotificationRoute.self) { _ in
-                            NotificationsInboxScreen()
-                        }
-                }
-                .miniPlayer(miniPlayerService: container.miniPlayerService, showFullPlayer: $showFullPlayer)
-                .offlineBanner(isConnected: container.networkMonitor.isConnected, isRetrying: container.streamPlayer.isRetrying, errorMessage: playbackBannerError)
-            }
-            Tab("Search", systemImage: "magnifyingglass", value: .search) {
-                NavigationStack(path: $searchStack) {
-                    SearchScreen(resetToken: searchResetToken)
-                        .settingsLogoButton($showingSettings, title: "Search")
-                        .navigationDestination(for: String.self) { showId in
-                            ShowDetailScreen(showId: showId, pendingSheet: $pendingShowSheet)
-                        }
-                }
-                .miniPlayer(miniPlayerService: container.miniPlayerService, showFullPlayer: $showFullPlayer)
-                .offlineBanner(isConnected: container.networkMonitor.isConnected, isRetrying: container.streamPlayer.isRetrying, errorMessage: playbackBannerError)
-            }
-            Tab("Favorites", systemImage: "heart.fill", value: .favorites) {
-                NavigationStack(path: $favoritesStack) {
-                    FavoritesScreen()
-                        .settingsLogoButton($showingSettings, title: "Favorites")
-                        .navigationDestination(for: String.self) { showId in
-                            ShowDetailScreen(showId: showId, pendingSheet: $pendingShowSheet)
-                        }
-                        .navigationDestination(for: FavoritesRoute.self) { route in
-                            switch route {
-                            case .downloads:
-                                DownloadsScreen()
-                            }
-                        }
-                }
-                .miniPlayer(miniPlayerService: container.miniPlayerService, showFullPlayer: $showFullPlayer)
-                .offlineBanner(isConnected: container.networkMonitor.isConnected, isRetrying: container.streamPlayer.isRetrying, errorMessage: playbackBannerError)
-            }
-            Tab("Collections", systemImage: "square.stack", value: .collections) {
-                NavigationStack(path: $collectionsStack) {
-                    CollectionsScreen()
-                        .settingsLogoButton($showingSettings, title: "Collections")
-                        .navigationDestination(for: CollectionRoute.self) { route in
-                            switch route {
-                            case .detail(let id):
-                                CollectionDetailScreen(collectionId: id)
-                            }
-                        }
-                        .navigationDestination(for: String.self) { showId in
-                            ShowDetailScreen(showId: showId, pendingSheet: $pendingShowSheet)
-                        }
-                }
-                .miniPlayer(miniPlayerService: container.miniPlayerService, showFullPlayer: $showFullPlayer)
-                .offlineBanner(isConnected: container.networkMonitor.isConnected, isRetrying: container.streamPlayer.isRetrying, errorMessage: playbackBannerError)
-            }
+        GeometryReader { geo in
+            rootLayout(isWide: geo.size.width >= Self.wideBreakpoint)
         }
         .overlay {
             SettingsDrawer(isOpen: $showingSettings, onNavigateToDownloads: {
@@ -250,6 +186,114 @@ struct MainNavigation: View {
         }
     }
 
+    // MARK: - Root layout (wide rail vs. compact TabView)
+
+    @ViewBuilder
+    private func rootLayout(isWide: Bool) -> some View {
+        if isWide {
+            // Wide (iPad, any phone in landscape): icon rail + selected section.
+            HStack(spacing: 0) {
+                NavSidebar(selectedTab: tabSelection)
+                Divider()
+                sectionContent(for: selectedTab)
+            }
+        } else {
+            // Compact (phone portrait): byte-for-byte today's TabView UX.
+            TabView(selection: tabSelection) {
+                Tab("Home", systemImage: "house", value: .home) { homeSection }
+                Tab("Search", systemImage: "magnifyingglass", value: .search) { searchSection }
+                Tab("Favorites", systemImage: "heart.fill", value: .favorites) { favoritesSection }
+                Tab("Collections", systemImage: "square.stack", value: .collections) { collectionsSection }
+            }
+        }
+    }
+
+    // MARK: - Section content (shared by the TabView and the wide rail layout)
+
+    @ViewBuilder
+    private func sectionContent(for tab: AppTab) -> some View {
+        switch tab {
+        case .home: homeSection
+        case .search: searchSection
+        case .favorites: favoritesSection
+        case .collections: collectionsSection
+        }
+    }
+
+    private var homeSection: some View {
+        NavigationStack(path: $homeStack) {
+            HomeScreen()
+                .settingsLogoButton($showingSettings, title: "Home")
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        NotificationBell()
+                    }
+                }
+                .navigationDestination(for: String.self) { showId in
+                    ShowDetailScreen(showId: showId, pendingSheet: $pendingShowSheet)
+                }
+                .navigationDestination(for: CollectionRoute.self) { route in
+                    switch route {
+                    case .detail(let id):
+                        CollectionDetailScreen(collectionId: id)
+                    }
+                }
+                .navigationDestination(for: NotificationRoute.self) { _ in
+                    NotificationsInboxScreen()
+                }
+        }
+        .miniPlayer(miniPlayerService: container.miniPlayerService, showFullPlayer: $showFullPlayer)
+        .offlineBanner(isConnected: container.networkMonitor.isConnected, isRetrying: container.streamPlayer.isRetrying, errorMessage: playbackBannerError)
+    }
+
+    private var searchSection: some View {
+        NavigationStack(path: $searchStack) {
+            SearchScreen(resetToken: searchResetToken)
+                .settingsLogoButton($showingSettings, title: "Search")
+                .navigationDestination(for: String.self) { showId in
+                    ShowDetailScreen(showId: showId, pendingSheet: $pendingShowSheet)
+                }
+        }
+        .miniPlayer(miniPlayerService: container.miniPlayerService, showFullPlayer: $showFullPlayer)
+        .offlineBanner(isConnected: container.networkMonitor.isConnected, isRetrying: container.streamPlayer.isRetrying, errorMessage: playbackBannerError)
+    }
+
+    private var favoritesSection: some View {
+        NavigationStack(path: $favoritesStack) {
+            FavoritesScreen()
+                .settingsLogoButton($showingSettings, title: "Favorites")
+                .navigationDestination(for: String.self) { showId in
+                    ShowDetailScreen(showId: showId, pendingSheet: $pendingShowSheet)
+                }
+                .navigationDestination(for: FavoritesRoute.self) { route in
+                    switch route {
+                    case .downloads:
+                        DownloadsScreen()
+                    }
+                }
+        }
+        .miniPlayer(miniPlayerService: container.miniPlayerService, showFullPlayer: $showFullPlayer)
+        .offlineBanner(isConnected: container.networkMonitor.isConnected, isRetrying: container.streamPlayer.isRetrying, errorMessage: playbackBannerError)
+    }
+
+    private var collectionsSection: some View {
+        NavigationStack(path: $collectionsStack) {
+            CollectionsScreen()
+                .settingsLogoButton($showingSettings, title: "Collections")
+                .navigationDestination(for: CollectionRoute.self) { route in
+                    switch route {
+                    case .detail(let id):
+                        CollectionDetailScreen(collectionId: id)
+                    }
+                }
+                .navigationDestination(for: String.self) { showId in
+                    ShowDetailScreen(showId: showId, pendingSheet: $pendingShowSheet)
+                }
+        }
+        .miniPlayer(miniPlayerService: container.miniPlayerService, showFullPlayer: $showFullPlayer)
+        .offlineBanner(isConnected: container.networkMonitor.isConnected, isRetrying: container.streamPlayer.isRetrying, errorMessage: playbackBannerError)
+    }
+
     private var tabSelection: Binding<AppTab> {
         Binding(
             get: { selectedTab },
@@ -303,10 +347,53 @@ struct MainNavigation: View {
 
 // MARK: - Tab enum
 
-enum AppTab: String, Hashable {
+enum AppTab: String, Hashable, CaseIterable {
     case home, search, favorites, collections
 
     var title: String { rawValue.capitalized }
+
+    var systemImage: String {
+        switch self {
+        case .home: return "house"
+        case .search: return "magnifyingglass"
+        case .favorites: return "heart.fill"
+        case .collections: return "square.stack"
+        }
+    }
+}
+
+// MARK: - Navigation Sidebar (wide layout)
+
+/// Icon-only vertical rail shown at regular width in place of the bottom tab
+/// bar. Drives the same `selectedTab` the TabView uses.
+private struct NavSidebar: View {
+    @Binding var selectedTab: AppTab
+
+    var body: some View {
+        VStack(spacing: 8) {
+            ForEach(AppTab.allCases, id: \.self) { tab in
+                let isSelected = tab == selectedTab
+                Button {
+                    selectedTab = tab
+                } label: {
+                    Image(systemName: tab.systemImage)
+                        .font(.title2)
+                        .frame(width: 44, height: 44)
+                        .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(isSelected ? Color.accentColor.opacity(0.15) : Color.clear)
+                        )
+                }
+                .accessibilityLabel(tab.title)
+            }
+            Spacer()
+        }
+        .padding(.vertical, 12)
+        .frame(width: 72)
+        .frame(maxHeight: .infinity)
+        .background(.bar)
+    }
 }
 
 // MARK: - Favorites Routes

--- a/iosApp/deadly/App/MainNavigation.swift
+++ b/iosApp/deadly/App/MainNavigation.swift
@@ -205,8 +205,12 @@ struct MainNavigation: View {
                 )
                 Divider()
                 sectionContent(for: selectedTab)
+                Divider()
+                // The side player column is always present in the wide layout so
+                // the three-pane balance holds even before anything is playing —
+                // it shows a quiet placeholder when idle and the live player once
+                // a track loads.
                 if container.miniPlayerService.isVisible {
-                    Divider()
                     SidePlayerView(
                         service: container.miniPlayerService,
                         showFullPlayer: $showFullPlayer,
@@ -223,6 +227,8 @@ struct MainNavigation: View {
                             navigateToShow(showId: showId, on: selectedTab)
                         }
                     )
+                } else {
+                    SidePlayerPlaceholder()
                 }
             }
         } else {

--- a/iosApp/deadly/App/MainNavigation.swift
+++ b/iosApp/deadly/App/MainNavigation.swift
@@ -200,7 +200,22 @@ struct MainNavigation: View {
                 sectionContent(for: selectedTab)
                 if container.miniPlayerService.isVisible {
                     Divider()
-                    SidePlayerView(service: container.miniPlayerService, showFullPlayer: $showFullPlayer)
+                    SidePlayerView(
+                        service: container.miniPlayerService,
+                        showFullPlayer: $showFullPlayer,
+                        onViewShow: { showId, sheet in
+                            pendingShowSheet = sheet
+                            Task {
+                                await container.playlistService.loadShow(showId)
+                                if let rid = container.streamPlayer.currentTrack?.metadata["recordingId"],
+                                   rid != container.playlistService.currentRecording?.identifier,
+                                   let rec = try? container.showRepository.getRecordingById(rid) {
+                                    await container.playlistService.selectRecording(rec)
+                                }
+                            }
+                            navigateToShow(showId: showId, on: selectedTab)
+                        }
+                    )
                 }
             }
         } else {

--- a/iosApp/deadly/Core/Design/ShowArtwork.swift
+++ b/iosApp/deadly/Core/Design/ShowArtwork.swift
@@ -49,6 +49,11 @@ struct ShowArtwork: View {
         }
         .overlay(alignment: .bottomTrailing) {
             if let resolvedSourceType, resolvedSourceType != .unknown {
+                // Badge metrics scale with the cover so it reads at the same
+                // visual weight on a tiny carousel thumb and a large iPad grid
+                // card alike. Clamped so it never shrinks below the old phone
+                // size or balloons on the full-screen player art.
+                let badgeFont = min(max(size * 0.095, 11), 22)
                 switch ShowArtworkService.shared.badgeStyle {
                 case .none:
                     EmptyView()
@@ -57,21 +62,20 @@ struct ShowArtwork: View {
                         ? resolvedSourceType.badgeLabel
                         : resolvedSourceType.displayName
                     Text(label)
-                        .font(.caption2)
-                        .fontWeight(.bold)
+                        .font(.system(size: badgeFont, weight: .bold))
                         .foregroundStyle(.white)
-                        .padding(.horizontal, 4)
-                        .padding(.vertical, 2)
-                        .background(.black.opacity(0.6), in: RoundedRectangle(cornerRadius: 4))
-                        .padding(3)
+                        .padding(.horizontal, badgeFont * 0.36)
+                        .padding(.vertical, badgeFont * 0.18)
+                        .background(.black.opacity(0.6), in: RoundedRectangle(cornerRadius: badgeFont * 0.36))
+                        .padding(badgeFont * 0.27)
                 case .icon:
                     if let sfSymbol = resolvedSourceType.sfSymbolName {
                         Image(systemName: sfSymbol)
-                            .font(.system(size: 8, weight: .bold))
+                            .font(.system(size: badgeFont * 0.72, weight: .bold))
                             .foregroundStyle(.white)
-                            .frame(width: 16, height: 16)
+                            .frame(width: badgeFont * 1.45, height: badgeFont * 1.45)
                             .background(.black.opacity(0.6), in: Circle())
-                            .padding(3)
+                            .padding(badgeFont * 0.27)
                     }
                 }
             }

--- a/iosApp/deadly/Feature/Favorites/FavoritesScreen.swift
+++ b/iosApp/deadly/Feature/Favorites/FavoritesScreen.swift
@@ -37,6 +37,10 @@ private let decades: [Decade] = [
 
 struct FavoritesScreen: View {
     @Environment(\.appContainer) private var container
+    // .regular on iPad (both orientations) + large tablets; .compact on every
+    // iPhone incl. landscape. Drives the larger grid-card typography so the text
+    // keeps pace with the big covers on a tablet without inflating it on a phone.
+    @Environment(\.horizontalSizeClass) private var hSizeClass
     private var service: FavoritesServiceImpl { container.favoritesService }
 
     @State private var selectedTab: FavoritesTab = .shows
@@ -483,7 +487,12 @@ struct FavoritesScreen: View {
     private func gridCard(_ favoriteShow: FavoriteShow, size: CGFloat) -> some View {
         let show = favoriteShow.show
         let downloadStatus = container.downloadService.downloadStatus(for: show.id)
-        return VStack(alignment: .leading, spacing: 4) {
+        // On a tablet the 3-up cards are large, so step the metadata up from
+        // caption2 to keep it legible beneath them; phones stay as they were.
+        let isRegular = hSizeClass == .regular
+        let dateFont: Font = isRegular ? .headline : .caption2
+        let metaFont: Font = isRegular ? .subheadline : .caption2
+        return VStack(alignment: .leading, spacing: isRegular ? 6 : 4) {
             ShowArtwork(
                 recordingId: show.bestRecordingId,
                 imageUrl: show.coverImageUrl,
@@ -491,36 +500,36 @@ struct FavoritesScreen: View {
                 cornerRadius: DeadlySize.cardCornerRadius
             )
 
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 2) {
+            VStack(alignment: .leading, spacing: isRegular ? 3 : 2) {
+                HStack(spacing: isRegular ? 4 : 2) {
                     if favoriteShow.isPinned {
                         Image(systemName: "pin.fill")
-                            .font(.caption2)
+                            .font(dateFont)
                             .foregroundStyle(DeadlyColors.primary)
                     }
                     if downloadStatus == .completed {
                         Image(systemName: "checkmark.circle.fill")
-                            .font(.caption2)
+                            .font(dateFont)
                             .foregroundStyle(DeadlyColors.primary)
                     }
                     if favoriteShow.hasReview {
                         Image(systemName: "star.fill")
-                            .font(.caption2)
+                            .font(dateFont)
                             .foregroundStyle(DeadlyColors.secondary)
                     }
                     Text(DateFormatting.formatShowDate(show.date, style: .short))
-                        .font(.caption2)
+                        .font(dateFont)
                         .fontWeight(.semibold)
                         .lineLimit(1)
                 }
 
                 Text(show.venue.name)
-                    .font(.caption2)
+                    .font(metaFont)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
 
                 Text(show.location.displayText)
-                    .font(.caption2)
+                    .font(metaFont)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }

--- a/iosApp/deadly/Feature/Player/MiniPlayerOverlay.swift
+++ b/iosApp/deadly/Feature/Player/MiniPlayerOverlay.swift
@@ -1,16 +1,24 @@
 import SwiftUI
 
 extension View {
-    func miniPlayer(miniPlayerService: MiniPlayerServiceImpl, showFullPlayer: Binding<Bool>) -> some View {
-        self
-            .contentMargins(.bottom, miniPlayerService.isVisible ? 80 : 0, for: .scrollContent)
-            .overlay(alignment: .bottom) {
-                VStack(spacing: 8) {
-                    // ADR-0010: end-of-show countdown card, above the mini player.
-                    AutoAdvanceOverlay()
-                    MiniPlayerOverlay(service: miniPlayerService, showFullPlayer: showFullPlayer)
+    /// - Parameter enabled: when `false` (wide layout, where a docked side
+    ///   player replaces the bottom bar) the overlay and its scroll inset are
+    ///   omitted entirely.
+    @ViewBuilder
+    func miniPlayer(miniPlayerService: MiniPlayerServiceImpl, showFullPlayer: Binding<Bool>, enabled: Bool = true) -> some View {
+        if enabled {
+            self
+                .contentMargins(.bottom, miniPlayerService.isVisible ? 80 : 0, for: .scrollContent)
+                .overlay(alignment: .bottom) {
+                    VStack(spacing: 8) {
+                        // ADR-0010: end-of-show countdown card, above the mini player.
+                        AutoAdvanceOverlay()
+                        MiniPlayerOverlay(service: miniPlayerService, showFullPlayer: showFullPlayer)
+                    }
                 }
-            }
+        } else {
+            self
+        }
     }
 }
 

--- a/iosApp/deadly/Feature/Player/SidePlayerView.swift
+++ b/iosApp/deadly/Feature/Player/SidePlayerView.swift
@@ -413,3 +413,28 @@ struct SidePlayerView: View {
         return String(format: "%d:%02d", mins, secs)
     }
 }
+
+/// Idle-state stand-in for the wide layout's side player column. Keeps the
+/// three-pane balance (rail · content · player) before anything is playing so
+/// the screen doesn't look lopsided on first launch. Matches `SidePlayerView`'s
+/// width and background so the live player drops straight in once a track loads.
+struct SidePlayerPlaceholder: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "play.circle")
+                .font(.system(size: 48))
+                .foregroundStyle(.tertiary)
+            Text("Nothing playing")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+            Text("Pick a show to start listening")
+                .font(.subheadline)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, 24)
+        .frame(width: 320)
+        .frame(maxHeight: .infinity)
+        .background(Color(.secondarySystemBackground))
+    }
+}

--- a/iosApp/deadly/Feature/Player/SidePlayerView.swift
+++ b/iosApp/deadly/Feature/Player/SidePlayerView.swift
@@ -52,7 +52,7 @@ struct SidePlayerView: View {
             // Capped by the height left after reserving room for the title,
             // scrubber, and the bottom-pinned controls, so transport is never
             // pushed off-screen on short landscape phones.
-            let cap = min(220, geo.size.height - 280)
+            let cap = min(220, geo.size.height - 348)
             let coverSize = max(56, min(geo.size.height * 0.30, cap))
 
             VStack(spacing: 0) {
@@ -70,16 +70,16 @@ struct SidePlayerView: View {
                 Spacer(minLength: 12)
 
                 secondaryActions
-
-                Spacer().frame(height: 16)
+                    .padding(.vertical, 18)
 
                 transport
+                    .padding(.vertical, 18)
             }
             // Pad inside the full-height frame so the bottom controls stay
             // within bounds with clear spacing beneath them (padding applied
             // after the frame would spill the bottom row off-screen).
-            .padding(.horizontal, 20)
-            .padding(.top, 20)
+            .padding(.horizontal, 16)
+            .padding(.top, 30)
             .padding(.bottom, 24)
             .frame(width: geo.size.width, height: geo.size.height, alignment: .top)
         }

--- a/iosApp/deadly/Feature/Player/SidePlayerView.swift
+++ b/iosApp/deadly/Feature/Player/SidePlayerView.swift
@@ -4,10 +4,12 @@ import SwiftUI
 /// the "more than mini, less than full" player from the tablet/landscape
 /// design. Sized to fit a single landscape screen without scrolling.
 ///
-/// Layout (top → bottom): a mini-player-style header (thumbnail + track info +
-/// favorite), a seekable scrubber, then — pushed to the bottom — a secondary
-/// action row (Connect · Share · Equalizer · ⋯ overflow) above the primary
-/// transport controls, which stay pinned at the bottom.
+/// Layout (top → bottom): a header card — album art with the show date + venue
+/// stacked beside it — then the song title and a seekable scrubber. The art
+/// scales with the column height so the upper block fills the available space
+/// instead of leaving a gap. A secondary action row (Connect · Share ·
+/// Equalizer · ⋯ overflow) sits above the primary transport controls, which
+/// stay pinned at the bottom.
 ///
 /// Contextual: the caller (`MainNavigation.rootLayout`) only mounts this column
 /// while a track is loaded (`service.isVisible`), so the content pane reclaims
@@ -44,26 +46,36 @@ struct SidePlayerView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            header
+        GeometryReader { geo in
+            // Art grows with the column height so the upper block fills the
+            // space (small on a short landscape phone, large on a tall iPad).
+            let coverSize = min(max(geo.size.height * 0.34, 96), 220)
 
-            Spacer().frame(height: 16)
+            VStack(spacing: 0) {
+                header(coverSize: coverSize)
 
-            scrubber
+                Spacer().frame(height: 16)
 
-            // Flexible space between the jog and the bottom-pinned controls.
-            Spacer(minLength: 12)
+                titleRow
 
-            secondaryActions
+                Spacer().frame(height: 18)
 
-            Spacer().frame(height: 16)
+                scrubber
 
-            transport
+                // Absorbs any residual height above the bottom-pinned controls.
+                Spacer(minLength: 12)
+
+                secondaryActions
+
+                Spacer().frame(height: 16)
+
+                transport
+            }
+            .frame(width: geo.size.width, height: geo.size.height, alignment: .top)
+            .padding(.horizontal, 20)
+            .padding(.vertical, 20)
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 20)
         .frame(width: Self.panelWidth)
-        .frame(maxHeight: .infinity)
         .background(Color(.secondarySystemBackground))
         .sheet(isPresented: $showConnectSheet) {
             ConnectSheet()
@@ -118,39 +130,50 @@ struct SidePlayerView: View {
         }
     }
 
-    // MARK: - Header (mini-player style: thumbnail + info + favorite)
+    // MARK: - Header (album art + date / venue beside it)
 
-    private var header: some View {
-        HStack(spacing: 12) {
-            Button {
-                showFullPlayer = true
-            } label: {
-                HStack(spacing: 12) {
-                    ShowArtwork(
-                        recordingId: service.artworkRecordingId,
-                        imageUrl: service.artworkURL,
-                        size: 56,
-                        cornerRadius: DeadlySize.artworkCornerRadius
-                    )
+    private func header(coverSize: CGFloat) -> some View {
+        HStack(alignment: .top, spacing: 14) {
+            ShowArtwork(
+                recordingId: service.artworkRecordingId,
+                imageUrl: service.artworkURL,
+                size: coverSize,
+                cornerRadius: DeadlySize.carouselCornerRadius
+            )
+            .shadow(color: .black.opacity(0.25), radius: 8, y: 4)
+            .contentShape(Rectangle())
+            .onTapGesture { showFullPlayer = true }
 
-                    VStack(alignment: .leading, spacing: 3) {
-                        Text(service.trackTitle ?? "")
-                            .font(.subheadline)
-                            .fontWeight(.semibold)
-                            .foregroundStyle(.primary)
-                            .lineLimit(2)
-                            .multilineTextAlignment(.leading)
+            VStack(alignment: .leading, spacing: 6) {
+                Text(service.showDate ?? "")
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
 
-                        Text(service.displaySubtitle ?? "")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .contentShape(Rectangle())
+                Text(service.venue ?? "")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+                    .multilineTextAlignment(.leading)
+
+                Spacer(minLength: 0)
             }
-            .buttonStyle(.plain)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    // MARK: - Title + favorite
+
+    private var titleRow: some View {
+        HStack(alignment: .center, spacing: 8) {
+            Text(service.trackTitle ?? "")
+                .font(.title3)
+                .fontWeight(.semibold)
+                .foregroundStyle(.primary)
+                .lineLimit(2)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
 
             Button {
                 toggleFavoriteSong()
@@ -188,10 +211,6 @@ struct SidePlayerView: View {
                 let posSec = sliderValue.map { $0 * durSec }
                     ?? Double(service.positionMs) / 1000.0
                 Text(formatTime(posSec))
-                Spacer()
-                if service.trackCount > 0 {
-                    Text("Track \(service.trackIndex + 1) of \(service.trackCount)")
-                }
                 Spacer()
                 Text("-\(formatTime(max(0, durSec - posSec)))")
             }

--- a/iosApp/deadly/Feature/Player/SidePlayerView.swift
+++ b/iosApp/deadly/Feature/Player/SidePlayerView.swift
@@ -22,6 +22,9 @@ struct SidePlayerView: View {
     /// Choose Recording from the "⋯" menu). Mirrors `PlayerScreen.onViewShow`.
     var onViewShow: ((String, ShowDetailSheet?) -> Void)? = nil
     @Environment(\.appContainer) private var container
+    /// Wider on iPad/large tablets (more room, keeps the date on one line beside
+    /// the big cover); stays tight on landscape phones where width is scarce.
+    @Environment(\.horizontalSizeClass) private var hSizeClass
 
     @State private var sliderValue: Double?
     @State private var isCurrentTrackFavorite = false
@@ -33,7 +36,7 @@ struct SidePlayerView: View {
     @State private var showMessageShare = false
     @State private var showQRShare = false
 
-    private static let panelWidth: CGFloat = 320
+    private var panelWidth: CGFloat { hSizeClass == .regular ? 400 : 320 }
 
     private var currentShowId: String? {
         container.streamPlayer.currentTrack?.metadata["showId"]
@@ -47,16 +50,23 @@ struct SidePlayerView: View {
 
     var body: some View {
         GeometryReader { geo in
-            // Art grows with the column height so the upper block fills the
-            // space (small on a short landscape phone, large on a tall iPad).
-            // Capped by the height left after reserving room for the title,
-            // scrubber, and the bottom-pinned controls, so transport is never
-            // pushed off-screen on short landscape phones.
-            let cap = min(220, geo.size.height - 348)
-            let coverSize = max(56, min(geo.size.height * 0.30, cap))
+            // Branch on available HEIGHT, not horizontalSizeClass (which is
+            // unreliable here — an iPad can report .compact). Tall columns
+            // (tablet, any orientation) stack the show text under the cover
+            // like the full player; short columns (landscape phone) keep the
+            // cover + text side-by-side so the title, scrubber, and bottom-
+            // pinned transport still fit without scrolling.
+            let isTall = geo.size.height >= 620
+            let coverSize: CGFloat = {
+                if isTall {
+                    return max(120, min(geo.size.width - 48, geo.size.height * 0.40, 360))
+                }
+                let cap = min(220, geo.size.height - 348)
+                return max(56, min(geo.size.height * 0.30, cap))
+            }()
 
             VStack(spacing: 0) {
-                header(coverSize: coverSize)
+                header(coverSize: coverSize, isTall: isTall)
 
                 Spacer().frame(height: 8)
 
@@ -83,7 +93,7 @@ struct SidePlayerView: View {
             .padding(.bottom, 24)
             .frame(width: geo.size.width, height: geo.size.height, alignment: .top)
         }
-        .frame(width: Self.panelWidth)
+        .frame(width: panelWidth)
         .background(Color(.secondarySystemBackground))
         .sheet(isPresented: $showConnectSheet) {
             ConnectSheet()
@@ -140,34 +150,63 @@ struct SidePlayerView: View {
 
     // MARK: - Header (album art + date / venue beside it)
 
-    private func header(coverSize: CGFloat) -> some View {
-        HStack(alignment: .top, spacing: 14) {
-            ShowArtwork(
-                recordingId: service.artworkRecordingId,
-                imageUrl: service.artworkURL,
-                size: coverSize,
-                cornerRadius: DeadlySize.carouselCornerRadius
-            )
-            .shadow(color: .black.opacity(0.25), radius: 8, y: 4)
-            .contentShape(Rectangle())
-            .onTapGesture { showFullPlayer = true }
+    @ViewBuilder
+    private func header(coverSize: CGFloat, isTall: Bool) -> some View {
+        let cover = ShowArtwork(
+            recordingId: service.artworkRecordingId,
+            imageUrl: service.artworkURL,
+            size: coverSize,
+            cornerRadius: DeadlySize.carouselCornerRadius
+        )
+        .shadow(color: .black.opacity(0.25), radius: 8, y: 4)
+        .contentShape(Rectangle())
+        .onTapGesture { showFullPlayer = true }
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text(service.showDate ?? "")
-                    .font(.headline)
-                    .foregroundStyle(.primary)
-                    .lineLimit(2)
-                    .multilineTextAlignment(.leading)
+        if isTall {
+            // Tablet: cover on top, show date + venue centered beneath it —
+            // mirrors the full mobile player, filling the room under the art.
+            VStack(spacing: 16) {
+                cover
 
-                Text(service.venue ?? "")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(3)
-                    .multilineTextAlignment(.leading)
+                VStack(spacing: 6) {
+                    Text(service.showDate ?? "")
+                        .font(.title3)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.primary)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.center)
 
-                Spacer(minLength: 0)
+                    Text(service.venue ?? "")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(maxWidth: .infinity)
+        } else {
+            // Landscape phone: side-by-side to stay compact against the short height.
+            HStack(alignment: .top, spacing: 14) {
+                cover
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(service.showDate ?? "")
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+
+                    Text(service.venue ?? "")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(3)
+                        .multilineTextAlignment(.leading)
+
+                    Spacer(minLength: 0)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
     }
 
@@ -419,6 +458,11 @@ struct SidePlayerView: View {
 /// the screen doesn't look lopsided on first launch. Matches `SidePlayerView`'s
 /// width and background so the live player drops straight in once a track loads.
 struct SidePlayerPlaceholder: View {
+    // Keep in lockstep with SidePlayerView.panelWidth so the column width
+    // doesn't jump when the live player swaps in.
+    @Environment(\.horizontalSizeClass) private var hSizeClass
+    private var panelWidth: CGFloat { hSizeClass == .regular ? 400 : 320 }
+
     var body: some View {
         VStack(spacing: 12) {
             Image(systemName: "play.circle")
@@ -433,7 +477,7 @@ struct SidePlayerPlaceholder: View {
                 .multilineTextAlignment(.center)
         }
         .padding(.horizontal, 24)
-        .frame(width: 320)
+        .frame(width: panelWidth)
         .frame(maxHeight: .infinity)
         .background(Color(.secondarySystemBackground))
     }

--- a/iosApp/deadly/Feature/Player/SidePlayerView.swift
+++ b/iosApp/deadly/Feature/Player/SidePlayerView.swift
@@ -1,0 +1,185 @@
+import SwiftUI
+
+/// Docked side player for the wide layout (iPad, any phone in landscape) —
+/// the "more than mini, less than full" player from the tablet/landscape
+/// design. A compact vertical arrangement reusing the full player's building
+/// blocks: cover art, track info (+ favorite), a seekable scrubber, and
+/// transport controls.
+///
+/// Contextual: the caller (`MainNavigation.rootLayout`) only mounts this column
+/// while a track is loaded (`service.isVisible`), so the content pane reclaims
+/// the full width when playback is idle. Reads the shared `MiniPlayerServiceImpl`
+/// (the same source the mini and full players use), so it stays in sync.
+struct SidePlayerView: View {
+    let service: MiniPlayerServiceImpl
+    @Binding var showFullPlayer: Bool
+    @Environment(\.appContainer) private var container
+
+    @State private var sliderValue: Double?
+    @State private var isCurrentTrackFavorite = false
+
+    private static let panelWidth: CGFloat = 320
+
+    private var currentShowId: String? {
+        container.streamPlayer.currentTrack?.metadata["showId"]
+    }
+    private var currentRecordingId: String? {
+        container.streamPlayer.currentTrack?.metadata["recordingId"]
+    }
+    private var currentTrackNumber: String? {
+        container.streamPlayer.currentTrack?.metadata["trackNumber"]
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                // Cover art — tap to open the full player.
+                ShowArtwork(
+                    recordingId: service.artworkRecordingId,
+                    imageUrl: service.artworkURL,
+                    size: Self.panelWidth - 48,
+                    cornerRadius: DeadlySize.carouselCornerRadius
+                )
+                .shadow(color: .black.opacity(0.3), radius: 12, y: 6)
+                .contentShape(Rectangle())
+                .onTapGesture { showFullPlayer = true }
+
+                Spacer().frame(height: 24)
+
+                // Track info with the prominent Favorite action (ADR-0014).
+                HStack(alignment: .center, spacing: 8) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(service.trackTitle ?? "")
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.primary)
+                            .lineLimit(2)
+                            .multilineTextAlignment(.leading)
+
+                        Text(service.displaySubtitle ?? "")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Button {
+                        toggleFavoriteSong()
+                    } label: {
+                        Image(systemName: isCurrentTrackFavorite ? "heart.fill" : "heart")
+                            .font(.title3)
+                            .foregroundStyle(isCurrentTrackFavorite ? DeadlyColors.primary : .secondary)
+                            .frame(width: 40, height: 40)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(currentShowId == nil)
+                }
+
+                Spacer().frame(height: 16)
+
+                // Progress slider
+                Slider(
+                    value: Binding(
+                        get: { sliderValue ?? service.playbackProgress },
+                        set: { sliderValue = $0 }
+                    ),
+                    in: 0...1
+                ) { editing in
+                    if !editing, let value = sliderValue {
+                        service.seek(fraction: value)
+                        sliderValue = nil
+                    }
+                }
+                .tint(DeadlyColors.primary)
+
+                HStack {
+                    let durSec = Double(service.durationMs) / 1000.0
+                    let posSec = sliderValue.map { $0 * durSec }
+                        ?? Double(service.positionMs) / 1000.0
+                    Text(formatTime(posSec))
+                    Spacer()
+                    Text("-\(formatTime(max(0, durSec - posSec)))")
+                }
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+
+                Spacer().frame(height: 16)
+
+                // Transport controls
+                HStack(spacing: 36) {
+                    Button {
+                        container.playlistService.noteUserSkip(forward: false)
+                        service.skipPrev()
+                    } label: {
+                        Image(systemName: "backward.fill")
+                            .font(.title2)
+                            .foregroundStyle(.primary)
+                    }
+
+                    if service.isPendingCommand || service.isPreparing || service.isRetrying
+                        || (service.isBuffering && !service.isPlaying) {
+                        ProgressView()
+                            .controlSize(.large)
+                            .frame(width: 56, height: 56)
+                    } else {
+                        Button {
+                            service.togglePlayPause()
+                        } label: {
+                            Image(systemName: service.isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                                .font(.system(size: 56))
+                                .foregroundStyle(DeadlyColors.primary)
+                        }
+                    }
+
+                    Button {
+                        container.playlistService.noteUserSkip(forward: true)
+                        service.skipNext()
+                    } label: {
+                        Image(systemName: "forward.fill")
+                            .font(.title2)
+                            .foregroundStyle(service.hasNext ? .primary : .tertiary)
+                    }
+                    .disabled(!service.hasNext)
+                }
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 24)
+        }
+        .frame(width: Self.panelWidth)
+        .frame(maxHeight: .infinity)
+        .background(Color(.secondarySystemBackground))
+        .task(id: container.streamPlayer.currentTrack?.id) {
+            loadFavoriteState()
+        }
+    }
+
+    private func toggleFavoriteSong() {
+        guard let showId = currentShowId,
+              let trackTitle = container.streamPlayer.currentTrack?.title else { return }
+        try? container.reviewService.toggleFavoriteSong(
+            showId: showId,
+            trackTitle: trackTitle,
+            trackNumber: currentTrackNumber.flatMap { Int($0) },
+            recordingId: currentRecordingId
+        )
+        isCurrentTrackFavorite.toggle()
+    }
+
+    private func loadFavoriteState() {
+        guard let showId = currentShowId,
+              let trackTitle = container.streamPlayer.currentTrack?.title else {
+            isCurrentTrackFavorite = false
+            return
+        }
+        isCurrentTrackFavorite = (try? container.reviewService.isSongFavorite(
+            showId: showId, trackTitle: trackTitle
+        )) ?? false
+    }
+
+    private func formatTime(_ seconds: TimeInterval) -> String {
+        guard seconds.isFinite, seconds >= 0 else { return "0:00" }
+        let mins = Int(seconds) / 60
+        let secs = Int(seconds) % 60
+        return String(format: "%d:%02d", mins, secs)
+    }
+}

--- a/iosApp/deadly/Feature/Player/SidePlayerView.swift
+++ b/iosApp/deadly/Feature/Player/SidePlayerView.swift
@@ -49,16 +49,20 @@ struct SidePlayerView: View {
         GeometryReader { geo in
             // Art grows with the column height so the upper block fills the
             // space (small on a short landscape phone, large on a tall iPad).
-            let coverSize = min(max(geo.size.height * 0.34, 96), 220)
+            // Capped by the height left after reserving room for the title,
+            // scrubber, and the bottom-pinned controls, so transport is never
+            // pushed off-screen on short landscape phones.
+            let cap = min(220, geo.size.height - 280)
+            let coverSize = max(56, min(geo.size.height * 0.30, cap))
 
             VStack(spacing: 0) {
                 header(coverSize: coverSize)
 
-                Spacer().frame(height: 16)
+                Spacer().frame(height: 8)
 
                 titleRow
 
-                Spacer().frame(height: 18)
+                Spacer().frame(height: 12)
 
                 scrubber
 
@@ -71,9 +75,13 @@ struct SidePlayerView: View {
 
                 transport
             }
-            .frame(width: geo.size.width, height: geo.size.height, alignment: .top)
+            // Pad inside the full-height frame so the bottom controls stay
+            // within bounds with clear spacing beneath them (padding applied
+            // after the frame would spill the bottom row off-screen).
             .padding(.horizontal, 20)
-            .padding(.vertical, 20)
+            .padding(.top, 20)
+            .padding(.bottom, 24)
+            .frame(width: geo.size.width, height: geo.size.height, alignment: .top)
         }
         .frame(width: Self.panelWidth)
         .background(Color(.secondarySystemBackground))

--- a/iosApp/deadly/Feature/Player/SidePlayerView.swift
+++ b/iosApp/deadly/Feature/Player/SidePlayerView.swift
@@ -2,9 +2,12 @@ import SwiftUI
 
 /// Docked side player for the wide layout (iPad, any phone in landscape) —
 /// the "more than mini, less than full" player from the tablet/landscape
-/// design. A compact vertical arrangement reusing the full player's building
-/// blocks: cover art, track info (+ favorite), a seekable scrubber, and
-/// transport controls.
+/// design. Sized to fit a single landscape screen without scrolling.
+///
+/// Layout (top → bottom): a mini-player-style header (thumbnail + track info +
+/// favorite), a seekable scrubber, then — pushed to the bottom — a secondary
+/// action row (Connect · Share · Equalizer · ⋯ overflow) above the primary
+/// transport controls, which stay pinned at the bottom.
 ///
 /// Contextual: the caller (`MainNavigation.rootLayout`) only mounts this column
 /// while a track is loaded (`service.isVisible`), so the content pane reclaims
@@ -13,10 +16,20 @@ import SwiftUI
 struct SidePlayerView: View {
     let service: MiniPlayerServiceImpl
     @Binding var showFullPlayer: Bool
+    /// Navigates to a show's playlist (its home for Setlist / Collections /
+    /// Choose Recording from the "⋯" menu). Mirrors `PlayerScreen.onViewShow`.
+    var onViewShow: ((String, ShowDetailSheet?) -> Void)? = nil
     @Environment(\.appContainer) private var container
 
     @State private var sliderValue: Double?
     @State private var isCurrentTrackFavorite = false
+    @State private var showCollectionsCount = 0
+    @State private var showConnectSheet = false
+    @State private var showEqualizerSheet = false
+    @State private var showMenuSheet = false
+    @State private var showShareChooser = false
+    @State private var showMessageShare = false
+    @State private var showQRShare = false
 
     private static let panelWidth: CGFloat = 320
 
@@ -31,24 +44,96 @@ struct SidePlayerView: View {
     }
 
     var body: some View {
-        ScrollView {
-            VStack(spacing: 0) {
-                // Cover art — tap to open the full player.
-                ShowArtwork(
-                    recordingId: service.artworkRecordingId,
-                    imageUrl: service.artworkURL,
-                    size: Self.panelWidth - 48,
-                    cornerRadius: DeadlySize.carouselCornerRadius
+        VStack(spacing: 0) {
+            header
+
+            Spacer().frame(height: 16)
+
+            scrubber
+
+            // Flexible space between the jog and the bottom-pinned controls.
+            Spacer(minLength: 12)
+
+            secondaryActions
+
+            Spacer().frame(height: 16)
+
+            transport
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 20)
+        .frame(width: Self.panelWidth)
+        .frame(maxHeight: .infinity)
+        .background(Color(.secondarySystemBackground))
+        .sheet(isPresented: $showConnectSheet) {
+            ConnectSheet()
+                .environment(\.appContainer, container)
+        }
+        .sheet(isPresented: $showEqualizerSheet) {
+            EqualizerSheet()
+                .presentationDetents([.medium, .large])
+        }
+        .sheet(isPresented: $showMenuSheet) {
+            menuSheet
+        }
+        .sheet(isPresented: $showShareChooser) {
+            ShareChooserSheet(
+                onMessageShare: {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        showMessageShare = true
+                    }
+                },
+                onQrShare: {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        showQRShare = true
+                    }
+                }
+            )
+        }
+        .sheet(isPresented: $showMessageShare) {
+            if let show = container.playlistService.currentShow,
+               let recording = container.playlistService.currentRecording {
+                let url = buildShareUrl(showId: show.id, recordingId: recording.identifier, trackNumber: currentTrackNumber)
+                ShareActivityView(items: MessageShareService.shareItems(url: url))
+            }
+        }
+        .sheet(isPresented: $showQRShare) {
+            if let show = container.playlistService.currentShow,
+               let recording = container.playlistService.currentRecording {
+                QRShareSheet(
+                    showId: show.id,
+                    recordingId: recording.identifier,
+                    showDate: DateFormatting.formatShowDate(show.date),
+                    venue: show.venue.name,
+                    location: show.venue.displayLocation,
+                    coverImageUrl: container.streamPlayer.currentTrack?.artworkURL?.absoluteString,
+                    trackNumber: currentTrackNumber,
+                    songTitle: container.streamPlayer.currentTrack?.title
                 )
-                .shadow(color: .black.opacity(0.3), radius: 12, y: 6)
-                .contentShape(Rectangle())
-                .onTapGesture { showFullPlayer = true }
+            }
+        }
+        .task(id: container.streamPlayer.currentTrack?.id) {
+            loadFavoriteState()
+            showCollectionsCount = currentShowId.map { container.collectionsService.collectionsContaining(showId: $0).count } ?? 0
+        }
+    }
 
-                Spacer().frame(height: 24)
+    // MARK: - Header (mini-player style: thumbnail + info + favorite)
 
-                // Track info with the prominent Favorite action (ADR-0014).
-                HStack(alignment: .center, spacing: 8) {
-                    VStack(alignment: .leading, spacing: 4) {
+    private var header: some View {
+        HStack(spacing: 12) {
+            Button {
+                showFullPlayer = true
+            } label: {
+                HStack(spacing: 12) {
+                    ShowArtwork(
+                        recordingId: service.artworkRecordingId,
+                        imageUrl: service.artworkURL,
+                        size: 56,
+                        cornerRadius: DeadlySize.artworkCornerRadius
+                    )
+
+                    VStack(alignment: .leading, spacing: 3) {
                         Text(service.trackTitle ?? "")
                             .font(.subheadline)
                             .fontWeight(.semibold)
@@ -62,96 +147,189 @@ struct SidePlayerView: View {
                             .lineLimit(1)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
-
-                    Button {
-                        toggleFavoriteSong()
-                    } label: {
-                        Image(systemName: isCurrentTrackFavorite ? "heart.fill" : "heart")
-                            .font(.title3)
-                            .foregroundStyle(isCurrentTrackFavorite ? DeadlyColors.primary : .secondary)
-                            .frame(width: 40, height: 40)
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(currentShowId == nil)
                 }
-
-                Spacer().frame(height: 16)
-
-                // Progress slider
-                Slider(
-                    value: Binding(
-                        get: { sliderValue ?? service.playbackProgress },
-                        set: { sliderValue = $0 }
-                    ),
-                    in: 0...1
-                ) { editing in
-                    if !editing, let value = sliderValue {
-                        service.seek(fraction: value)
-                        sliderValue = nil
-                    }
-                }
-                .tint(DeadlyColors.primary)
-
-                HStack {
-                    let durSec = Double(service.durationMs) / 1000.0
-                    let posSec = sliderValue.map { $0 * durSec }
-                        ?? Double(service.positionMs) / 1000.0
-                    Text(formatTime(posSec))
-                    Spacer()
-                    Text("-\(formatTime(max(0, durSec - posSec)))")
-                }
-                .font(.caption2)
-                .foregroundStyle(.tertiary)
-
-                Spacer().frame(height: 16)
-
-                // Transport controls
-                HStack(spacing: 36) {
-                    Button {
-                        container.playlistService.noteUserSkip(forward: false)
-                        service.skipPrev()
-                    } label: {
-                        Image(systemName: "backward.fill")
-                            .font(.title2)
-                            .foregroundStyle(.primary)
-                    }
-
-                    if service.isPendingCommand || service.isPreparing || service.isRetrying
-                        || (service.isBuffering && !service.isPlaying) {
-                        ProgressView()
-                            .controlSize(.large)
-                            .frame(width: 56, height: 56)
-                    } else {
-                        Button {
-                            service.togglePlayPause()
-                        } label: {
-                            Image(systemName: service.isPlaying ? "pause.circle.fill" : "play.circle.fill")
-                                .font(.system(size: 56))
-                                .foregroundStyle(DeadlyColors.primary)
-                        }
-                    }
-
-                    Button {
-                        container.playlistService.noteUserSkip(forward: true)
-                        service.skipNext()
-                    } label: {
-                        Image(systemName: "forward.fill")
-                            .font(.title2)
-                            .foregroundStyle(service.hasNext ? .primary : .tertiary)
-                    }
-                    .disabled(!service.hasNext)
-                }
+                .contentShape(Rectangle())
             }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 24)
-        }
-        .frame(width: Self.panelWidth)
-        .frame(maxHeight: .infinity)
-        .background(Color(.secondarySystemBackground))
-        .task(id: container.streamPlayer.currentTrack?.id) {
-            loadFavoriteState()
+            .buttonStyle(.plain)
+
+            Button {
+                toggleFavoriteSong()
+            } label: {
+                Image(systemName: isCurrentTrackFavorite ? "heart.fill" : "heart")
+                    .font(.title3)
+                    .foregroundStyle(isCurrentTrackFavorite ? DeadlyColors.primary : .secondary)
+                    .frame(width: 40, height: 40)
+            }
+            .buttonStyle(.plain)
+            .disabled(currentShowId == nil)
         }
     }
+
+    // MARK: - Scrubber
+
+    private var scrubber: some View {
+        VStack(spacing: 4) {
+            Slider(
+                value: Binding(
+                    get: { sliderValue ?? service.playbackProgress },
+                    set: { sliderValue = $0 }
+                ),
+                in: 0...1
+            ) { editing in
+                if !editing, let value = sliderValue {
+                    service.seek(fraction: value)
+                    sliderValue = nil
+                }
+            }
+            .tint(DeadlyColors.primary)
+
+            HStack {
+                let durSec = Double(service.durationMs) / 1000.0
+                let posSec = sliderValue.map { $0 * durSec }
+                    ?? Double(service.positionMs) / 1000.0
+                Text(formatTime(posSec))
+                Spacer()
+                if service.trackCount > 0 {
+                    Text("Track \(service.trackIndex + 1) of \(service.trackCount)")
+                }
+                Spacer()
+                Text("-\(formatTime(max(0, durSec - posSec)))")
+            }
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+        }
+    }
+
+    // MARK: - Secondary actions (Connect · Share · Equalizer · ⋯)
+
+    private var secondaryActions: some View {
+        HStack(spacing: 0) {
+            // Connect / AirPlay — left, with optional active-device label.
+            Button {
+                showConnectSheet = true
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "airplayaudio")
+                        .font(.title3)
+                    if let name = container.connectService.connectState?.activeDeviceName,
+                       container.connectService.isRemoteControlling {
+                        Text(name)
+                            .font(.caption2)
+                            .lineLimit(1)
+                            .frame(maxWidth: 80, alignment: .leading)
+                    }
+                }
+                .foregroundStyle(container.connectService.isRemoteControlling ? DeadlyColors.primary : .secondary)
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+
+            // Share
+            Button {
+                showShareChooser = true
+            } label: {
+                Image(systemName: "square.and.arrow.up")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 40, height: 40)
+            }
+            .buttonStyle(.plain)
+            .disabled(currentShowId == nil)
+
+            // Equalizer
+            Button {
+                showEqualizerSheet = true
+            } label: {
+                Image(systemName: "slider.vertical.3")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 40, height: 40)
+            }
+            .buttonStyle(.plain)
+
+            // Overflow "⋯" — the full menu (Choose Recording · Autoplay ·
+            // Setlist · Collections · Download).
+            Button {
+                showMenuSheet = true
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 40, height: 40)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: - Transport (pinned at the bottom)
+
+    private var transport: some View {
+        HStack(spacing: 36) {
+            Button {
+                container.playlistService.noteUserSkip(forward: false)
+                service.skipPrev()
+            } label: {
+                Image(systemName: "backward.fill")
+                    .font(.title2)
+                    .foregroundStyle(.primary)
+            }
+
+            if service.isPendingCommand || service.isPreparing || service.isRetrying
+                || (service.isBuffering && !service.isPlaying) {
+                ProgressView()
+                    .controlSize(.large)
+                    .frame(width: 56, height: 56)
+            } else {
+                Button {
+                    service.togglePlayPause()
+                } label: {
+                    Image(systemName: service.isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                        .font(.system(size: 56))
+                        .foregroundStyle(DeadlyColors.primary)
+                }
+            }
+
+            Button {
+                container.playlistService.noteUserSkip(forward: true)
+                service.skipNext()
+            } label: {
+                Image(systemName: "forward.fill")
+                    .font(.title2)
+                    .foregroundStyle(service.hasNext ? .primary : .tertiary)
+            }
+            .disabled(!service.hasNext)
+        }
+    }
+
+    // MARK: - Overflow menu
+
+    private var menuSheet: some View {
+        ShowActionsMenuSheet(
+            isAutoplayEnabled: container.appPreferences.autoAdvanceEnabled,
+            collectionsCount: showCollectionsCount,
+            onChooseRecording: {
+                showMenuSheet = false
+                if let sid = currentShowId { onViewShow?(sid, .recording) }
+            },
+            onAutoplay: { toggleAutoAdvance() },
+            onSetlist: {
+                showMenuSheet = false
+                if let sid = currentShowId { onViewShow?(sid, .setlist) }
+            },
+            onCollections: {
+                showMenuSheet = false
+                if let sid = currentShowId { onViewShow?(sid, .collections) }
+            },
+            onDownload: {
+                showMenuSheet = false
+                downloadCurrentShow()
+            },
+            onDone: { showMenuSheet = false }
+        )
+    }
+
+    // MARK: - Actions
 
     private func toggleFavoriteSong() {
         guard let showId = currentShowId,
@@ -174,6 +352,31 @@ struct SidePlayerView: View {
         isCurrentTrackFavorite = (try? container.reviewService.isSongFavorite(
             showId: showId, trackTitle: trackTitle
         )) ?? false
+    }
+
+    private func toggleAutoAdvance() {
+        let newValue = !container.appPreferences.autoAdvanceEnabled
+        container.appPreferences.autoAdvanceEnabled = newValue
+        container.toastPresenter.show(autoplayToastMessage(newValue))
+        container.analyticsService.track("feature_use", props: [
+            "feature": "toggle_auto_advance",
+            "category": "playback",
+            "enabled": newValue,
+        ])
+    }
+
+    private func downloadCurrentShow() {
+        guard let showId = currentShowId else { return }
+        Task {
+            try? await container.downloadService.downloadShow(showId, recordingId: currentRecordingId)
+        }
+    }
+
+    private func buildShareUrl(showId: String, recordingId: String?, trackNumber: String?) -> String {
+        var url = "\(container.appPreferences.shareBaseUrl)/shows/\(showId)"
+        if let rid = recordingId { url += "/recording/\(rid)" }
+        if let track = trackNumber { url += "/track/\(track)" }
+        return url
     }
 
     private func formatTime(_ seconds: TimeInterval) -> String {


### PR DESCRIPTION
## Summary
Adds a width-gated wide layout for tablets and landscape phones: a left icon nav rail + content + a contextual docked side player, replacing the bottom tab bar / mini player when the screen is wide enough. Narrow (phone portrait) is unchanged.

- **Wide layout** gated on width ≥600 (iOS `GeometryReader`, Android ≥600dp) so a landscape phone reporting `.compact` still qualifies; iPad target enabled.
- **Icon nav rail** with Settings + notifications bell; cutout padding and a capped settings-drawer width in wide layouts.
- **Contextual side player** — header card (height-scaled cover + show date/venue), title/favorite, scrubber, Connect/Share/EQ/⋯ row, pinned transport. Shows an idle placeholder so the three-pane balance holds before playback.
- **Side player show info stacks under the cover** on tall (tablet) columns and stays side-by-side on short (landscape-phone) columns — branches on available height, not `horizontalSizeClass` (unreliable on iPad).
- **Tablet readability**: source badge metrics + Favorites grid typography scale up at the larger size.
- **Android Favorites** default to grid + tighter spacing in landscape.

## Incidental fixes
- `fix(android/player)`: skip-previous vector rendered as `|/` on legacy Fire OS — split into two absolute paths.
- `chore(build)`: harden `ios-remote-sim`/build make targets (generic sim destination, `pipefail`, refuse to install a stale `.app`).

## Testing
- iPad Pro 11" sim: three-pane layout + stacked side-player header verified.
- Fire tablet (`installDebug`): builds/installs; skip-previous icon fixed.
- Android tablet: side-player stacked header verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)