### PR TITLE
feat(mobile/developer): show git commit hash linked to repo in Developer menu

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -16,6 +16,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
+    - name: Embed git commit hash
+      run: printf 'GIT_COMMIT_HASH = %s\n' "$(git rev-parse --short HEAD)" > iosApp/GitHash.xcconfig
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@7bae1d00b5db9166f4f0fc47985a3a5702cb58f0 # v1.227.0
       with:

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -16,6 +16,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
+    - name: Embed git commit hash
+      run: printf 'GIT_COMMIT_HASH = %s\n' "$(git rev-parse --short HEAD)" > iosApp/GitHash.xcconfig
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@7bae1d00b5db9166f4f0fc47985a3a5702cb58f0 # v1.227.0
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ tmp-data/
 # iOS secrets — never commit the live file; use Secrets.swift.example as template
 iosApp/deadly/App/Secrets.swift
 
+# Generated commit-hash xcconfig (written by `make remote-sync` and iOS CI);
+# overrides GIT_COMMIT_HASH in iosApp/deadly.xcconfig. The base xcconfig IS committed.
+iosApp/GitHash.xcconfig
+
 # Claude Code local config
 .claude/
 # Pi local config

--- a/Makefile
+++ b/Makefile
@@ -467,6 +467,10 @@ IOS_SIM        ?= iPhone 17
 # xcodebuild/gradle runs there.
 remote-sync:
 	@echo "Syncing to $(REMOTE_HOST):$(REMOTE_PATH)..."
+	@# The remote Mac has no .git (excluded below), so capture the commit hash
+	@# here on Linux and ship it as an xcconfig the iOS build inherits via
+	@# iosApp/deadly.xcconfig. An empty value falls back to "unknown" in-app.
+	@printf 'GIT_COMMIT_HASH = %s\n' "$$(git rev-parse --short HEAD 2>/dev/null)" > iosApp/GitHash.xcconfig
 	@rsync -avz --delete \
 		--exclude='.git' \
 		--exclude='.claude' \
@@ -482,10 +486,7 @@ remote-sync:
 		--exclude='ui/out' \
 		--exclude='ui/dist' \
 		--exclude='.secrets' \
-		--exclude='data/stage01-collected-data' \
-		--exclude='data/stage02-generated-data' \
-		--exclude='data/data.zip' \
-		--exclude='data/scripts/.venv' \
+		--exclude='data' \
 		./ $(REMOTE_HOST):$(REMOTE_PATH)/
 
 # Build debug on Mac

--- a/androidApp/app/build.gradle.kts
+++ b/androidApp/app/build.gradle.kts
@@ -114,9 +114,9 @@ android {
                 signingConfigs.getByName("debug")
             }
 
-            // Add build type and no commit hash for release builds
+            // Add build type and git commit hash for release builds
             buildConfigField("String", "BUILD_TYPE", "\"release\"")
-            buildConfigField("String", "GIT_COMMIT_HASH", "\"\"")
+            buildConfigField("String", "GIT_COMMIT_HASH", "\"${getGitCommitHash().get()}\"")
         }
 
         create("benchmark") {

--- a/androidApp/feature/settings/build.gradle.kts
+++ b/androidApp/feature/settings/build.gradle.kts
@@ -18,6 +18,20 @@ val versionProps = Properties().apply {
     }
 }
 
+// Resolve the current git commit hash at build time (configuration cache friendly).
+// Baked into BuildConfig for all build types so the Developer screen can show it
+// and link to the exact commit on GitHub.
+fun getGitCommitHash(): Provider<String> {
+    return try {
+        providers.exec {
+            commandLine("git", "rev-parse", "--short", "HEAD")
+            isIgnoreExitValue = true
+        }.standardOutput.asText.map { it.trim() }.orElse("worktree-build")
+    } catch (e: Exception) {
+        providers.provider { "worktree-build" }
+    }
+}
+
 android {
     namespace = "com.grateful.deadly.feature.settings"
     compileSdk = 36
@@ -32,6 +46,7 @@ android {
     buildTypes {
         debug {
             buildConfigField("String", "VERSION_NAME", "\"${versionProps.getProperty("VERSION_NAME", "1.0.0")}\"")
+            buildConfigField("String", "GIT_COMMIT_HASH", "\"${getGitCommitHash().get()}\"")
         }
         release {
             isMinifyEnabled = false
@@ -40,6 +55,7 @@ android {
                 "proguard-rules.pro"
             )
             buildConfigField("String", "VERSION_NAME", "\"${versionProps.getProperty("VERSION_NAME", "1.0.0")}\"")
+            buildConfigField("String", "GIT_COMMIT_HASH", "\"${getGitCommitHash().get()}\"")
         }
     }
 

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/developer/DeveloperScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/developer/DeveloperScreen.kt
@@ -9,11 +9,13 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.text.KeyboardOptions
 import java.io.File
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.grateful.deadly.feature.settings.BuildConfig
 import com.grateful.deadly.feature.settings.SettingsViewModel
 
 @Composable
@@ -30,6 +32,10 @@ fun DeveloperScreen(
     val environments = listOf("prod" to "Production", "beta" to "Beta", "custom" to "Custom")
 
     LazyColumn(modifier = Modifier.fillMaxSize()) {
+
+        item { CommitHashRow() }
+
+        item { HorizontalDivider() }
 
         item {
             Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
@@ -252,6 +258,47 @@ private fun DevRow(
             text = title,
             style = MaterialTheme.typography.bodyLarge,
             color = titleColor
+        )
+    }
+}
+
+@Composable
+private fun CommitHashRow() {
+    val uriHandler = LocalUriHandler.current
+    val hash = BuildConfig.GIT_COMMIT_HASH
+    val hasHash = hash.isNotBlank() && hash != "worktree-build"
+    val displayHash = if (hash.isBlank()) "unknown" else hash
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .let { base ->
+                if (hasHash) {
+                    base.clickable {
+                        uriHandler.openUri("https://github.com/ds17f/deadly-monorepo/commit/$hash")
+                    }
+                } else {
+                    base
+                }
+            }
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = "Commit", style = MaterialTheme.typography.bodyLarge)
+            Text(
+                text = if (hasHash) "Tap to view on GitHub" else "No commit hash available",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = displayHash,
+            style = MaterialTheme.typography.bodyLarge,
+            fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+            color = if (hasHash) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
         )
     }
 }

--- a/iosApp/Info.plist
+++ b/iosApp/Info.plist
@@ -16,6 +16,8 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
+	<key>GitCommitHash</key>
+	<string>$(GIT_COMMIT_HASH)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/iosApp/deadly.xcconfig
+++ b/iosApp/deadly.xcconfig
@@ -1,0 +1,12 @@
+// Base build configuration for the deadly app target.
+//
+// GIT_COMMIT_HASH is substituted into Info.plist (key `GitCommitHash`) and shown
+// in the Developer screen, linking to the commit on GitHub.
+//
+// It defaults to empty here and is overridden by a generated GitHash.xcconfig
+// (gitignored) written by `make remote-sync` for dev builds and by the iOS CI
+// workflow for releases. The optional include is silently skipped when that file
+// is absent (e.g. a plain Xcode GUI build), in which case the hash shows as
+// "unknown" rather than failing the build.
+GIT_COMMIT_HASH =
+#include? "GitHash.xcconfig"

--- a/iosApp/deadly.xcodeproj/project.pbxproj
+++ b/iosApp/deadly.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		DEADBEEFCAFE000000000002 /* deadly.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = deadly.xcconfig; sourceTree = "<group>"; };
 		DB5773832E98961B0085783F /* deadly.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = deadly.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB5773912E98961C0085783F /* deadlyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = deadlyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB57739B2E98961C0085783F /* deadlyUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = deadlyUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -90,6 +91,7 @@
 		DB57737A2E98961B0085783F = {
 			isa = PBXGroup;
 			children = (
+				DEADBEEFCAFE000000000002 /* deadly.xcconfig */,
 				DB5773852E98961B0085783F /* deadly */,
 				DB5773942E98961C0085783F /* deadlyTests */,
 				DB57739E2E98961C0085783F /* deadlyUITests */,
@@ -409,6 +411,7 @@
 		};
 		DB5773A62E98961C0085783F /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = DEADBEEFCAFE000000000002 /* deadly.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -441,6 +444,7 @@
 		};
 		DB5773A72E98961C0085783F /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = DEADBEEFCAFE000000000002 /* deadly.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/iosApp/deadly/Feature/Settings/DeveloperView.swift
+++ b/iosApp/deadly/Feature/Settings/DeveloperView.swift
@@ -16,8 +16,33 @@ struct DeveloperView: View {
     @State private var syncInFlight = false
     @State private var syncLog: [String] = []
 
+    /// Git commit hash embedded into Info.plist at build time by the
+    /// "Embed Git Commit Hash" build phase. Nil when unavailable.
+    private var gitCommitHash: String? {
+        let value = Bundle.main.infoDictionary?["GitCommitHash"] as? String
+        guard let value, !value.isEmpty else { return nil }
+        return value
+    }
+
     var body: some View {
         List {
+            Section("Build") {
+                if let hash = gitCommitHash {
+                    Link(destination: URL(string: "https://github.com/ds17f/deadly-monorepo/commit/\(hash)")!) {
+                        LabeledContent("Commit") {
+                            HStack(spacing: 4) {
+                                Text(hash)
+                                    .font(.system(.body, design: .monospaced))
+                                Image(systemName: "arrow.up.right")
+                                    .font(.caption)
+                            }
+                        }
+                    }
+                } else {
+                    LabeledContent("Commit", value: "unknown")
+                }
+            }
+
             Section {
                 Picker("Server", selection: Binding(
                     get: { container.appPreferences.serverEnvironment },


### PR DESCRIPTION
## Summary
Bakes the git commit hash into both apps (all build types) and shows it as a tappable **Commit** row in the Developer menu that opens the exact commit on GitHub (`…/commit/<hash>`).

## Android
- `getGitCommitHash()` injects `BuildConfig.GIT_COMMIT_HASH` for **debug + release** (`feature:settings` + `app` modules; release was previously empty).
- `DeveloperScreen` opens the commit via `LocalUriHandler`; shows "unknown" when blank.
- Builds locally where `.git` exists, so no extra plumbing.

## iOS (sandbox-safe, no run-script phase)
- `Info.plist`: `GitCommitHash = $(GIT_COMMIT_HASH)` — substituted by Xcode's own Info.plist processor.
- `iosApp/deadly.xcconfig` (committed) is the app target's base config: defaults `GIT_COMMIT_HASH` empty and `#include? "GitHash.xcconfig"`.
- `iosApp/GitHash.xcconfig` (gitignored, generated) carries the real hash, written by the build **driver** which always has git: `make remote-sync` (Linux) and a step in `ios-ci.yml` / `ios-release.yml` (Mac).
- `DeveloperView` reads `Bundle.main.infoDictionary["GitCommitHash"]`.

**Why this shape:** the remote Mac build excludes `.git` (and has a stale leftover one), and macOS user-script sandboxing blocks a build script from both reading outside files and writing the built `Info.plist`. Variable substitution via a base xcconfig sidesteps all of that — every `xcodebuild` invocation inherits the value automatically (nothing to remember), `ENABLE_USER_SCRIPT_SANDBOXING` stays **on**, and a missing `GitHash.xcconfig` degrades to "unknown" rather than failing the build.

## Incidental infra fix
- `make remote-sync` now `--exclude='data'` — it was rsyncing ~53MB of tracked `data/stage00-created-data` (≈11.8k files, 91% of the transfer) to the Mac on every iOS build.

## Verification
- Android: `:feature:settings` + `:app` debug build; `BuildConfig.GIT_COMMIT_HASH` matches `HEAD`.
- iOS: remote sim builds with sandboxing ON — `GitCommitHash` resolves to the real hash; confirmed build still succeeds and shows empty when `GitHash.xcconfig` is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)