### PR TITLE
fix(all/connect): add per-device "Enable Connect (Beta)" toggle in Settings

### DIFF
--- a/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectService.kt
+++ b/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectService.kt
@@ -26,6 +26,14 @@ interface ConnectService {
 
     fun startIfAuthenticated()
     fun stop()
+
+    /**
+     * Toggle the per-device Connect kill switch (Settings). Persists the choice
+     * and either tears down or (re)starts the session. When turning off while
+     * this device is the active player, sends an explicit `stop` first so
+     * followers pause cleanly before the socket closes.
+     */
+    fun setEnabled(enabled: Boolean)
     fun handleNetworkRestored()
 
     fun sendStop()

--- a/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
+++ b/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
@@ -236,7 +236,10 @@ class ConnectServiceImpl @Inject constructor(
 
     override fun startIfAuthenticated() {
         val token = authService.getAuthToken()
-        Log.d(TAG, "startIfAuthenticated: token=${if (token != null) "present" else "null"}, shouldConnect=$shouldConnect")
+        Log.d(TAG, "startIfAuthenticated: token=${if (token != null) "present" else "null"}, shouldConnect=$shouldConnect, enabled=${appPreferences.connectEnabled.value}")
+        // Per-device kill switch (Settings → Playback & Audio → Connect). When
+        // off, this device never joins a session.
+        if (!appPreferences.connectEnabled.value) return
         if (token == null) return
         if (shouldConnect) {
             // Already meant to be connected. Since we no longer stop() on
@@ -250,6 +253,23 @@ class ConnectServiceImpl @Inject constructor(
         shouldConnect = true
         reconnectAttempt = 0
         connect()
+    }
+
+    override fun setEnabled(enabled: Boolean) {
+        Log.d(TAG, "setEnabled($enabled)")
+        appPreferences.setConnectEnabled(enabled)
+        if (enabled) {
+            // Pause local audio before joining: this device is opting into
+            // cross-device control, so we don't want it playing on its own while
+            // it adopts the shared session state. Avoids a local-vs-shared clash.
+            scope.launch { mediaControllerRepository.pause() }
+            startIfAuthenticated()
+        } else {
+            if (_isActiveDevice.value && _isConnected.value) {
+                sendStop()
+            }
+            stop()
+        }
     }
 
     override fun stop() {

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
@@ -66,6 +66,25 @@ class AppPreferences @Inject constructor(
         private const val KEY_HOME_POPULAR_ENABLED = "home_popular_enabled"
         private const val KEY_HOME_POPULAR_CARD_SIZE = "home_popular_card_size"
         private const val KEY_HOME_POPULAR_DECADE = "home_popular_decade"
+        private const val KEY_CONNECT_ENABLED = "connect_enabled"
+
+        /**
+         * Default for the per-device Connect toggle. Flip to `false` to disable
+         * cross-device Connect by default across all installs (see settings).
+         */
+        const val CONNECT_ENABLED_DEFAULT = true
+    }
+
+    private val _connectEnabled = MutableStateFlow(
+        prefs.getBoolean(KEY_CONNECT_ENABLED, CONNECT_ENABLED_DEFAULT)
+    )
+
+    /** Per-device kill switch for cross-device Connect (Beta). On by default. */
+    val connectEnabled: StateFlow<Boolean> = _connectEnabled.asStateFlow()
+
+    fun setConnectEnabled(value: Boolean) {
+        prefs.edit().putBoolean(KEY_CONNECT_ENABLED, value).apply()
+        _connectEnabled.value = value
     }
 
     private val _homeTrendingCardSize = MutableStateFlow(

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -477,6 +478,7 @@ private fun PlaybackAudioSettingsScreen(
 ) {
     val sourceBadgeStyle by viewModel.sourceBadgeStyle.collectAsState()
     val playerControlsStyle by viewModel.playerControlsStyle.collectAsState()
+    val connectEnabled by viewModel.connectEnabled.collectAsState()
 
     SubscreenScaffold("Playback & Audio", onBack) {
         item { SectionHeader("Controls") }
@@ -514,20 +516,34 @@ private fun PlaybackAudioSettingsScreen(
             )
         }
 
+        item { HorizontalDivider() }
+        item { SectionHeader("Connect") }
+
         item {
-            PreferenceRow(
-                title = "Connected Devices",
-                subtitle = "View devices connected to your account",
-                leading = { LeadingIcon(IconResources.Content.Cast()) },
-                onClick = onNavigateToConnect,
-                trailing = {
-                    Icon(
-                        painter = IconResources.Navigation.ChevronRight(),
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
+            PreferenceToggleRow(
+                title = "Enable Connect (Beta)",
+                subtitle = "Play in sync across your devices. Turn off to keep this device out of Connect.",
+                checked = connectEnabled,
+                onCheckedChange = { viewModel.toggleConnectEnabled() }
             )
+        }
+
+        item {
+            Box(modifier = Modifier.alpha(if (connectEnabled) 1f else 0.38f)) {
+                PreferenceRow(
+                    title = "Connected Devices",
+                    subtitle = "View devices connected to your account",
+                    leading = { LeadingIcon(IconResources.Content.Cast()) },
+                    onClick = { if (connectEnabled) onNavigateToConnect() },
+                    trailing = {
+                        Icon(
+                            painter = IconResources.Navigation.ChevronRight(),
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                )
+            }
         }
     }
 }

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
@@ -10,6 +10,7 @@ import com.grateful.deadly.core.api.auth.AuthState
 import com.grateful.deadly.core.api.usersync.FavoritesPushService
 import com.grateful.deadly.core.api.usersync.UserSyncService
 import com.grateful.deadly.core.database.AnalyticsService
+import com.grateful.deadly.core.connect.ConnectService
 import com.grateful.deadly.core.database.AppPreferences
 import com.grateful.deadly.core.database.AppReviewManager
 import com.grateful.deadly.core.database.migration.MigrationImportService
@@ -41,6 +42,7 @@ class SettingsViewModel @Inject constructor(
     private val favoritesPushService: FavoritesPushService,
     private val analyticsService: AnalyticsService,
     private val appReviewManager: AppReviewManager,
+    private val connectService: ConnectService,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
@@ -79,6 +81,18 @@ class SettingsViewModel @Inject constructor(
         analyticsService.track("feature_use", mapOf("feature" to event, "category" to "account"))
         analyticsService.flush()
         appPreferences.setAnalyticsEnabled(newValue)
+    }
+
+    val connectEnabled: StateFlow<Boolean> = appPreferences.connectEnabled
+
+    fun toggleConnectEnabled() {
+        val newValue = !appPreferences.connectEnabled.value
+        connectService.setEnabled(newValue)
+        analyticsService.track("feature_use", mapOf(
+            "feature" to "set_connect_enabled",
+            "category" to "preference",
+            "value" to if (newValue) "on" else "off",
+        ))
     }
 
     val sourceBadgeStyle: StateFlow<String> = appPreferences.sourceBadgeStyle

--- a/iosApp/deadly/Core/Service/AppPreferences.swift
+++ b/iosApp/deadly/Core/Service/AppPreferences.swift
@@ -13,7 +13,12 @@ final class AppPreferences {
     private static let eqBandGainsKey = "eq_band_gains"
     private static let shareAttachImageKey = "share_attach_image"
     private static let autoAdvanceEnabledKey = "auto_advance_enabled"
+    private static let connectEnabledKey = "connect_enabled"
     private static let sourceBadgeStyleKey = "source_badge_style"
+
+    /// Default for the per-device Connect toggle. Flip to `false` to disable
+    /// cross-device Connect by default across all installs (see settings toggle).
+    static let connectEnabledDefault = true
     private static let useBetaShareLinksKey = "use_beta_share_links"
     private static let useBetaModeKey = "use_beta_mode"
     private static let serverEnvironmentKey = "server_environment"
@@ -123,6 +128,12 @@ final class AppPreferences {
     /// ADR-0010: roll into the next show when one ends ("Autoplay"). Off by default.
     var autoAdvanceEnabled: Bool {
         didSet { UserDefaults.standard.set(autoAdvanceEnabled, forKey: Self.autoAdvanceEnabledKey) }
+    }
+
+    /// Per-device kill switch for cross-device Connect (Beta). On by default;
+    /// when off, this device never opens the Connect WebSocket. See ConnectService.
+    var connectEnabled: Bool {
+        didSet { UserDefaults.standard.set(connectEnabled, forKey: Self.connectEnabledKey) }
     }
 
     var analyticsEnabled: Bool {
@@ -273,6 +284,9 @@ final class AppPreferences {
             ?? "LIST"
         shareAttachImage = UserDefaults.standard.bool(forKey: Self.shareAttachImageKey)
         autoAdvanceEnabled = UserDefaults.standard.bool(forKey: Self.autoAdvanceEnabledKey)
+        connectEnabled = UserDefaults.standard.object(forKey: Self.connectEnabledKey) == nil
+            ? Self.connectEnabledDefault
+            : UserDefaults.standard.bool(forKey: Self.connectEnabledKey)
         sourceBadgeStyle = UserDefaults.standard.string(forKey: Self.sourceBadgeStyleKey) ?? "LONG"
         playerControlsStyle = UserDefaults.standard.string(forKey: Self.playerControlsStyleKey) ?? "skipTrack"
         homeTrendingWindow = UserDefaults.standard.string(forKey: Self.homeTrendingWindowKey) ?? "now"

--- a/iosApp/deadly/Core/Service/ConnectService.swift
+++ b/iosApp/deadly/Core/Service/ConnectService.swift
@@ -137,7 +137,10 @@ final class ConnectService: NSObject {
 
     func startIfAuthenticated() {
         let hasToken = authService.token != nil
-        logger.info("startIfAuthenticated: token=\(hasToken ? "present" : "null", privacy: .public) shouldConnect=\(self.shouldConnect, privacy: .public)")
+        logger.info("startIfAuthenticated: token=\(hasToken ? "present" : "null", privacy: .public) shouldConnect=\(self.shouldConnect, privacy: .public) enabled=\(self.appPreferences.connectEnabled, privacy: .public)")
+        // Per-device kill switch (Settings → Playback & Audio → Connect). When
+        // off, this device never joins a session.
+        guard appPreferences.connectEnabled else { return }
         guard hasToken else { return }
         if shouldConnect {
             // Already meant to be connected. Since we no longer stop() on
@@ -150,6 +153,27 @@ final class ConnectService: NSObject {
         shouldConnect = true
         reconnectAttempt = 0
         Task { await connect() }
+    }
+
+    /// Toggle the per-device Connect kill switch (Settings). Persists the choice
+    /// and either tears down or (re)starts the session. When turning off while
+    /// this device is the active player, send an explicit `stop` first so
+    /// followers pause cleanly before the socket closes.
+    func setEnabled(_ enabled: Bool) {
+        logger.info("setEnabled(\(enabled, privacy: .public))")
+        appPreferences.connectEnabled = enabled
+        if enabled {
+            // Pause local audio before joining: this device is opting into
+            // cross-device control, so we don't want it playing on its own while
+            // it adopts the shared session state. Avoids a local-vs-shared clash.
+            streamPlayer.pause()
+            startIfAuthenticated()
+        } else {
+            if isActiveDevice && isConnected {
+                sendStop()
+            }
+            stop()
+        }
     }
 
     func stop() {

--- a/iosApp/deadly/Feature/Settings/SettingsScreen.swift
+++ b/iosApp/deadly/Feature/Settings/SettingsScreen.swift
@@ -331,12 +331,26 @@ struct PlaybackAudioSettingsView: View {
             }
 
             if container.authService.isSignedIn {
-                Section("Connect") {
+                Section {
+                    Toggle(isOn: Binding(
+                        get: { container.appPreferences.connectEnabled },
+                        set: { newValue in
+                            container.connectService.setEnabled(newValue)
+                            container.analyticsService.track("feature_use", props: [
+                                "feature": "set_connect_enabled",
+                                "category": "preference",
+                                "value": newValue ? "on" : "off",
+                            ])
+                        }
+                    )) {
+                        Label("Enable Connect (Beta)", systemImage: "iphone.and.arrow.forward")
+                    }
+
                     NavigationLink {
                         ConnectScreen()
                     } label: {
                         HStack {
-                            settingsRow("Connected Devices", systemImage: "iphone.and.arrow.forward")
+                            settingsRow("Connected Devices", systemImage: "rectangle.connected.to.line.below")
                             if container.connectService.isConnected && !container.connectService.devices.isEmpty {
                                 Text("\(container.connectService.devices.count)")
                                     .font(.caption)
@@ -345,6 +359,11 @@ struct PlaybackAudioSettingsView: View {
                         }
                     }
                     .foregroundStyle(.primary)
+                    .disabled(!container.appPreferences.connectEnabled)
+                } header: {
+                    Text("Connect")
+                } footer: {
+                    Text("Play in sync across your devices. Turn off to keep this device out of Connect.")
                 }
             }
         }

--- a/ui/src/app/me/_components/SettingsTab.tsx
+++ b/ui/src/app/me/_components/SettingsTab.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { usePlayer } from "@/contexts/PlayerContext";
+import { useConnect } from "@/contexts/ConnectContext";
 import { deleteAccount } from "@/lib/userDataApi";
 import { SUBREDDIT_HANDLE, SUBREDDIT_URL } from "@/lib/community";
 
@@ -13,6 +14,7 @@ const DATA_VERSION = process.env.NEXT_PUBLIC_DATA_VERSION ?? "dev";
 export default function SettingsTab() {
   const { user, signOut } = useAuth();
   const { autoAdvanceEnabled, toggleAutoAdvance } = usePlayer();
+  const { connectEnabled, setConnectEnabled } = useConnect();
   const router = useRouter();
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [confirmText, setConfirmText] = useState("");
@@ -81,6 +83,30 @@ export default function SettingsTab() {
             <span
               className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
                 autoAdvanceEnabled ? "translate-x-[1.375rem]" : "translate-x-0.5"
+              }`}
+            />
+          </button>
+        </div>
+
+        <div className="mt-4 flex items-center justify-between gap-4 border-t border-white/10 pt-4">
+          <div className="min-w-0">
+            <p className="text-sm text-white/80">Enable Connect (Beta)</p>
+            <p className="mt-0.5 text-xs text-white/40">
+              Play in sync across your devices. Turn off to keep this browser out of Connect.
+            </p>
+          </div>
+          <button
+            role="switch"
+            aria-checked={connectEnabled}
+            aria-label="Enable Connect"
+            onClick={() => setConnectEnabled(!connectEnabled)}
+            className={`inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
+              connectEnabled ? "bg-deadly-highlight" : "bg-white/15"
+            }`}
+          >
+            <span
+              className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
+                connectEnabled ? "translate-x-[1.375rem]" : "translate-x-0.5"
               }`}
             />
           </button>

--- a/ui/src/components/connect/ConnectProvider.tsx
+++ b/ui/src/components/connect/ConnectProvider.tsx
@@ -17,6 +17,10 @@ const APP_VERSION = (process.env.NEXT_PUBLIC_DATA_VERSION ?? "web").slice(0, 20)
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const RECONNECT_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 30_000];
 const DEVICE_ID_KEY = "deadly-device-id";
+const CONNECT_ENABLED_KEY = "deadly-connect-enabled";
+// Default for the per-device Connect toggle. Flip to false to disable
+// cross-device Connect by default across all browsers (see Settings).
+const CONNECT_ENABLED_DEFAULT = true;
 const TIME_SYNC_REFRESH_MS = 5 * 60 * 1000;
 const TIME_SYNC_SAMPLES = 3;
 const TIME_SYNC_SAMPLE_SPACING_MS = 200;
@@ -69,6 +73,13 @@ export default function ConnectProvider({
 
   const [activeDeviceVolume, setActiveDeviceVolume] = useState<number | null>(null);
   const [serverTimeOffsetMs, setServerTimeOffsetMs] = useState(0);
+  // Per-device kill switch for cross-device Connect (Beta). On by default; when
+  // off, this browser never opens the Connect WebSocket. Persisted to localStorage.
+  const [connectEnabled, setConnectEnabledState] = useState<boolean>(() => {
+    if (typeof window === "undefined") return CONNECT_ENABLED_DEFAULT;
+    const stored = localStorage.getItem(CONNECT_ENABLED_KEY);
+    return stored === null ? CONNECT_ENABLED_DEFAULT : stored === "1";
+  });
 
   const wsRef = useRef<WebSocket | null>(null);
   const heartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -332,16 +343,44 @@ export default function ConnectProvider({
     currentVersionRef.current = 0;
   }, [clearHeartbeat, clearReconnectTimer, clearTimeSyncRefresh]);
 
+  // Toggle the per-device Connect kill switch (Settings). When turning off
+  // while this browser is the active player, send an explicit `stop` first so
+  // followers pause cleanly before the socket closes (the gate effect below
+  // tears it down on the resulting re-render).
+  const setConnectEnabled = useCallback(
+    (enabled: boolean) => {
+      log(`setConnectEnabled(${enabled})`);
+      if (
+        !enabled &&
+        connectState?.activeDeviceId === myDeviceId &&
+        wsRef.current?.readyState === WebSocket.OPEN
+      ) {
+        sendCommand("stop");
+      }
+      if (typeof window !== "undefined") {
+        localStorage.setItem(CONNECT_ENABLED_KEY, enabled ? "1" : "0");
+      }
+      setConnectEnabledState(enabled);
+    },
+    [connectState, myDeviceId, sendCommand],
+  );
+
   useEffect(() => {
     if (isLoading) return;
 
-    if (user && !onAdmin) {
+    if (user && !onAdmin && connectEnabled) {
       log(`User authenticated, starting connect`);
       shouldConnectRef.current = true;
       reconnectAttemptRef.current = 0;
       connect();
     } else {
-      log(onAdmin ? `On admin route, disconnecting` : `No user, disconnecting`);
+      log(
+        !connectEnabled
+          ? `Connect disabled, disconnecting`
+          : onAdmin
+            ? `On admin route, disconnecting`
+            : `No user, disconnecting`,
+      );
       disconnect();
     }
 
@@ -349,10 +388,10 @@ export default function ConnectProvider({
       disconnect();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user, isLoading, onAdmin]);
+  }, [user, isLoading, onAdmin, connectEnabled]);
 
   return (
-    <ConnectContext.Provider value={{ devices, state: connectState, myDeviceId, connected, sendCommand, activeDeviceVolume, onVolumeMessage, reportVolume, setLocalPlaybackSource, serverTimeOffsetMs }}>
+    <ConnectContext.Provider value={{ devices, state: connectState, myDeviceId, connected, sendCommand, activeDeviceVolume, onVolumeMessage, reportVolume, setLocalPlaybackSource, serverTimeOffsetMs, connectEnabled, setConnectEnabled }}>
       {children}
     </ConnectContext.Provider>
   );

--- a/ui/src/contexts/ConnectContext.ts
+++ b/ui/src/contexts/ConnectContext.ts
@@ -28,6 +28,10 @@ export interface ConnectContextValue {
   // server's current wall-clock. 0 until the first time_sync round-trip
   // completes. See docs/connect-v2-architecture.md "Clock Sync".
   serverTimeOffsetMs: number;
+  // Per-device kill switch for cross-device Connect (Beta). When false, this
+  // browser never opens the Connect WebSocket. Persisted to localStorage.
+  connectEnabled: boolean;
+  setConnectEnabled: (enabled: boolean) => void;
 }
 
 export const ConnectContext = createContext<ConnectContextValue | null>(null);


### PR DESCRIPTION
## What

Adds a per-device **Enable Connect (Beta)** toggle so a user can turn off cross-device Connect on a single device when it misbehaves.

- **On by default**, behind a single named constant per platform (`connectEnabledDefault` / `CONNECT_ENABLED_DEFAULT`) so the default can be flipped off everywhere in one line if Connect instability persists.
- **When off:** the device never opens the Connect WebSocket — it doesn't register, isn't listed by other devices, can't be remote-controlled, and skips cross-device auto-advance. Local playback is untouched.
- **Turning off while active player:** sends an explicit `stop` first so followers pause cleanly before the socket closes.
- **Turning on:** pauses local audio before joining (mobile), so the device adopts the shared session cleanly instead of a local-vs-shared clash.

## Where

Settings → **Playback & Audio → Connect** (mobile) and the **Playback** section (web). The **Connected Devices** row is greyed out while disabled.

## Platforms

- **iOS** — `AppPreferences` pref, gate in `ConnectService.startIfAuthenticated()`, `setEnabled(_:)`, toggle in `PlaybackAudioSettingsView`. ✅ compiles on Mac, tested on device.
- **Android** — `AppPreferences` StateFlow, gate + `setEnabled()` in `ConnectServiceImpl`, `SettingsViewModel.toggleConnectEnabled()`, toggle row in `PlaybackAudioSettingsScreen`. ✅ builds, tested on Pixel.
- **Web** — localStorage-persisted `connectEnabled` in `ConnectProvider`, added to the connect gate, sends `stop` before close when active, toggle in `SettingsTab`. ✅ builds clean.

## Follow-up

- Web mirrors the toggle + teardown, but **pausing local audio on enable is mobile-only** for now (the web `ConnectProvider` has no player pause hook yet).

## Test plan

- [x] Toggle off → device drops from Connect, local audio keeps playing
- [x] Toggle off while active → followers pause cleanly
- [x] Toggle on → local audio pauses, device joins clean (no stale-snapshot weirdness)
- [x] Default on for fresh installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)