### PR TITLE
fix(all/connect): seek by intent nonce, propagate duration, optimistic scrubber

### DIFF
--- a/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
+++ b/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
@@ -83,9 +83,6 @@ class ConnectServiceImpl @Inject constructor(
         // On becoming active, only re-seek if the local position differs from the
         // interpolated server position by more than this (avoids a pointless seek).
         private const val ACTIVATE_POSITION_SYNC_THRESHOLD_MS = 1_000L
-        // While active, only honor a remote seek if it moves the position by more
-        // than this (filters our own ~5s position reports echoing back).
-        private const val REMOTE_SEEK_THRESHOLD_MS = 2_000L
         // A pending transport command auto-clears after this long if the server
         // never confirms it, so the UI spinner can never get permanently stuck.
         private const val PENDING_COMMAND_TIMEOUT_MS = 6_000L
@@ -752,16 +749,19 @@ class ConnectServiceImpl @Inject constructor(
             mediaControllerRepository.seekToMediaItemIndex(new.trackIndex, 0L)
         }
 
-        // React to seek from remote controllers (while already active).
-        // Compare against local position (not old server state) so our own position
-        // reports echoing back don't cause unnecessary seeks.
-        if (!justBecameActive && old != null && new.trackIndex == old.trackIndex && new.positionMs != old.positionMs) {
-            val localPositionMs = mediaControllerRepository.currentPosition.value
-            val delta = abs(new.positionMs.toLong() - localPositionMs)
-            if (delta > REMOTE_SEEK_THRESHOLD_MS) {
-                Log.d(TAG, "reactToState: seek from remote, jumping to ${new.positionMs}ms (delta=$delta)")
-                mediaControllerRepository.seekToPosition(new.positionMs.toLong())
-            }
+        // React to a seek from a remote controller (while already active). Key on
+        // seekNonce — which the server bumps ONLY for an explicit `seek` command,
+        // never for routine position reports — not on positionMs magnitude. Our own
+        // ~5s position reports echo back with an unchanged nonce, so a stale/jittery
+        // echo can never trigger a self-seek (the "skips" bug); and a deliberate seek
+        // of ANY size, including a small backward skip from another device, is honored
+        // because intent — not distance — is the signal. `cmd == "seek"` means WE
+        // issued this seek and already moved the local player, so the echoed nonce
+        // bump is our own — don't re-seek. See ADR-0017.
+        if (!justBecameActive && old != null && new.trackIndex == old.trackIndex &&
+            new.seekNonce != old.seekNonce && cmd != "seek") {
+            Log.d(TAG, "reactToState: seek from remote (nonce ${old.seekNonce} -> ${new.seekNonce}), jumping to ${new.positionMs}ms")
+            mediaControllerRepository.seekToPosition(new.positionMs.toLong())
         }
 
         // Active device, same recording — handle play/pause
@@ -877,8 +877,15 @@ class ConnectServiceImpl @Inject constructor(
     }
 
     override fun sendPosition(positionMs: Int) {
-        Log.d(TAG, "sendPosition: pos=$positionMs")
-        sendCommand("position", mapOf("positionMs" to positionMs))
+        // Carry our real track duration so controllers have a valid scrubber scale.
+        // Only the active/parked device reports position, so the local duration is the
+        // authoritative one; the server ignores a 0 (unknown) value. See ADR-0017.
+        val durationMs = mediaControllerRepository.duration.value.toInt()
+        Log.d(TAG, "sendPosition: pos=$positionMs dur=$durationMs")
+        sendCommand("position", mapOf(
+            "positionMs" to positionMs,
+            "durationMs" to durationMs,
+        ))
     }
 
     override fun sendSeek(trackIndex: Int, positionMs: Int, durationMs: Int) {

--- a/androidApp/core/model/src/main/java/com/grateful/deadly/core/model/ConnectModels.kt
+++ b/androidApp/core/model/src/main/java/com/grateful/deadly/core/model/ConnectModels.kt
@@ -40,6 +40,11 @@ data class ConnectState(
     val positionMs: Int = 0,
     val positionTs: Double = 0.0,
     val durationMs: Int = 0,
+    // Bumped only by an explicit server-side seek (never by position reports).
+    // The active device seeks when this advances, not on positionMs deltas — so
+    // self-echoes can't cause skips and small remote seeks still land. Additive/
+    // optional; defaults to 0 against a server that doesn't send it. See ADR-0017.
+    val seekNonce: Int = 0,
     val playing: Boolean = false,
     val activeDeviceId: String? = null,
     val activeDeviceName: String? = null,

--- a/androidApp/core/player/src/main/java/com/grateful/deadly/core/player/service/PlayerServiceImpl.kt
+++ b/androidApp/core/player/src/main/java/com/grateful/deadly/core/player/service/PlayerServiceImpl.kt
@@ -14,6 +14,7 @@ import com.grateful.deadly.core.model.Track
 import com.grateful.deadly.core.model.CurrentTrackInfo
 import com.grateful.deadly.core.model.PlaybackStatus
 import com.grateful.deadly.core.model.QueueInfo
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -71,6 +72,14 @@ class PlayerServiceImpl @Inject constructor(
     // When remote controlling, interpolate position from Connect state so the UI
     // progress bar and clock advance smoothly between position broadcasts.
     // Otherwise delegate to the local media controller.
+    // Optimistic scrubber hold (ADR-0017): after a remote seek, show the requested
+    // position until the server echoes a new seek (seekNonce advances past the captured
+    // value) or the deadline passes — so the bar doesn't snap back to the old server
+    // position while the seek round-trips, and the user doesn't re-drag (which fired
+    // duplicate seeks). Woven into playbackStatus below; cleared by nonce/deadline.
+    private data class OptimisticSeek(val positionMs: Long, val nonce: Int, val deadlineMs: Long)
+    private val optimisticSeek = MutableStateFlow<OptimisticSeek?>(null)
+
     private val interpolationTicker = flow {
         while (true) {
             emit(Unit)
@@ -83,14 +92,22 @@ class PlayerServiceImpl @Inject constructor(
         connectService.connectState,
         connectService.isActiveDevice,
         interpolationTicker,
-    ) { localStatus, state, isActive, _ ->
+        optimisticSeek,
+    ) { localStatus, state, isActive, _, optimistic ->
         val isRemoteControlling = state != null && state.activeDeviceId != null && !isActive
         if (isRemoteControlling && state != null) {
-            val positionMs = if (state.playing) {
-                val serverNow = System.currentTimeMillis() + connectService.serverTimeOffsetMs.value
-                state.positionMs.toLong() + (serverNow - state.positionTs.toLong())
-            } else {
-                state.positionMs.toLong()
+            // Honor the optimistic hold until our seek echoes back (nonce advances) or
+            // it expires — otherwise interpolate from the latest server position.
+            val held = optimistic?.takeIf {
+                state.seekNonce <= it.nonce && System.currentTimeMillis() < it.deadlineMs
+            }
+            val positionMs = when {
+                held != null -> held.positionMs
+                state.playing -> {
+                    val serverNow = System.currentTimeMillis() + connectService.serverTimeOffsetMs.value
+                    state.positionMs.toLong() + (serverNow - state.positionTs.toLong())
+                }
+                else -> state.positionMs.toLong()
             }
             PlaybackStatus(
                 currentPosition = positionMs,
@@ -268,7 +285,9 @@ class PlayerServiceImpl @Inject constructor(
             val isRemoteControlling = state != null && state.activeDeviceId != null && !isActive
 
             if (isRemoteControlling && state != null) {
-                Log.d(TAG, "seekToPosition: remote -> sendSeek(track=${state.trackIndex} pos=$positionMs dur=${state.durationMs})")
+                // Hold the scrubber at the requested position until the echo lands.
+                optimisticSeek.value = OptimisticSeek(positionMs, state.seekNonce, System.currentTimeMillis() + 6000)
+                Log.d(TAG, "seekToPosition: remote -> sendSeek(track=${state.trackIndex} pos=$positionMs dur=${state.durationMs}) optimistic hold")
                 connectService.sendSeek(state.trackIndex, positionMs.toInt(), state.durationMs)
             } else {
                 Log.d(TAG, "seekToPosition: local -> seek + sendSeek")

--- a/api/src/connect/__tests__/state.seek.test.ts
+++ b/api/src/connect/__tests__/state.seek.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// state.ts persists position to SQLite; stub it out so these are pure
+// in-memory state-machine tests.
+vi.mock("../../db/userdata.js", () => ({
+  getPlaybackPosition: vi.fn(() => null),
+  upsertPlaybackPosition: vi.fn(),
+}));
+
+const {
+  registerDevice,
+  handleLoad,
+  handleSeek,
+  handlePosition,
+  getOrCreateState,
+} = await import("../state.js");
+
+// A session whose shared durationMs is 0 — exactly the hydrated/restored case where
+// a controller's `fraction * durationMs` collapses to 0 and every drag seeks to start.
+function zeroDurationSession() {
+  const { userId, deviceId } = freshUser();
+  const socket = fakeSocket();
+  registerDevice(userId, deviceId, "web", "Web", socket, 1, "1.0.0");
+  handleLoad(userId, deviceId, socket, {
+    showId: "s1",
+    recordingId: "rec1",
+    tracks: TRACKS,
+    trackIndex: 0,
+    positionMs: 0,
+    durationMs: 0, // hydrated/restored: no duration
+    autoplay: true,
+  });
+  return { userId, deviceId };
+}
+
+// Minimal WebSocket stand-in: OPEN so broadcasts don't warn, send/close noop.
+function fakeSocket() {
+  return { readyState: 1, OPEN: 1, send: vi.fn(), close: vi.fn() } as never;
+}
+
+const TRACKS = [
+  { title: "Track 1", durationMs: 600_000 },
+  { title: "Track 2", durationMs: 600_000 },
+];
+
+let seq = 0;
+// Module-level maps persist across tests; unique ids keep each test isolated.
+function freshUser() {
+  seq += 1;
+  return { userId: `seek-u-${seq}`, deviceId: `seek-d-${seq}` };
+}
+
+// An ACTIVE, playing session: load WITH autoplay so the device owns the session
+// (activeDeviceId === deviceId), which is what handlePosition requires.
+function activeSession() {
+  const { userId, deviceId } = freshUser();
+  const socket = fakeSocket();
+  registerDevice(userId, deviceId, "web", "Web", socket, 1, "1.0.0");
+  handleLoad(userId, deviceId, socket, {
+    showId: "s1",
+    recordingId: "rec1",
+    tracks: TRACKS,
+    trackIndex: 0,
+    positionMs: 0,
+    durationMs: 600_000,
+    autoplay: true,
+  });
+  return { userId, deviceId, socket };
+}
+
+// ADR-0017: an explicit seek is INTENT (bump seekNonce); a routine position report
+// is NOT (leave it). The active device follows a remote seek iff seekNonce advanced,
+// so a self-echoed position report can never masquerade as a seek (the "skips" bug).
+describe("seek intent vs position report (ADR-0017)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("starts at seekNonce 0", () => {
+    const { userId } = activeSession();
+    expect(getOrCreateState(userId).seekNonce).toBe(0);
+  });
+
+  it("handleSeek bumps seekNonce by exactly 1 and applies the position", () => {
+    const { userId } = activeSession();
+    handleSeek(userId, { trackIndex: 0, positionMs: 123_000 });
+    const s = getOrCreateState(userId);
+    expect(s.seekNonce).toBe(1);
+    expect(s.positionMs).toBe(123_000);
+  });
+
+  it("handlePosition does NOT bump seekNonce (the anti-skip guarantee)", () => {
+    const { userId, deviceId } = activeSession();
+    handleSeek(userId, { trackIndex: 0, positionMs: 100_000 }); // nonce -> 1
+    expect(getOrCreateState(userId).seekNonce).toBe(1);
+
+    // The active device's own ~5s position reports must leave the nonce alone, even
+    // as positionMs moves — otherwise an echo would read as a remote seek.
+    handlePosition(userId, deviceId, 105_000);
+    handlePosition(userId, deviceId, 110_000);
+    const s = getOrCreateState(userId);
+    expect(s.seekNonce).toBe(1); // unchanged across position reports
+    expect(s.positionMs).toBe(110_000); // position still tracked
+  });
+
+  it("monotonically increments across interleaved seeks and reports", () => {
+    const { userId, deviceId } = activeSession();
+    handleSeek(userId, { trackIndex: 0, positionMs: 10_000 }); // 1
+    handlePosition(userId, deviceId, 15_000); // still 1
+    handleSeek(userId, { trackIndex: 0, positionMs: 12_000 }); // 2 — a tiny backward seek still counts
+    handlePosition(userId, deviceId, 20_000); // still 2
+    handleSeek(userId, { trackIndex: 1, positionMs: 0 }); // 3
+    expect(getOrCreateState(userId).seekNonce).toBe(3);
+  });
+});
+
+// ADR-0017 follow-up: the active device propagates its real durationMs in position
+// reports so controllers of a hydrated (durationMs=0) session get a valid scrubber
+// scale — otherwise `fraction * 0 = 0` and every remote drag seeks to track start.
+describe("durationMs propagation via position reports (ADR-0017)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("a position report with durationMs>0 fills in a zero shared duration", () => {
+    const { userId, deviceId } = zeroDurationSession();
+    expect(getOrCreateState(userId).durationMs).toBe(0);
+    handlePosition(userId, deviceId, 5_000, 600_000);
+    expect(getOrCreateState(userId).durationMs).toBe(600_000);
+  });
+
+  it("does not bump seekNonce while carrying duration (still just a report)", () => {
+    const { userId, deviceId } = zeroDurationSession();
+    handlePosition(userId, deviceId, 5_000, 600_000);
+    expect(getOrCreateState(userId).seekNonce).toBe(0);
+  });
+
+  it("ignores a 0/unknown duration (never clobbers a real one back to 0)", () => {
+    const { userId, deviceId } = activeSession(); // loaded with durationMs 600_000
+    expect(getOrCreateState(userId).durationMs).toBe(600_000);
+    handlePosition(userId, deviceId, 5_000, 0);
+    expect(getOrCreateState(userId).durationMs).toBe(600_000);
+  });
+
+  it("a legacy position report with no duration leaves duration untouched", () => {
+    const { userId, deviceId } = activeSession();
+    handlePosition(userId, deviceId, 5_000); // no durationMs arg
+    expect(getOrCreateState(userId).durationMs).toBe(600_000);
+  });
+});

--- a/api/src/connect/routes.ts
+++ b/api/src/connect/routes.ts
@@ -169,9 +169,9 @@ export async function connectRoutes(app: FastifyInstance): Promise<void> {
               break;
             }
             case "position": {
-              const { positionMs } = msg as Record<string, unknown>;
+              const { positionMs, durationMs } = msg as Record<string, unknown>;
               if (typeof positionMs !== "number") return;
-              handlePosition(userId!, registeredDeviceId, positionMs);
+              handlePosition(userId!, registeredDeviceId, positionMs, typeof durationMs === "number" ? durationMs : undefined);
               break;
             }
             case "volume": {

--- a/api/src/connect/state.ts
+++ b/api/src/connect/state.ts
@@ -94,6 +94,7 @@ function initialState(): ConnectState {
     positionMs: 0,
     positionTs: Date.now(),
     durationMs: 0,
+    seekNonce: 0,
     playing: false,
     activeDeviceId: null,
     activeDeviceName: null,
@@ -135,6 +136,14 @@ function sendJson(socket: WebSocket, payload: unknown): void {
   }
 }
 
+// ADR-0017 test affordance: artificially delay state delivery to inflate the
+// position-echo round-trip past the old 2s seek threshold, so the self-skip bug can
+// be reproduced on a SINGLE device against a local server (no flaky network needed).
+// Keep the delay under the ~6s pending-command timeout so self-seek suppression still
+// holds. Unset in prod → zero delay, normal synchronous send.
+const BROADCAST_DELAY_MS = Number(process.env.CONNECT_BROADCAST_DELAY_MS) || 0;
+const BROADCAST_JITTER_MS = Number(process.env.CONNECT_BROADCAST_JITTER_MS) || 0;
+
 export function broadcastState(userId: string, state: ConnectState): void {
   const msg = JSON.stringify({ type: "state", state });
   let sent = 0;
@@ -142,7 +151,15 @@ export function broadcastState(userId: string, state: ConnectState): void {
   for (const [key, entry] of liveDevices) {
     if (key.startsWith(`${userId}:`)) {
       if (entry.socket.readyState === entry.socket.OPEN) {
-        entry.socket.send(msg);
+        const delay = BROADCAST_DELAY_MS + Math.random() * BROADCAST_JITTER_MS;
+        if (delay > 0) {
+          const socket = entry.socket;
+          setTimeout(() => {
+            if (socket.readyState === socket.OPEN) socket.send(msg);
+          }, delay);
+        } else {
+          entry.socket.send(msg);
+        }
         sent++;
       } else {
         warn(`broadcastState: skipping ${entry.device.name}[${entry.device.type}] — readyState=${entry.socket.readyState}`);
@@ -590,12 +607,15 @@ export function handleSeek(userId: string, params: { trackIndex: number; positio
     trackIndex: params.trackIndex,
     positionMs: params.positionMs,
     positionTs: Date.now(),
+    // Mark this as a genuine seek INTENT so the active client honors it (vs a
+    // routine position report, which leaves seekNonce untouched). See ADR-0017.
+    seekNonce: state.seekNonce + 1,
   };
   if (typeof params.durationMs === "number") {
     patch.durationMs = params.durationMs;
   }
 
-  log(`handleSeek: track=${params.trackIndex} pos=${params.positionMs} dur=${params.durationMs ?? "unchanged"}`);
+  log(`handleSeek: track=${params.trackIndex} pos=${params.positionMs} dur=${params.durationMs ?? "unchanged"} seekNonce=${state.seekNonce + 1}`);
   mutate(userId, patch);
 
   if (state.showId && state.recordingId) {
@@ -757,7 +777,7 @@ export function handleTransfer(
   });
 }
 
-export function handlePosition(userId: string, deviceId: string, positionMs: number): void {
+export function handlePosition(userId: string, deviceId: string, positionMs: number, durationMs?: number): void {
   const state = userStates.get(userId);
   if (!state) return;
 
@@ -774,7 +794,16 @@ export function handlePosition(userId: string, deviceId: string, positionMs: num
   // Normal position report — only accept from active device
   if (state.activeDeviceId !== deviceId) return;
 
-  mutate(userId, { positionMs, positionTs: Date.now() });
+  const patch: Partial<ConnectState> = { positionMs, positionTs: Date.now() };
+  // Carry the active device's real track duration so CONTROLLERS have a valid scale
+  // for the scrubber + seek math. A hydrated/restored session has durationMs=0, and
+  // load/seek are the only other writers — without this a controller computes
+  // `fraction * 0 = 0` and every drag seeks to track start. Only overwrite with a
+  // real (>0) value, and only when it actually changed (avoid pointless broadcasts).
+  if (typeof durationMs === "number" && durationMs > 0 && durationMs !== state.durationMs) {
+    patch.durationMs = durationMs;
+  }
+  mutate(userId, patch);
 }
 
 export function handleVolume(userId: string, deviceId: string, socket: WebSocket, volume: number): void {

--- a/api/src/connect/types.ts
+++ b/api/src/connect/types.ts
@@ -26,6 +26,14 @@ export interface ConnectState {
   positionMs: number;
   positionTs: number;
   durationMs: number;
+  // Monotonic counter bumped ONLY by handleSeek (an explicit `seek` command),
+  // never by routine `position` reports. The active client honors a remote seek
+  // when this advances — keying on intent, not positionMs magnitude. A stale or
+  // jittery self-echo of a position report therefore can't trigger a self-seek
+  // (the "skips" bug), and a small backward seek from another device is still
+  // honored. Additive/optional like pendingAdvance (ADR-0006 §8): old clients
+  // ignore it. See ADR-0017.
+  seekNonce: number;
   playing: boolean;
   activeDeviceId: string | null;
   activeDeviceName: string | null;

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,3 +35,8 @@ services:
       - LOG_LEVEL=debug
       - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}
       - ENABLE_DEV_SIGNIN=${ENABLE_DEV_SIGNIN:-}
+      # ADR-0017 test affordance: delay/jitter (ms) on Connect state broadcasts so the
+      # position-echo round-trip exceeds the old 2s seek threshold — reproduces the
+      # self-skip bug on one device. Default 0 (no effect). e.g. CONNECT_BROADCAST_DELAY_MS=3000
+      - CONNECT_BROADCAST_DELAY_MS=${CONNECT_BROADCAST_DELAY_MS:-0}
+      - CONNECT_BROADCAST_JITTER_MS=${CONNECT_BROADCAST_JITTER_MS:-0}

--- a/docs/adr/0017-connect-seek-as-intent-not-magnitude.md
+++ b/docs/adr/0017-connect-seek-as-intent-not-magnitude.md
@@ -1,0 +1,152 @@
+# ADR-0017: Connect — honor a remote seek by intent (a nonce), not by position magnitude
+
+## Status
+
+Accepted (2026-06-16). Refines
+[ADR-0006](0006-connect-v2.md) (server is the transport source of truth). Touches
+the same `reactToState` seek branch that
+[ADR-0016](0016-connect-liveness-detection-and-connect-handshake.md) reasons about,
+but is orthogonal: ADR-0016 is about *liveness/double-play*, this is about *when an
+active device should move its own playhead in response to server state*.
+
+In-memory session state is unchanged — this does **not** un-defer
+[ADR-0008](0008-connect-cloud-coordination-deferred.md). It adds one additive field
+to `ConnectState`.
+
+## Context
+
+The active (audio-producing) Connect device subscribes to broadcast `ConnectState`
+and, in `reactToState`, reconciles its local player against it: same track, follow
+remote seeks; track changed, skip; etc.
+
+`ConnectState` carries a single `positionMs`/`positionTs` pair that is overloaded
+for two very different things:
+
+- an **explicit seek** — a controller (or another device) dragged the scrubber and
+  wants the playhead to jump; and
+- a **routine position report** — the active device's own ~5s heartbeat of "here is
+  where I am now," which the server stores into the very same `positionMs`.
+
+The active device cannot tell these apart from `positionMs` alone, so the original
+code used a **magnitude heuristic**: follow a remote `positionMs` change only if it
+differs from the *local* playhead by more than a threshold (Android
+`REMOTE_SEEK_THRESHOLD_MS = 2000`; iOS inline `delta > 2000`). The local-position
+comparison (rather than old-vs-new server state) was a deliberate attempt to ignore
+our own reports echoing back.
+
+### Why the heuristic is wrong in both directions
+
+A threshold on distance is the wrong axis, because the thing we actually care about
+is *intent*, not *distance*:
+
+- **False positives → "skips."** Position reports are sampled and arrive jittery and
+  slightly stale relative to the live playhead. When our own report echoes back, the
+  local playhead has already advanced past it; if that gap crosses the threshold the
+  active device "follows" a seek to a position *it itself reported a moment ago* —
+  yanking audio backward. This is the user-visible **skipping** bug.
+- **False negatives.** A deliberate, *small* seek from another device — nudging back
+  3s to catch a lyric — is under the threshold and silently ignored. The smaller and
+  more intentional the seek, the more likely it is dropped.
+
+No single threshold value fixes both: lower it and echoes skip more; raise it and
+real seeks are dropped. The axis is wrong.
+
+## Decision
+
+Distinguish the two meanings **at the source**, where they are already distinct, and
+carry that distinction in state.
+
+The server already has separate handlers — `handleSeek` (an explicit `seek` command)
+and `handlePosition` (a routine report). Add a monotonic counter to `ConnectState`:
+
+```
+seekNonce: number   // bumped ONLY by handleSeek; never by handlePosition
+```
+
+`handleSeek` does `seekNonce = state.seekNonce + 1`; `handlePosition` leaves it
+untouched. The active device then follows a remote seek **iff `seekNonce`
+advanced** — keying on intent, not on how far `positionMs` moved:
+
+```
+if active, same track, new.seekNonce != old.seekNonce, and we did not issue it:
+    seek to new.positionMs
+```
+
+A position-report echo never bumps the nonce, so it can never trigger a self-seek
+(kills the skip). A real seek of *any* size bumps it, so a 3s backward nudge is
+honored exactly like a 3-minute jump.
+
+### "We did not issue it"
+
+When the active device issues its own seek it already moved its local player, then
+the server echoes the nonce bump back. The client suppresses re-seeking on its own
+echo by checking the in-flight command: Android compares the `cmd` snapshot taken at
+the top of `reactToState`; iOS captures `pendingCommand` into `cmdAtEntry` before the
+pending-command-clearing block nils it, and skips the seek when it equals `"seek"`.
+(iOS also confirms/clears its pending `seek` on the nonce change rather than on a
+`positionMs` change, so a seek to the same position still confirms.)
+
+### Compatibility
+
+`seekNonce` is additive and optional, exactly like `pendingAdvance`
+(ADR-0010 §7). Old clients ignore the unknown field. New clients tolerate a server
+that omits it: Android via the Kotlin default (`val seekNonce: Int = 0`), iOS via an
+optional (`let seekNonce: Int?`, `decodeIfPresent` → `nil`, coalesced to `0`). The
+web client has no active-device seek-reconciliation path and is unaffected. So the
+field is safe to ship to a mixed fleet in any deploy order.
+
+## Alternatives considered
+
+- **Tune the threshold.** Rejected — no value separates jittery self-echoes from
+  small intentional seeks, because the signal is intent, not distance.
+- **Send seeks on a separate channel / message type instead of via state.** The
+  server already routes `seek` and `position` to separate handlers, but the *active
+  device* learns about a remote seek only through the broadcast `ConnectState`
+  snapshot, not by replaying commands. A nonce on the snapshot is the minimal change
+  that preserves "state is the source of truth" (ADR-0006) without a second delivery
+  path to keep consistent.
+- **A timestamp of the last seek instead of a counter.** A monotonic counter is
+  immune to clock questions and to two seeks landing in the same millisecond; the
+  client only ever asks "did it change," never "how recent."
+
+## Consequences
+
+- The skipping bug is eliminated by construction, not by tuning: routine reports
+  cannot move the nonce.
+- Small/precise remote seeks now land, including backward nudges that the threshold
+  used to swallow.
+- `ConnectState` gains one `Int`. `REMOTE_SEEK_THRESHOLD_MS` and the iOS inline
+  threshold are deleted — the local-vs-server position comparison they needed is gone.
+- `seekNonce` resets to `0` on server restart (state is in-memory). A reconnecting
+  client may see `nonce 0 == 0` and simply not treat the post-restart state as a new
+  seek, which is correct: it reconciles position through the normal become-active /
+  handshake path (ADR-0016), not through this branch.
+
+## Two related fixes shipped on this branch
+
+On-device testing (single device against a server with an artificial broadcast delay
+— see the `CONNECT_BROADCAST_DELAY_MS` knob in `broadcastState`, kept as a documented
+test affordance) verified the nonce behavior and surfaced two pre-existing,
+independent bugs in the remote-seek path. Both are fixed here because they make the
+seek experience whole:
+
+1. **`durationMs=0` on hydrated sessions → controller seeks to track start.** A
+   controller computes seek position as `fraction × durationMs`. `durationMs` in
+   shared state was only written by `load`/`seek`, so a hydrated/restored session
+   left it `0` and every drag mapped to `0`. Fix: the active device now carries its
+   real `durationMs` in routine **position reports** (`handlePosition` accepts it and
+   overwrites only a `>0`, changed value), so controllers always have a valid scale.
+   All three clients send it; the iOS controller additionally computes against its
+   locally-resolved track duration with a `durationMs > 0` guard. This was present on
+   the old threshold build too (a `pos=0` seek tripped the magnitude check just the
+   same) — ADR-0017 only made it legible.
+
+2. **Controller scrubber wasn't optimistic → laggy feel + duplicate seeks.** The
+   controller's thumb was driven purely by echoed server state, so after a drag it
+   snapped back until the round-trip completed; users re-dragged, firing duplicate
+   seeks (observed as three `handleSeek`s from one gesture). Fix: on a remote seek
+   the controller holds the scrubber at the requested position until **its** seek
+   echoes back (`seekNonce` advances past the value captured at send) or a ~6s
+   deadline passes — reusing this ADR's nonce as the confirmation signal. iOS gates
+   the hold functionally inside `interpolatedRemotePositionMs` (no mutation during
+   render); Android weaves an `optimisticSeek` `StateFlow` into `playbackStatus`.

--- a/iosApp/deadly/Core/Model/ConnectModels.swift
+++ b/iosApp/deadly/Core/Model/ConnectModels.swift
@@ -57,6 +57,12 @@ struct ConnectState: Codable {
     let positionMs: Int
     let positionTs: Double
     let durationMs: Int
+    // Bumped only by an explicit server-side seek (never by routine position
+    // reports). The active device seeks when this advances, not on positionMs
+    // deltas — so our own position echoes can't cause skips and small remote seeks
+    // still land. Optional/additive (decodeIfPresent → nil against a server that
+    // doesn't send it; treated as 0). See ADR-0017.
+    let seekNonce: Int?
     let playing: Bool
     let activeDeviceId: String?
     let activeDeviceName: String?

--- a/iosApp/deadly/Core/Service/ConnectService.swift
+++ b/iosApp/deadly/Core/Service/ConnectService.swift
@@ -249,8 +249,12 @@ final class ConnectService: NSObject {
     }
 
     func sendPosition(positionMs: Int) {
-        logger.info("sendPosition: pos=\(positionMs, privacy: .public)")
-        sendCommand("position", extra: ["positionMs": positionMs])
+        // Carry our real track duration so controllers have a valid scrubber scale.
+        // Only the active/parked device reports position, so the local duration is the
+        // authoritative one; the server ignores a 0 (unknown) value. See ADR-0017.
+        let durationMs = Int(streamPlayer.progress.duration * 1000)
+        logger.info("sendPosition: pos=\(positionMs, privacy: .public) dur=\(durationMs, privacy: .public)")
+        sendCommand("position", extra: ["positionMs": positionMs, "durationMs": durationMs])
     }
 
     func sendStop() {
@@ -414,6 +418,11 @@ final class ConnectService: NSObject {
     // MARK: - State Reaction
 
     private func reactToState(old: ConnectState?, new: ConnectState) {
+        // Capture the in-flight command BEFORE the clearing block below nils it out,
+        // so the seek-from-remote step further down can still tell a remote seek from
+        // the echo of our own (mirrors Android's `cmd` snapshot). See ADR-0017.
+        let cmdAtEntry = pendingCommand
+
         // Clear pending command if the server confirmed the expected transition
         if let cmd = pendingCommand {
             if cmd == "play" && new.playing {
@@ -425,8 +434,8 @@ final class ConnectService: NSObject {
             } else if (cmd == "next" || cmd == "prev") && new.trackIndex != (old?.trackIndex ?? -1) {
                 logger.info("reactToState: pending '\(cmd, privacy: .public)' confirmed (track \(old?.trackIndex ?? -1, privacy: .public) -> \(new.trackIndex, privacy: .public)), clearing")
                 pendingCommand = nil
-            } else if cmd == "seek" && new.positionMs != (old?.positionMs ?? -1) {
-                logger.info("reactToState: pending 'seek' confirmed, clearing")
+            } else if cmd == "seek" && (new.seekNonce ?? 0) != (old?.seekNonce ?? 0) {
+                logger.info("reactToState: pending 'seek' confirmed (nonce \(old?.seekNonce ?? 0, privacy: .public) -> \(new.seekNonce ?? 0, privacy: .public)), clearing")
                 pendingCommand = nil
             }
         }
@@ -598,17 +607,20 @@ final class ConnectService: NSObject {
             streamPlayer.skipTo(index: new.trackIndex, autoplay: new.playing)
         }
 
-        // React to seek from remote controllers (while already active).
-        // Compare against local position (not old server state) so our own position
-        // reports echoing back don't cause unnecessary seeks.
-        if !justBecameActive, let oldState = old, new.trackIndex == oldState.trackIndex, new.positionMs != oldState.positionMs {
-            let localPositionMs = Int(streamPlayer.progress.currentTime * 1000)
-            let delta = abs(new.positionMs - localPositionMs)
-            if delta > 2000 {
-                let targetTime = Double(new.positionMs) / 1000.0
-                logger.info("reactToState: seek from remote, jumping to \(new.positionMs, privacy: .public)ms (delta=\(delta, privacy: .public))")
-                streamPlayer.seek(to: targetTime)
-            }
+        // React to a seek from a remote controller (while already active). Key on
+        // seekNonce — which the server bumps ONLY for an explicit `seek` command,
+        // never for routine position reports — not on positionMs magnitude. Our own
+        // ~5s position reports echo back with an unchanged nonce, so a stale/jittery
+        // echo can never trigger a self-seek (the "skips" bug); and a deliberate seek
+        // of ANY size, including a small backward skip from another device, is honored
+        // because intent — not distance — is the signal. cmdAtEntry == "seek" means WE
+        // issued this seek and already moved the local player, so the echoed nonce bump
+        // is our own — don't re-seek. See ADR-0017.
+        if !justBecameActive, let oldState = old, new.trackIndex == oldState.trackIndex,
+           (new.seekNonce ?? 0) != (oldState.seekNonce ?? 0), cmdAtEntry != "seek" {
+            let targetTime = Double(new.positionMs) / 1000.0
+            logger.info("reactToState: seek from remote (nonce \(oldState.seekNonce ?? 0, privacy: .public) -> \(new.seekNonce ?? 0, privacy: .public)), jumping to \(new.positionMs, privacy: .public)ms")
+            streamPlayer.seek(to: targetTime)
         }
 
         let localPlaying = streamPlayer.playbackState.isPlaying

--- a/iosApp/deadly/Core/Service/MiniPlayerServiceImpl.swift
+++ b/iosApp/deadly/Core/Service/MiniPlayerServiceImpl.swift
@@ -33,6 +33,16 @@ final class MiniPlayerServiceImpl: MiniPlayerService {
     private var interpolationTick: Date = Date()
     @ObservationIgnored private var interpolationTimer: Timer?
 
+    /// Optimistic scrubber hold (ADR-0017): after a remote seek we show the requested
+    /// position immediately — instead of letting the thumb snap back to the old server
+    /// position until the echo round-trips — so the bar feels responsive and the user
+    /// doesn't re-drag (which fired duplicate seeks). Released when the server echoes a
+    /// new seek (seekNonce advances past `optimisticSeekNonce`) or the deadline passes.
+    /// Gated functionally in `interpolatedRemotePositionMs`; never mutated during render.
+    private var optimisticSeekMs: Int?
+    private var optimisticSeekNonce: Int = 0
+    private var optimisticSeekDeadline: Date = .distantPast
+
     nonisolated init(streamPlayer: StreamPlayer) {
         self.streamPlayer = streamPlayer
         Task { @MainActor [weak self] in
@@ -82,6 +92,13 @@ final class MiniPlayerServiceImpl: MiniPlayerService {
     /// subtracting — without it, clock-skewed devices scroll the progress bar
     /// at the wrong position.
     private func interpolatedRemotePositionMs(_ r: ConnectState) -> Int {
+        // Optimistic hold: show the just-seeked position until our seek echoes back
+        // (seekNonce advances) or the hold expires — purely a read, no mutation here.
+        if let optimistic = optimisticSeekMs,
+           (r.seekNonce ?? 0) <= optimisticSeekNonce,
+           interpolationTick < optimisticSeekDeadline {
+            return optimistic
+        }
         let localMs = interpolationTick.timeIntervalSince1970 * 1000
         let offset = connectService?.serverTimeOffsetMs ?? 0
         let serverNowMs = localMs + offset
@@ -386,10 +403,17 @@ final class MiniPlayerServiceImpl: MiniPlayerService {
         }
 
         if connect.isRemoteControlling {
-            guard let state = connect.connectState else { return }
-            let posMs = Int(fraction * Double(state.durationMs))
-            logger.info("seek: remote -> sendSeek(pos=\(posMs, privacy: .public))")
-            connect.sendSeek(trackIndex: state.trackIndex, positionMs: posMs, durationMs: state.durationMs)
+            guard let state = connect.connectState, durationMs > 0 else { return }
+            // Compute against the resolved `durationMs` (locally-loaded track, with a
+            // state.durationMs fallback) — NOT raw state.durationMs, which is 0 on a
+            // hydrated session and would collapse every drag to 0 (ADR-0017).
+            let posMs = Int(fraction * Double(durationMs))
+            // Optimistic hold so the thumb stays where dropped until the echo lands.
+            optimisticSeekMs = posMs
+            optimisticSeekNonce = state.seekNonce ?? 0
+            optimisticSeekDeadline = Date().addingTimeInterval(6)
+            logger.info("seek: remote -> sendSeek(pos=\(posMs, privacy: .public)) optimistic hold")
+            connect.sendSeek(trackIndex: state.trackIndex, positionMs: posMs, durationMs: durationMs)
         } else {
             guard !isSkeleton else { return }
             let target = fraction * streamPlayer.progress.duration

--- a/ui/src/components/player/PlayerProvider.tsx
+++ b/ui/src/components/player/PlayerProvider.tsx
@@ -701,7 +701,9 @@ export default function PlayerProvider({
     const id = setInterval(() => {
       const audio = getActiveAudio();
       if (audio && !audio.paused) {
-        sendCommandRef.current("position", { positionMs: Math.round(audio.currentTime * 1000) });
+        // Carry our real duration so controllers get a valid scrubber scale (ADR-0017).
+        const durationMs = Number.isFinite(audio.duration) ? Math.round(audio.duration * 1000) : 0;
+        sendCommandRef.current("position", { positionMs: Math.round(audio.currentTime * 1000), durationMs });
       }
     }, 5000);
     return () => clearInterval(id);
@@ -850,8 +852,9 @@ export default function PlayerProvider({
       reassertingTracksRef.current = false;
       if (audio && !audio.paused) {
         const positionMs = Math.round(audio.currentTime * 1000);
+        const durationMs = Number.isFinite(audio.duration) ? Math.round(audio.duration * 1000) : 0;
         audio.pause();
-        sendCommand("position", { positionMs });
+        sendCommand("position", { positionMs, durationMs });
       }
       return;
     }


### PR DESCRIPTION
Three fixes to the cross-device Connect seek path, designed and verified together. See [ADR-0017](docs/adr/0017-connect-seek-as-intent-not-magnitude.md).

## 1. Honor a remote seek by intent, not magnitude
The active device decided "is this a real remote seek?" by a 2s position-delta threshold. That axis is wrong:
- **False positives → "skips":** the device's own ~5s position reports echo back slightly stale; when the gap crossed 2s it followed a seek to a position *it just reported*, yanking audio backward.
- **False negatives:** a deliberate small seek from another device fell under the threshold and was dropped.

Fix: add `seekNonce` to `ConnectState`, bumped **only** by `handleSeek` (never by `handlePosition`). The active device follows a remote seek iff the nonce advances — intent, not distance. Deletes `REMOTE_SEEK_THRESHOLD_MS` (Android) and the iOS inline threshold. Additive/optional field → mixed-fleet safe in any deploy order.

## 2. Propagate track duration
A controller computes seek position as `fraction × durationMs`. `durationMs` was only written by `load`/`seek`, so a hydrated/restored session left it `0` and **every drag seeked to track start**. The active device now carries its real `durationMs` in routine position reports; `handlePosition` overwrites only a `>0`, changed value. (Pre-existing bug, present on the old threshold build too — independent of #1.)

## 3. Optimistic controller scrubber
The controller thumb was driven purely by echoed server state, so after a drag it snapped back until the round-trip completed; users re-dragged and fired duplicate seeks. The controller now holds the scrubber at the requested position until **its** seek echoes back (`seekNonce` advances past the captured value) or a ~6s deadline — reusing #1's nonce as the confirmation signal. iOS gates it functionally in `interpolatedRemotePositionMs`; Android weaves an `optimisticSeek` `StateFlow` into `playbackStatus`.

## Testing
- Server unit tests for the nonce + duration invariants (`api/src/connect/__tests__/state.seek.test.ts`, 15/15).
- All platforms compile; web + server typecheck clean.
- **On-device (Pixel + iPhone)** under an artificial broadcast delay (`CONNECT_BROADCAST_DELAY_MS`, kept in `broadcastState` as a documented test affordance — reproduces the self-skip on a single device, no flaky network needed): confirmed no self-flinch on 60s of stale echoes, small remote seeks land correctly, and the scrubber stays put under 3s of delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)