### PR TITLE
fix(all/connect): trust the playing device over stale server track state

### DIFF
--- a/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
+++ b/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
@@ -375,6 +375,7 @@ class ConnectServiceImpl @Inject constructor(
             put("type", "heartbeat")
             put("playing", mediaControllerRepository.isPlaying.value)
             put("recordingId", recordingId)
+            put("trackIndex", mediaControllerRepository.currentTrackIndex.value)
             put("positionMs", mediaControllerRepository.currentPosition.value.toInt())
         }.toString()
     }
@@ -701,16 +702,35 @@ class ConnectServiceImpl @Inject constructor(
             val currentVolume = mediaControllerRepository.getVolume()
             _activeDeviceVolume.value = currentVolume
             sendVolumeReport(currentVolume)
-            val targetPositionMs = interpolatedPositionMs(new)
-            val localTrackIndex = mediaControllerRepository.currentTrackIndex.value
-            if (localTrackIndex != new.trackIndex) {
-                Log.d(TAG, "reactToState: became active, syncing track $localTrackIndex -> ${new.trackIndex} pos=${targetPositionMs}ms (interpolated from ${new.positionMs}ms)")
-                mediaControllerRepository.seekToMediaItemIndex(new.trackIndex, targetPositionMs.toLong())
+
+            // The device producing audio is the transport authority. When we're
+            // already playing this recording and the lease promotes us to active,
+            // do NOT seek the local player down to the server's stored track/pos:
+            // that snaps the user backward (the server's trackIndex goes stale after
+            // a natural auto-advance, and its position can lag behind ours). Keep
+            // playing — our heartbeat lease (which carries trackIndex+pos) and our
+            // position reports push our real state UP to the server instead.
+            // Breaking live audio to match the server is never the right trade.
+            //
+            // We still sync DOWN when we became active some other way (e.g. a
+            // transfer in while paused or on a different recording): there the
+            // server state is the genuine intent, not a stale echo of ours.
+            val alreadyPlayingThisRecording =
+                locallyPlaying && localRecordingId == new.recordingId
+            if (alreadyPlayingThisRecording) {
+                Log.d(TAG, "reactToState: became active while already playing ${new.recordingId} — keeping local track/pos, asserting up to server (not seeking down)")
             } else {
-                val localPositionMs = mediaControllerRepository.currentPosition.value
-                if (abs(localPositionMs - targetPositionMs.toLong()) > ACTIVATE_POSITION_SYNC_THRESHOLD_MS) {
-                    Log.d(TAG, "reactToState: became active, syncing position to ${targetPositionMs}ms (interpolated from ${new.positionMs}ms)")
-                    mediaControllerRepository.seekToPosition(targetPositionMs.toLong())
+                val targetPositionMs = interpolatedPositionMs(new)
+                val localTrackIndex = mediaControllerRepository.currentTrackIndex.value
+                if (localTrackIndex != new.trackIndex) {
+                    Log.d(TAG, "reactToState: became active, syncing track $localTrackIndex -> ${new.trackIndex} pos=${targetPositionMs}ms (interpolated from ${new.positionMs}ms)")
+                    mediaControllerRepository.seekToMediaItemIndex(new.trackIndex, targetPositionMs.toLong())
+                } else {
+                    val localPositionMs = mediaControllerRepository.currentPosition.value
+                    if (abs(localPositionMs - targetPositionMs.toLong()) > ACTIVATE_POSITION_SYNC_THRESHOLD_MS) {
+                        Log.d(TAG, "reactToState: became active, syncing position to ${targetPositionMs}ms (interpolated from ${new.positionMs}ms)")
+                        mediaControllerRepository.seekToPosition(targetPositionMs.toLong())
+                    }
                 }
             }
         }

--- a/api/src/connect/__tests__/state.lease.test.ts
+++ b/api/src/connect/__tests__/state.lease.test.ts
@@ -51,27 +51,30 @@ function ownerlessSession(proto = 1) {
 describe("handleHeartbeat ownership lease (ADR-0011 Chunk B)", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("claims an ownerless session when the heartbeat is playing + recording matches", () => {
-    const { userId, deviceId } = ownerlessSession();
+  it("claims an ownerless session when the heartbeat is playing + recording matches, healing to the device's own track/pos", () => {
+    const { userId, deviceId } = ownerlessSession(); // loaded at trackIndex 0
     expect(getOrCreateState(userId).activeDeviceId).toBeNull();
 
-    handleHeartbeat(userId, deviceId, { playing: true, recordingId: "rec1", positionMs: 5_000 });
+    // Device has since auto-advanced to track 1 — the server never learned that
+    // (auto-advance emits no command), so its stored trackIndex is a stale 0.
+    handleHeartbeat(userId, deviceId, { playing: true, recordingId: "rec1", trackIndex: 1, positionMs: 5_000 });
 
     const s = getOrCreateState(userId);
     expect(s.activeDeviceId).toBe(deviceId);
     expect(s.playing).toBe(true);
+    expect(s.trackIndex).toBe(1); // healed to the device's real track, not the stale 0
     expect(s.positionMs).toBe(5_000); // position taken from the lease
   });
 
   it("does NOT claim when the lease is paused (parked/transferred-away device)", () => {
     const { userId, deviceId } = ownerlessSession();
-    handleHeartbeat(userId, deviceId, { playing: false, recordingId: "rec1", positionMs: 5_000 });
+    handleHeartbeat(userId, deviceId, { playing: false, recordingId: "rec1", trackIndex: 0, positionMs: 5_000 });
     expect(getOrCreateState(userId).activeDeviceId).toBeNull();
   });
 
   it("does NOT claim when the lease recording differs from the session", () => {
     const { userId, deviceId } = ownerlessSession();
-    handleHeartbeat(userId, deviceId, { playing: true, recordingId: "OTHER", positionMs: 5_000 });
+    handleHeartbeat(userId, deviceId, { playing: true, recordingId: "OTHER", trackIndex: 0, positionMs: 5_000 });
     expect(getOrCreateState(userId).activeDeviceId).toBeNull();
   });
 
@@ -83,7 +86,7 @@ describe("handleHeartbeat ownership lease (ADR-0011 Chunk B)", () => {
 
   it("does NOT claim from a protocolVersion 0 (legacy) connection even with a lease", () => {
     const { userId, deviceId } = ownerlessSession(0);
-    handleHeartbeat(userId, deviceId, { playing: true, recordingId: "rec1", positionMs: 5_000 });
+    handleHeartbeat(userId, deviceId, { playing: true, recordingId: "rec1", trackIndex: 0, positionMs: 5_000 });
     expect(getOrCreateState(userId).activeDeviceId).toBeNull();
   });
 
@@ -106,7 +109,7 @@ describe("handleHeartbeat ownership lease (ADR-0011 Chunk B)", () => {
     // B connects and leases the same recording while playing — must back off.
     const b = `${a}-b`;
     registerDevice(userId, b, "ios", "Phone B", fakeSocket(), 1, "1.0.0");
-    handleHeartbeat(userId, b, { playing: true, recordingId: "rec1", positionMs: 9_999 });
+    handleHeartbeat(userId, b, { playing: true, recordingId: "rec1", trackIndex: 0, positionMs: 9_999 });
 
     const s = getOrCreateState(userId);
     expect(s.activeDeviceId).toBe(a); // unchanged — never preempted
@@ -116,10 +119,10 @@ describe("handleHeartbeat ownership lease (ADR-0011 Chunk B)", () => {
   it("refreshing as the existing owner leaves ownership intact", () => {
     const { userId, deviceId } = ownerlessSession();
     // First heartbeat claims the vacuum.
-    handleHeartbeat(userId, deviceId, { playing: true, recordingId: "rec1", positionMs: 5_000 });
+    handleHeartbeat(userId, deviceId, { playing: true, recordingId: "rec1", trackIndex: 0, positionMs: 5_000 });
     const versionAfterClaim = getOrCreateState(userId).version;
     // Owner re-heartbeats → no ownership change, no extra broadcast/mutate.
-    handleHeartbeat(userId, deviceId, { playing: true, recordingId: "rec1", positionMs: 6_000 });
+    handleHeartbeat(userId, deviceId, { playing: true, recordingId: "rec1", trackIndex: 0, positionMs: 6_000 });
     const s = getOrCreateState(userId);
     expect(s.activeDeviceId).toBe(deviceId);
     expect(s.version).toBe(versionAfterClaim); // refresh didn't mutate/broadcast

--- a/api/src/connect/routes.ts
+++ b/api/src/connect/routes.ts
@@ -74,6 +74,7 @@ export async function connectRoutes(app: FastifyInstance): Promise<void> {
             ? {
                 playing: msg.playing === true,
                 recordingId: msg.recordingId,
+                trackIndex: typeof msg.trackIndex === "number" ? msg.trackIndex : 0,
                 positionMs: typeof msg.positionMs === "number" ? msg.positionMs : 0,
               }
             : undefined;

--- a/api/src/connect/state.ts
+++ b/api/src/connect/state.ts
@@ -278,6 +278,7 @@ export function unregisterDevice(userId: string, deviceId: string): void {
 export interface LeaseRenewal {
   playing: boolean;
   recordingId: string;
+  trackIndex: number;
   positionMs: number;
 }
 
@@ -314,12 +315,18 @@ export function handleHeartbeat(userId: string, deviceId: string, lease?: LeaseR
   // loaded device (playing=false, e.g. transferred away) from the real source,
   // so it can't steal ownership back after a restart.
   if (state.activeDeviceId === null && lease.playing) {
-    log(`handleHeartbeat: lease claim — ${entry.device.name}[${entry.device.type}] heals ownerless session rec=${lease.recordingId} pos=${lease.positionMs}`);
+    log(`handleHeartbeat: lease claim — ${entry.device.name}[${entry.device.type}] heals ownerless session rec=${lease.recordingId} track=${lease.trackIndex} pos=${lease.positionMs}`);
     mutate(userId, {
       activeDeviceId: deviceId,
       activeDeviceName: entry.device.name,
       activeDeviceType: entry.device.type,
       playing: true,
+      // Heal to the device's OWN track/pos, not the server's stored pointer. The
+      // server only learns trackIndex from explicit commands, so after a natural
+      // auto-advance (which doesn't emit one) its trackIndex is stale. Trusting it
+      // here would snap the still-playing device backward. The producing device is
+      // the transport authority — follow it.
+      trackIndex: lease.trackIndex,
       positionMs: lease.positionMs,
       positionTs: Date.now(),
     });

--- a/api/src/connect/types.ts
+++ b/api/src/connect/types.ts
@@ -72,6 +72,7 @@ export interface HeartbeatMessage {
   // optional — legacy clients omit them. Server gates on protocolVersion >= 1.
   playing?: boolean;
   recordingId?: string;
+  trackIndex?: number;
   positionMs?: number;
 }
 

--- a/iosApp/deadly/Core/Service/ConnectService.swift
+++ b/iosApp/deadly/Core/Service/ConnectService.swift
@@ -536,25 +536,44 @@ final class ConnectService: NSObject {
             let currentVolume = Int(streamPlayer.volume * 100)
             activeDeviceVolume = currentVolume
             sendVolumeReport(volume: currentVolume)
-            let targetPositionMs = interpolatedPositionMs(new)
-            if self.streamPlayer.queueState.currentIndex != new.trackIndex {
-                logger.info("reactToState: became active, syncing track \(self.streamPlayer.queueState.currentIndex, privacy: .public) -> \(new.trackIndex, privacy: .public)")
-                streamPlayer.skipTo(index: new.trackIndex, autoplay: new.playing)
-            }
-            let serverPosition = Double(targetPositionMs) / 1000.0
-            if streamPlayer.playbackState.isPlaying {
-                // Already playing the track — a direct seek is honored.
-                if abs(streamPlayer.progress.currentTime - serverPosition) > 1 {
-                    logger.info("reactToState: became active (playing), seeking to \(targetPositionMs, privacy: .public)ms (interpolated from \(new.positionMs, privacy: .public)ms)")
-                    streamPlayer.seek(to: serverPosition)
-                }
+
+            // The device producing audio is the transport authority. When we're
+            // already playing this recording and the lease promotes us to active,
+            // do NOT seek the local player down to the server's stored track/pos:
+            // that snaps the user backward (the server's trackIndex goes stale after
+            // a natural auto-advance, and its position can lag behind ours). Keep
+            // playing — our heartbeat lease (which carries trackIndex+pos) and our
+            // position reports push our real state UP to the server instead.
+            // Breaking live audio to match the server is never the right trade.
+            //
+            // We still sync DOWN when we became active some other way (e.g. a
+            // transfer in while paused or on a different recording): there the
+            // server state is the genuine intent, not a stale echo of ours.
+            let alreadyPlayingThisRecording =
+                streamPlayer.playbackState.isPlaying && localRecordingId == new.recordingId
+            if alreadyPlayingThisRecording {
+                logger.info("reactToState: became active while already playing \(new.recordingId ?? "nil", privacy: .public) — keeping local track/pos, asserting up to server (not seeking down)")
             } else {
-                // Paused (e.g. this show was freshly hydrated): the engine drops
-                // seeks while not playing, then play() would start from 0. Stash
-                // the position as the first-play seek so the play() in the
-                // playback-reconciliation step below lands at the right spot.
-                logger.info("reactToState: became active (paused), pendingSeekOnFirstPlay=\(targetPositionMs, privacy: .public)ms (interpolated from \(new.positionMs, privacy: .public)ms)")
-                streamPlayer.pendingSeekOnFirstPlay = serverPosition
+                let targetPositionMs = interpolatedPositionMs(new)
+                if self.streamPlayer.queueState.currentIndex != new.trackIndex {
+                    logger.info("reactToState: became active, syncing track \(self.streamPlayer.queueState.currentIndex, privacy: .public) -> \(new.trackIndex, privacy: .public)")
+                    streamPlayer.skipTo(index: new.trackIndex, autoplay: new.playing)
+                }
+                let serverPosition = Double(targetPositionMs) / 1000.0
+                if streamPlayer.playbackState.isPlaying {
+                    // Already playing the track — a direct seek is honored.
+                    if abs(streamPlayer.progress.currentTime - serverPosition) > 1 {
+                        logger.info("reactToState: became active (playing), seeking to \(targetPositionMs, privacy: .public)ms (interpolated from \(new.positionMs, privacy: .public)ms)")
+                        streamPlayer.seek(to: serverPosition)
+                    }
+                } else {
+                    // Paused (e.g. this show was freshly hydrated): the engine drops
+                    // seeks while not playing, then play() would start from 0. Stash
+                    // the position as the first-play seek so the play() in the
+                    // playback-reconciliation step below lands at the right spot.
+                    logger.info("reactToState: became active (paused), pendingSeekOnFirstPlay=\(targetPositionMs, privacy: .public)ms (interpolated from \(new.positionMs, privacy: .public)ms)")
+                    streamPlayer.pendingSeekOnFirstPlay = serverPosition
+                }
             }
         }
 
@@ -784,6 +803,7 @@ final class ConnectService: NSObject {
             "type": "heartbeat",
             "playing": streamPlayer.playbackState.isPlaying,
             "recordingId": recordingId,
+            "trackIndex": streamPlayer.queueState.currentIndex,
             "positionMs": Int(streamPlayer.progress.currentTime * 1000),
         ]
         guard let data = try? JSONSerialization.data(withJSONObject: lease),


### PR DESCRIPTION
## Problem

A real user reported playback **skipping ~5s backward repeatedly**, then jumping from a later track back to the start of the previous one. It's a **Connect** bug, and it hits ordinary **single-device** users (Connect auto-connects whenever signed in).

Root cause, traced through client + server:
- The server's Connect state only learns `trackIndex` from **explicit** commands (`next`/`prev`/`seek`/`load`). A **natural end-of-track auto-advance** emits no command — and the client only forwards the auto-advance once it's *already* the active device (`_isActiveDevice` gate). So a device that resumed playback before the ownership lease promoted it advances tracks silently and the server's `trackIndex` freezes.
- The ADR-0011 lease then promotes the device to active, and on "became active" the client **seeks the local player down** to the server's stale track/position — yanking the user backward. A flaky connection (the report log is wall-to-wall socket timeouts, `rtt≈10s`, broken clock offset) makes it flap and repeat.

## Fix

The device producing audio is the transport authority.

1. **Heartbeat lease carries `trackIndex`** (Android + iOS + server type/route). When the server heals an ownerless session via the lease, it sets `trackIndex` from the lease — the device's *real* track — instead of its stale stored pointer. Also fixes followers.
2. **Client "became active" guard** (Android + iOS): when promoted to active while **already playing this recording**, keep local track/pos and assert up to the server rather than seeking down. Genuine remote intent (remote load / next / seek, transfer-in) still syncs down as before.

Two-device thrash isn't possible: the server names exactly one active device and ignores position reports from any other (`handlePosition`), so the non-owner is muted server-side.

## Testing

- API: `state.lease.test.ts` green (7/7), incl. a new assertion that the lease claim heals to the device's track, not the stale stored one. Connect files typecheck clean.
- Android: `:core:connect:compileDebugKotlin` ✅
- iOS: remote simulator debug build **BUILD SUCCEEDED** ✅
- **Still needs on-device behavioral testing** across a resume/auto-advance cycle.

## Deploy note

Deploying the API restarts the process, which clears the affected user's currently-stuck in-memory session as a side effect — fixes forward **and** unsticks them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)