### PR TITLE
feat(all/connect): server-gated Connect beta — admin kill switch + min-protocol gate

### DIFF
--- a/PLANS/connect-beta-opt-in.md
+++ b/PLANS/connect-beta-opt-in.md
@@ -1,0 +1,101 @@
+# Connect beta opt-in + server-gated UI — implementation plan
+
+Tracks [ADR-0018](../docs/adr/0018-connect-beta-opt-in-and-server-gated-ui.md).
+Goal: Connect stays default-OFF and server-gated, but becomes a discoverable
+user-facing beta opt-in (icon always present, greyed when server-off, enable
+sheet when server-on-but-device-off, full UI when on).
+
+Status legend: ⬜ not started · 🟡 in progress · ✅ done
+
+## Part 0 — Server: public flag read
+
+- ✅ `GET /api/connect/enabled` → `{ connectEnabled }`, **no auth**
+  (`api/src/routes/connectPublic.ts`, registered in `app.ts`). Reuses
+  `getConnectEnabled()`.
+- ✅ Test `api/src/routes/__tests__/connectPublic.test.ts`: reachable with no
+  auth, reflects the flag. Passes; tsc clean.
+
+This is the dependency for every client part — do it first.
+
+## Shared client state model (all three platforms)
+
+Two booleans drive all Connect UI:
+- `serverConnectEnabled` — from `GET /api/connect/enabled`. Fetch **at startup**
+  (short ~2–3s timeout so it never blocks launch), **fall back to a foreground
+  fetch** on timeout/failure, and **refresh on the existing focus/navigation
+  trigger** used for userdata sync. Also set `false` when a live session receives
+  close code **4005**. Until the first read resolves, use the last cached value,
+  defaulting to `false` (greyed) on a fresh install — fail safe to "not offered".
+- `connectOptedIn` — the local per-device/per-install toggle (default **false**).
+
+Icon rendering:
+- `serverConnectEnabled == false` → icon **greyed**, tap → "Connect unavailable".
+- `true && connectOptedIn == false` → icon enabled, tap → **enable sheet**.
+- `true && connectOptedIn == true` → existing full Connect UI + "Turn off" row.
+
+Client only opens the WS / registers when `connectOptedIn == true`.
+
+## Part 1 — Android
+
+Files touched in `e64b1f7c` are the map of every gate site:
+
+- ✅ `core/connect/ConnectServiceImpl.kt` — short-timeout `restClient` fetch of
+  `/api/connect/enabled` via `refreshServerConnectEnabled()`; expose
+  `serverConnectEnabled`; on 4005 set it false; also tear down a live session if
+  a refresh reports off. Hooked in `MainActivity.onStart` (startup + foreground).
+- ✅ `core/database/AppPreferences.kt` — cached `server_connect_enabled` getter/
+  setter (default false), `connectEnabled` opt-in unchanged.
+- ✅ Toggle moved out of `DeveloperScreen.kt` into **Playback & Audio → Connect
+  (Beta)** (`SettingsScreen.kt` / `SettingsViewModel.kt`).
+- ✅ Three-state render handled by the **ConnectSheet** (unavailable / promo /
+  full); the four player surfaces now always show the icon, greyed when
+  `!serverConnectEnabled`:
+  - `PlayerScreen.kt` (+ `PlayerViewModel`), `PlayerSecondaryControls.kt`,
+    `PlayerMiniPlayer.kt`, `PlayerSidePanel.kt`
+  - `MiniPlayerScreen.kt` (+ `MiniPlayerViewModel`)
+- ✅ `ConnectSheet.kt` rebuilt into 3 modes: `ConnectUnavailableContent`,
+  `ConnectEnablePromoContent` ("Enable Connect (Beta)" + beta/other-devices copy
+  + confirm), and the full picker with a "Turn off Connect" row ("your other
+  devices stay connected"). `ConnectViewModel` exposes the two flags + setter.
+- ✅ Build: `./gradlew assembleDebug` succeeds (pre-existing deprecation warning
+  only).
+
+## Part 2 — iOS
+
+- ✅ `Core/Service/ConnectService.swift` — `serverConnectEnabled` (seeded from
+  cache), `refreshServerConnectEnabled()` (3s URLSession GET), 4005 →
+  `setServerConnectEnabled(false)` which also tears down a live session.
+- ✅ `Core/Service/AppPreferences.swift` — `serverConnectEnabledCached` (default
+  false); `connectEnabled` opt-in unchanged.
+- ✅ Refresh hooked in `App/deadlyApp.swift` (cold start + willEnterForeground).
+- ✅ Toggle moved from `DeveloperView.swift` into **Playback & Audio → Connect
+  (Beta)** in `SettingsScreen.swift`.
+- ✅ Connect icon always shown, greyed when off, at `PlayerScreen.swift`
+  (`connectIconColor`), `SidePlayerView.swift`, `MiniPlayerOverlay.swift`.
+- ✅ `ConnectSheet.swift` rebuilt into 3 modes (`ConnectUnavailableView`,
+  `ConnectEnablePromoView`, `fullDeviceList` + "Turn off Connect" footer).
+- ✅ Compiles clean on the remote Mac (`generic/platform=iOS Simulator`, Debug).
+
+## Part 3 — Web
+
+- ✅ `ui/src/components/connect/ConnectProvider.tsx` — `refreshServerConnectEnabled`
+  (no-store GET on mount + focus/visibility); per-install opt-in in
+  `localStorage` (`deadly-connect-opted-in`); socket attempted only when signed
+  in + opted in + server enabled; 4005 → flag false; context exports the three.
+- ✅ `ui/src/contexts/ConnectContext.ts` — added `serverConnectEnabled`,
+  `connectOptedIn`, `setConnectOptedIn`.
+- ✅ **Settings → Connect (Beta)** toggle in `SettingsTab.tsx` (per-browser; copy
+  adapts when server OFF).
+- ✅ Three-mode device popover in `DeviceList.tsx` (unavailable / enable promo /
+  full + "Turn off Connect on this device"); icon in `HeaderPlayer.tsx` shown
+  when opted-in-or-server-on, greyed when server OFF.
+- ✅ `tsc --noEmit` clean. Device/redeploy verification pending
+  (`make ui-build` + `make docker-redeploy`).
+
+## Validation
+
+- ⬜ Server OFF: all platforms show greyed icon + "unavailable" on tap; no socket.
+- ⬜ Server ON, never opted in: promo icon → enable sheet → confirm → connects.
+- ⬜ Active session, admin flips server OFF: client receives 4005, session dies,
+  icon goes greyed (no churn — Android `onClosing` path).
+- ⬜ Disable from full UI: copy mentions other devices stay connected.

--- a/androidApp/app/src/main/java/com/grateful/deadly/MainActivity.kt
+++ b/androidApp/app/src/main/java/com/grateful/deadly/MainActivity.kt
@@ -62,6 +62,9 @@ class MainActivity : ComponentActivity() {
 
     override fun onStart() {
         super.onStart()
+        // Refresh the global Connect flag on every foreground so the Connect UI
+        // reflects an admin flipping the kill switch without a relaunch (ADR-0018).
+        connectService.refreshServerConnectEnabled()
         connectService.startIfAuthenticated()
     }
 

--- a/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectService.kt
+++ b/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectService.kt
@@ -24,7 +24,25 @@ interface ConnectService {
      */
     val serverTimeOffsetMs: StateFlow<Long>
 
+    /**
+     * Whether the server's global Connect kill switch is ON (ADR-0018). Drives
+     * UI discovery: when false the Connect icon renders greyed/"unavailable" and
+     * no session can form. Seeded from the last cached value (default false on a
+     * fresh install — fail safe to "not offered"), refreshed by
+     * [refreshServerConnectEnabled], and forced false when a live session is
+     * closed with code 4005.
+     */
+    val serverConnectEnabled: StateFlow<Boolean>
+
     fun startIfAuthenticated()
+
+    /**
+     * Fetch the global Connect flag (`GET /api/connect/enabled`) and update
+     * [serverConnectEnabled]. Short-timeout, best-effort: on failure the last
+     * cached value is kept. Call on startup and on foreground (ADR-0018).
+     */
+    fun refreshServerConnectEnabled()
+
     fun stop()
 
     /**

--- a/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
+++ b/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
@@ -57,7 +57,8 @@ class ConnectServiceImpl @Inject constructor(
         private const val TAG = "ConnectService"
         // Connect WS wire-contract version. See docs/PROTOCOL.md for semantics.
         // Bump in lockstep with the documented protocol; the server may branch on it.
-        private const val CONNECT_PROTOCOL_VERSION = 1
+        // v2: understands the 4005 "Connect disabled" terminal close code.
+        private const val CONNECT_PROTOCOL_VERSION = 2
         private val RECONNECT_DELAYS_S = listOf(1L, 2L, 4L, 8L, 30L)
         private const val HEARTBEAT_INTERVAL_MS = 15_000L
         // WS keep-alive ping. readTimeout(0) keeps the read side open forever but
@@ -70,7 +71,14 @@ class ConnectServiceImpl @Inject constructor(
         // session is handed away. This is one coupled budget with the sweep; see
         // ADR-0016. Keep it < ~22s (2*ping < 45s) if either constant changes.
         private const val PING_INTERVAL_MS = 20_000L
+        // Server replaced this socket with a newer one for the same deviceId.
+        // Terminal: reconnecting would re-register and kick the newer socket,
+        // a self-perpetuating churn (see web ConnectProvider).
+        private const val CLOSE_CODE_REPLACED = 4000
         private const val CLOSE_CODE_UNAUTHORIZED = 4003
+        // Connect globally disabled by the server (admin kill switch). Terminal:
+        // don't reconnect. Only sent to proto>=2 clients.
+        private const val CLOSE_CODE_DISABLED = 4005
         private const val DEFAULT_FORMAT = "VBR MP3"
         private const val HARDWARE_VOLUME_DEBOUNCE_MS = 300L
         private const val VOLUME_ECHO_SUPPRESS_MS = 1_500L
@@ -354,6 +362,20 @@ class ConnectServiceImpl @Inject constructor(
         override fun onMessage(webSocket: WebSocket, text: String) {
             Log.d(TAG, "onMessage: ${text.take(200)}")
             handleMessage(text)
+        }
+
+        // A server-initiated close lands HERE, not onClosed. Without this
+        // override OkHttp's default onClosing is a no-op, the closing handshake
+        // never completes, onClosed never fires, and the half-dead socket only
+        // dies via the ping-pong timeout → onFailure → reconnect (~40s churn).
+        // So: complete the handshake AND route the server's real close code to
+        // handleDisconnect so terminal codes (4000/4003/4005) suppress reconnect.
+        // handleDisconnect is idempotent, so the onClosed(1000) that follows our
+        // close() is a no-op.
+        override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+            Log.d(TAG, "Closing: code=$code reason=$reason")
+            webSocket.close(1000, null)
+            handleDisconnect(code)
         }
 
         override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
@@ -1034,6 +1056,12 @@ class ConnectServiceImpl @Inject constructor(
     }
 
     private fun handleDisconnect(closeCode: Int?) {
+        // Idempotent: onClosing + the onClosed(1000) that follows our handshake
+        // ack (or onFailure) can both land here for one socket. First wins; a
+        // duplicate must not schedule a second reconnect. The close completes
+        // synchronously inside onClosing, well before any reconnect backoff, so
+        // a stale onClosed can't tear down a freshly reconnected socket.
+        if (webSocket == null && !_isConnected.value) return
         stopHeartbeat()
         stopTimeSyncRefresh()
         stopPositionReporting()
@@ -1047,7 +1075,15 @@ class ConnectServiceImpl @Inject constructor(
         setPendingCommand(null)
         _pendingTransfer.value = null
 
-        if (!shouldConnect || closeCode == CLOSE_CODE_UNAUTHORIZED) return
+        // Terminal closes (don't reconnect): 4000 replaced-by-newer-connection,
+        // 4003 unauthorized, 4005 Connect disabled. 4001 (heartbeat timeout) and
+        // null (network/ping failure) fall through to reconnect. Mirrors the web
+        // client's terminal set.
+        if (!shouldConnect ||
+            closeCode == CLOSE_CODE_REPLACED ||
+            closeCode == CLOSE_CODE_UNAUTHORIZED ||
+            closeCode == CLOSE_CODE_DISABLED
+        ) return
 
         val delaySecs = RECONNECT_DELAYS_S[minOf(reconnectAttempt, RECONNECT_DELAYS_S.size - 1)]
         reconnectAttempt++

--- a/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
+++ b/androidApp/core/connect/src/main/java/com/grateful/deadly/core/connect/ConnectServiceImpl.kt
@@ -94,12 +94,20 @@ class ConnectServiceImpl @Inject constructor(
         // A pending transport command auto-clears after this long if the server
         // never confirms it, so the UI spinner can never get permanently stuck.
         private const val PENDING_COMMAND_TIMEOUT_MS = 6_000L
+        // Short timeout for the public Connect-flag read so it never blocks the
+        // foreground path; on failure we keep the last cached value. ADR-0018.
+        private const val SERVER_FLAG_TIMEOUT_MS = 3_000L
     }
 
     private val json = Json { ignoreUnknownKeys = true }
     private val okHttpClient = OkHttpClient.Builder()
         .readTimeout(0, TimeUnit.MILLISECONDS) // required for WebSocket keep-alive
         .pingInterval(PING_INTERVAL_MS, TimeUnit.MILLISECONDS) // detect dead peer → fail fast → reconnect
+        .build()
+    // Separate short-timeout client for the public flag read — the WS client's
+    // readTimeout(0) would let a hung GET block forever. ADR-0018.
+    private val restClient = OkHttpClient.Builder()
+        .callTimeout(SERVER_FLAG_TIMEOUT_MS, TimeUnit.MILLISECONDS)
         .build()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -142,6 +150,11 @@ class ConnectServiceImpl @Inject constructor(
 
     private val _serverTimeOffsetMs = MutableStateFlow(0L)
     override val serverTimeOffsetMs: StateFlow<Long> = _serverTimeOffsetMs.asStateFlow()
+
+    // Seeded from the last cached value so the UI renders correctly before the
+    // first network read resolves (default false ⇒ greyed on a fresh install).
+    private val _serverConnectEnabled = MutableStateFlow(appPreferences.getServerConnectEnabledCached())
+    override val serverConnectEnabled: StateFlow<Boolean> = _serverConnectEnabled.asStateFlow()
 
     @Volatile private var currentVersion = 0L
     // Best (lowest) RTT seen in the current time_sync batch. Replies with
@@ -261,6 +274,40 @@ class ConnectServiceImpl @Inject constructor(
         shouldConnect = true
         reconnectAttempt = 0
         connect()
+    }
+
+    override fun refreshServerConnectEnabled() {
+        scope.launch {
+            val baseUrl = appPreferences.apiBaseUrl
+            if (baseUrl.isBlank()) return@launch
+            val url = "$baseUrl/api/connect/enabled"
+            try {
+                val request = Request.Builder().url(url).get().build()
+                restClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        Log.d(TAG, "refreshServerConnectEnabled: HTTP ${response.code}, keeping cached=${_serverConnectEnabled.value}")
+                        return@launch
+                    }
+                    val body = response.body?.string() ?: return@launch
+                    val enabled = json.parseToJsonElement(body)
+                        .jsonObject["connectEnabled"]?.jsonPrimitive?.content?.toBooleanStrictOrNull()
+                        ?: return@launch
+                    setServerConnectEnabled(enabled)
+                    Log.d(TAG, "refreshServerConnectEnabled: serverConnectEnabled=$enabled")
+                    // If the server just turned Connect off, tear down any live
+                    // session locally too (mirrors the 4005 runtime path for a
+                    // client that is currently connected).
+                    if (!enabled && shouldConnect) stop()
+                }
+            } catch (e: Exception) {
+                Log.d(TAG, "refreshServerConnectEnabled failed (keeping cached=${_serverConnectEnabled.value}): ${e.message}")
+            }
+        }
+    }
+
+    private fun setServerConnectEnabled(enabled: Boolean) {
+        _serverConnectEnabled.value = enabled
+        appPreferences.setServerConnectEnabledCached(enabled)
     }
 
     override fun setEnabled(enabled: Boolean) {
@@ -1074,6 +1121,12 @@ class ConnectServiceImpl @Inject constructor(
         // the fresh state snapshot after reconnect.
         setPendingCommand(null)
         _pendingTransfer.value = null
+
+        // The server refused us because Connect is globally disabled — flip the
+        // cached flag so every Connect icon greys out immediately, without waiting
+        // for the next refresh. This is the runtime enforcement half of ADR-0018
+        // (the REST read is the discovery half).
+        if (closeCode == CLOSE_CODE_DISABLED) setServerConnectEnabled(false)
 
         // Terminal closes (don't reconnect): 4000 replaced-by-newer-connection,
         // 4003 unauthorized, 4005 Connect disabled. 4001 (heartbeat timeout) and

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
@@ -69,17 +69,18 @@ class AppPreferences @Inject constructor(
         private const val KEY_CONNECT_ENABLED = "connect_enabled"
 
         /**
-         * Default for the per-device Connect toggle. Flip to `false` to disable
-         * cross-device Connect by default across all installs (see settings).
+         * Default for the per-device Connect toggle. OFF by default: Connect is
+         * a dev/beta opt-in living under Developer settings, and the server gates
+         * it globally too. A user must explicitly turn it on to participate.
          */
-        const val CONNECT_ENABLED_DEFAULT = true
+        const val CONNECT_ENABLED_DEFAULT = false
     }
 
     private val _connectEnabled = MutableStateFlow(
         prefs.getBoolean(KEY_CONNECT_ENABLED, CONNECT_ENABLED_DEFAULT)
     )
 
-    /** Per-device kill switch for cross-device Connect (Beta). On by default. */
+    /** Per-device kill switch for cross-device Connect (Beta). Off by default. */
     val connectEnabled: StateFlow<Boolean> = _connectEnabled.asStateFlow()
 
     fun setConnectEnabled(value: Boolean) {

--- a/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
+++ b/androidApp/core/database/src/main/java/com/grateful/deadly/core/database/AppPreferences.kt
@@ -67,13 +67,21 @@ class AppPreferences @Inject constructor(
         private const val KEY_HOME_POPULAR_CARD_SIZE = "home_popular_card_size"
         private const val KEY_HOME_POPULAR_DECADE = "home_popular_decade"
         private const val KEY_CONNECT_ENABLED = "connect_enabled"
+        private const val KEY_SERVER_CONNECT_ENABLED = "server_connect_enabled_cached"
 
         /**
          * Default for the per-device Connect toggle. OFF by default: Connect is
-         * a dev/beta opt-in living under Developer settings, and the server gates
-         * it globally too. A user must explicitly turn it on to participate.
+         * a beta opt-in the user explicitly turns on, and the server gates it
+         * globally too. See ADR-0018.
          */
         const val CONNECT_ENABLED_DEFAULT = false
+
+        /**
+         * Default for the cached server Connect flag (ADR-0018). False so a fresh
+         * install fails safe to "not offered" (icon greyed) until the first
+         * `GET /api/connect/enabled` resolves.
+         */
+        const val SERVER_CONNECT_ENABLED_DEFAULT = false
     }
 
     private val _connectEnabled = MutableStateFlow(
@@ -86,6 +94,18 @@ class AppPreferences @Inject constructor(
     fun setConnectEnabled(value: Boolean) {
         prefs.edit().putBoolean(KEY_CONNECT_ENABLED, value).apply()
         _connectEnabled.value = value
+    }
+
+    /**
+     * Last-known value of the server's global Connect flag, cached so the UI can
+     * render the correct icon state on launch before the network read resolves.
+     * The live source of truth is ConnectService.serverConnectEnabled (ADR-0018).
+     */
+    fun getServerConnectEnabledCached(): Boolean =
+        prefs.getBoolean(KEY_SERVER_CONNECT_ENABLED, SERVER_CONNECT_ENABLED_DEFAULT)
+
+    fun setServerConnectEnabledCached(value: Boolean) {
+        prefs.edit().putBoolean(KEY_SERVER_CONNECT_ENABLED, value).apply()
     }
 
     private val _homeTrendingCardSize = MutableStateFlow(

--- a/androidApp/feature/miniplayer/build.gradle.kts
+++ b/androidApp/feature/miniplayer/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(project(":core:model"))
     implementation(project(":core:design"))
     implementation(project(":core:connect"))
+    implementation(project(":core:database"))
     implementation(project(":feature:settings"))
     
     // Hilt

--- a/androidApp/feature/miniplayer/src/main/java/com/grateful/deadly/feature/miniplayer/screens/main/MiniPlayerScreen.kt
+++ b/androidApp/feature/miniplayer/src/main/java/com/grateful/deadly/feature/miniplayer/screens/main/MiniPlayerScreen.kt
@@ -49,6 +49,7 @@ fun MiniPlayerScreen(
     val connectRemoteDeviceName by viewModel.connectRemoteDeviceName.collectAsState()
     val showConnectTooltip by viewModel.shouldShowConnectTooltip.collectAsState()
     val showVolumeUI by viewModel.showVolumeUI.collectAsState()
+    val connectEnabled by viewModel.connectEnabled.collectAsState()
     var showConnectSheet by remember { mutableStateOf(false) }
 
     // Hardware volume button pressed during a Connect session — surface the sheet.
@@ -195,18 +196,20 @@ fun MiniPlayerScreen(
                     }
                 }
                 
-                // Connect button
-                IconButton(
-                    onClick = { showConnectSheet = true },
-                    modifier = Modifier.size(40.dp)
-                ) {
-                    Icon(
-                        painter = IconResources.Content.Cast(),
-                        contentDescription = "Connect",
-                        tint = if (connectRemoteDeviceName != null) MaterialTheme.colorScheme.primary
-                               else MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(20.dp)
-                    )
+                // Connect button — hidden when Connect is disabled on this device (off by default)
+                if (connectEnabled) {
+                    IconButton(
+                        onClick = { showConnectSheet = true },
+                        modifier = Modifier.size(40.dp)
+                    ) {
+                        Icon(
+                            painter = IconResources.Content.Cast(),
+                            contentDescription = "Connect",
+                            tint = if (connectRemoteDeviceName != null) MaterialTheme.colorScheme.primary
+                                   else MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
                 }
 
                 // Play/pause button with loading state

--- a/androidApp/feature/miniplayer/src/main/java/com/grateful/deadly/feature/miniplayer/screens/main/MiniPlayerScreen.kt
+++ b/androidApp/feature/miniplayer/src/main/java/com/grateful/deadly/feature/miniplayer/screens/main/MiniPlayerScreen.kt
@@ -49,7 +49,7 @@ fun MiniPlayerScreen(
     val connectRemoteDeviceName by viewModel.connectRemoteDeviceName.collectAsState()
     val showConnectTooltip by viewModel.shouldShowConnectTooltip.collectAsState()
     val showVolumeUI by viewModel.showVolumeUI.collectAsState()
-    val connectEnabled by viewModel.connectEnabled.collectAsState()
+    val connectAvailable by viewModel.serverConnectEnabled.collectAsState()
     var showConnectSheet by remember { mutableStateOf(false) }
 
     // Hardware volume button pressed during a Connect session — surface the sheet.
@@ -196,20 +196,22 @@ fun MiniPlayerScreen(
                     }
                 }
                 
-                // Connect button — hidden when Connect is disabled on this device (off by default)
-                if (connectEnabled) {
-                    IconButton(
-                        onClick = { showConnectSheet = true },
-                        modifier = Modifier.size(40.dp)
-                    ) {
-                        Icon(
-                            painter = IconResources.Content.Cast(),
-                            contentDescription = "Connect",
-                            tint = if (connectRemoteDeviceName != null) MaterialTheme.colorScheme.primary
-                                   else MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.size(20.dp)
-                        )
-                    }
+                // Connect button — always shown; greyed when the server kill
+                // switch is off (ADR-0018).
+                IconButton(
+                    onClick = { showConnectSheet = true },
+                    modifier = Modifier.size(40.dp)
+                ) {
+                    Icon(
+                        painter = IconResources.Content.Cast(),
+                        contentDescription = "Connect",
+                        tint = when {
+                            !connectAvailable -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+                            connectRemoteDeviceName != null -> MaterialTheme.colorScheme.primary
+                            else -> MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                        modifier = Modifier.size(20.dp)
+                    )
                 }
 
                 // Play/pause button with loading state

--- a/androidApp/feature/miniplayer/src/main/java/com/grateful/deadly/feature/miniplayer/screens/main/models/MiniPlayerViewModel.kt
+++ b/androidApp/feature/miniplayer/src/main/java/com/grateful/deadly/feature/miniplayer/screens/main/models/MiniPlayerViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.grateful.deadly.core.api.miniplayer.MiniPlayerService
 import com.grateful.deadly.core.connect.ConnectService
+import com.grateful.deadly.core.database.AppPreferences
 import com.grateful.deadly.core.model.MiniPlayerUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import com.grateful.deadly.core.model.AppLaunchState
@@ -28,8 +29,12 @@ import javax.inject.Inject
 @HiltViewModel
 class MiniPlayerViewModel @Inject constructor(
     private val miniPlayerService: MiniPlayerService,
-    private val connectService: ConnectService
+    private val connectService: ConnectService,
+    appPreferences: AppPreferences
 ) : ViewModel() {
+
+    /** Per-device Connect kill switch (off by default). Gates the Connect icon. */
+    val connectEnabled: StateFlow<Boolean> = appPreferences.connectEnabled
     
     companion object {
         private const val TAG = "MiniPlayerViewModel"

--- a/androidApp/feature/miniplayer/src/main/java/com/grateful/deadly/feature/miniplayer/screens/main/models/MiniPlayerViewModel.kt
+++ b/androidApp/feature/miniplayer/src/main/java/com/grateful/deadly/feature/miniplayer/screens/main/models/MiniPlayerViewModel.kt
@@ -33,8 +33,8 @@ class MiniPlayerViewModel @Inject constructor(
     appPreferences: AppPreferences
 ) : ViewModel() {
 
-    /** Per-device Connect kill switch (off by default). Gates the Connect icon. */
-    val connectEnabled: StateFlow<Boolean> = appPreferences.connectEnabled
+    /** Server global Connect flag — greys the Connect icon when off (ADR-0018). */
+    val serverConnectEnabled: StateFlow<Boolean> = connectService.serverConnectEnabled
     
     companion object {
         private const val TAG = "MiniPlayerViewModel"

--- a/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerScreen.kt
+++ b/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerScreen.kt
@@ -49,6 +49,7 @@ fun PlayerScreen(
     val isCurrentTrackFavorite by viewModel.isCurrentTrackFavorite.collectAsState()
     val equalizerState by viewModel.equalizerState.collectAsState()
     val connectRemoteDeviceName by viewModel.connectRemoteDeviceName.collectAsState()
+    val connectEnabled by viewModel.appPreferences.connectEnabled.collectAsState()
     val autoAdvanceEnabled by viewModel.autoAdvanceEnabled.collectAsState()
     val showCollectionsCount by viewModel.showCollectionsCount.collectAsState()
 
@@ -149,6 +150,7 @@ fun PlayerScreen(
             // Secondary controls row (updated for queue sheet)
             item {
                 PlayerSecondaryControls(
+                    showConnect = connectEnabled,
                     connectDeviceName = connectRemoteDeviceName,
                     onEqualizerClick = { showEqualizerBottomSheet = true },
                     onConnectClick = { showConnectSheet = true },
@@ -254,6 +256,7 @@ fun PlayerScreen(
         if (showMiniPlayer) {
             PlayerMiniPlayer(
                 uiState = uiState,
+                showConnect = connectEnabled,
                 connectDeviceName = connectRemoteDeviceName,
                 onPlayPause = viewModel::onPlayPauseClicked,
                 onConnectClick = { showConnectSheet = true },

--- a/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerScreen.kt
+++ b/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerScreen.kt
@@ -49,7 +49,9 @@ fun PlayerScreen(
     val isCurrentTrackFavorite by viewModel.isCurrentTrackFavorite.collectAsState()
     val equalizerState by viewModel.equalizerState.collectAsState()
     val connectRemoteDeviceName by viewModel.connectRemoteDeviceName.collectAsState()
-    val connectEnabled by viewModel.appPreferences.connectEnabled.collectAsState()
+    // ADR-0018: the Connect icon is always shown; greyed when the server kill
+    // switch is off, and the sheet itself handles enable/full/unavailable modes.
+    val connectAvailable by viewModel.serverConnectEnabled.collectAsState()
     val autoAdvanceEnabled by viewModel.autoAdvanceEnabled.collectAsState()
     val showCollectionsCount by viewModel.showCollectionsCount.collectAsState()
 
@@ -150,7 +152,7 @@ fun PlayerScreen(
             // Secondary controls row (updated for queue sheet)
             item {
                 PlayerSecondaryControls(
-                    showConnect = connectEnabled,
+                    connectAvailable = connectAvailable,
                     connectDeviceName = connectRemoteDeviceName,
                     onEqualizerClick = { showEqualizerBottomSheet = true },
                     onConnectClick = { showConnectSheet = true },
@@ -256,7 +258,7 @@ fun PlayerScreen(
         if (showMiniPlayer) {
             PlayerMiniPlayer(
                 uiState = uiState,
-                showConnect = connectEnabled,
+                connectAvailable = connectAvailable,
                 connectDeviceName = connectRemoteDeviceName,
                 onPlayPause = viewModel::onPlayPauseClicked,
                 onConnectClick = { showConnectSheet = true },

--- a/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerSidePanel.kt
+++ b/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerSidePanel.kt
@@ -81,7 +81,8 @@ fun PlayerSidePanel(
     val isFavorite by viewModel.isCurrentTrackFavorite.collectAsState()
     val equalizerState by viewModel.equalizerState.collectAsState()
     val connectRemoteDeviceName by viewModel.connectRemoteDeviceName.collectAsState()
-    val connectEnabled by viewModel.appPreferences.connectEnabled.collectAsState()
+    // ADR-0018: always show the Connect icon; greyed when the server kill switch is off.
+    val connectAvailable by viewModel.serverConnectEnabled.collectAsState()
     val autoAdvanceEnabled by viewModel.autoAdvanceEnabled.collectAsState()
     val showCollectionsCount by viewModel.showCollectionsCount.collectAsState()
 
@@ -250,10 +251,9 @@ fun PlayerSidePanel(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    // Connect (left). Hidden when Connect is disabled on this
-                    // device (off by default); empty placeholder keeps the right
-                    // cluster right-aligned (SpaceBetween).
-                    if (connectEnabled) {
+                    // Connect (left). Always shown (ADR-0018); greyed when the
+                    // server kill switch is off, tappable to explain via the sheet.
+                    run {
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
                             modifier = Modifier
@@ -265,8 +265,11 @@ fun PlayerSidePanel(
                             Icon(
                                 painter = IconResources.Content.Cast(),
                                 contentDescription = "Connect",
-                                tint = if (connectRemoteDeviceName != null) MaterialTheme.colorScheme.primary
-                                       else MaterialTheme.colorScheme.onSurfaceVariant
+                                tint = when {
+                                    !connectAvailable -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+                                    connectRemoteDeviceName != null -> MaterialTheme.colorScheme.primary
+                                    else -> MaterialTheme.colorScheme.onSurfaceVariant
+                                }
                             )
                             if (connectRemoteDeviceName != null) {
                                 Spacer(Modifier.width(8.dp))
@@ -280,8 +283,6 @@ fun PlayerSidePanel(
                                 )
                             }
                         }
-                    } else {
-                        Spacer(Modifier)
                     }
 
                     Row(verticalAlignment = Alignment.CenterVertically) {

--- a/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerSidePanel.kt
+++ b/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/PlayerSidePanel.kt
@@ -81,6 +81,7 @@ fun PlayerSidePanel(
     val isFavorite by viewModel.isCurrentTrackFavorite.collectAsState()
     val equalizerState by viewModel.equalizerState.collectAsState()
     val connectRemoteDeviceName by viewModel.connectRemoteDeviceName.collectAsState()
+    val connectEnabled by viewModel.appPreferences.connectEnabled.collectAsState()
     val autoAdvanceEnabled by viewModel.autoAdvanceEnabled.collectAsState()
     val showCollectionsCount by viewModel.showCollectionsCount.collectAsState()
 
@@ -249,31 +250,38 @@ fun PlayerSidePanel(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier
-                            .height(40.dp)
-                            .clip(RoundedCornerShape(20.dp))
-                            .clickable { showConnectSheet = true }
-                            .padding(horizontal = 8.dp)
-                    ) {
-                        Icon(
-                            painter = IconResources.Content.Cast(),
-                            contentDescription = "Connect",
-                            tint = if (connectRemoteDeviceName != null) MaterialTheme.colorScheme.primary
-                                   else MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        if (connectRemoteDeviceName != null) {
-                            Spacer(Modifier.width(8.dp))
-                            Text(
-                                text = connectRemoteDeviceName!!,
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.primary,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.widthIn(max = 80.dp)
+                    // Connect (left). Hidden when Connect is disabled on this
+                    // device (off by default); empty placeholder keeps the right
+                    // cluster right-aligned (SpaceBetween).
+                    if (connectEnabled) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .height(40.dp)
+                                .clip(RoundedCornerShape(20.dp))
+                                .clickable { showConnectSheet = true }
+                                .padding(horizontal = 8.dp)
+                        ) {
+                            Icon(
+                                painter = IconResources.Content.Cast(),
+                                contentDescription = "Connect",
+                                tint = if (connectRemoteDeviceName != null) MaterialTheme.colorScheme.primary
+                                       else MaterialTheme.colorScheme.onSurfaceVariant
                             )
+                            if (connectRemoteDeviceName != null) {
+                                Spacer(Modifier.width(8.dp))
+                                Text(
+                                    text = connectRemoteDeviceName!!,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.primary,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    modifier = Modifier.widthIn(max = 80.dp)
+                                )
+                            }
                         }
+                    } else {
+                        Spacer(Modifier)
                     }
 
                     Row(verticalAlignment = Alignment.CenterVertically) {

--- a/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/components/PlayerMiniPlayer.kt
+++ b/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/components/PlayerMiniPlayer.kt
@@ -26,7 +26,8 @@ fun PlayerMiniPlayer(
     onPlayPause: () -> Unit,
     onConnectClick: () -> Unit,
     onTapToExpand: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    showConnect: Boolean = true
 ) {
     Card(
         modifier = modifier
@@ -90,18 +91,20 @@ fun PlayerMiniPlayer(
                     )
                 }
 
-                // Connect button
-                IconButton(
-                    onClick = onConnectClick,
-                    modifier = Modifier.size(40.dp)
-                ) {
-                    Icon(
-                        painter = IconResources.Content.Cast(),
-                        contentDescription = "Connect",
-                        tint = if (connectDeviceName != null) MaterialTheme.colorScheme.primary
-                               else MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(20.dp)
-                    )
+                // Connect button — hidden when Connect is disabled (off by default)
+                if (showConnect) {
+                    IconButton(
+                        onClick = onConnectClick,
+                        modifier = Modifier.size(40.dp)
+                    ) {
+                        Icon(
+                            painter = IconResources.Content.Cast(),
+                            contentDescription = "Connect",
+                            tint = if (connectDeviceName != null) MaterialTheme.colorScheme.primary
+                                   else MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
                 }
 
                 // Play/Pause button (NOT clickable for expansion)

--- a/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/components/PlayerMiniPlayer.kt
+++ b/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/components/PlayerMiniPlayer.kt
@@ -27,7 +27,7 @@ fun PlayerMiniPlayer(
     onConnectClick: () -> Unit,
     onTapToExpand: () -> Unit,
     modifier: Modifier = Modifier,
-    showConnect: Boolean = true
+    connectAvailable: Boolean = true
 ) {
     Card(
         modifier = modifier
@@ -91,20 +91,22 @@ fun PlayerMiniPlayer(
                     )
                 }
 
-                // Connect button — hidden when Connect is disabled (off by default)
-                if (showConnect) {
-                    IconButton(
-                        onClick = onConnectClick,
-                        modifier = Modifier.size(40.dp)
-                    ) {
-                        Icon(
-                            painter = IconResources.Content.Cast(),
-                            contentDescription = "Connect",
-                            tint = if (connectDeviceName != null) MaterialTheme.colorScheme.primary
-                                   else MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.size(20.dp)
-                        )
-                    }
+                // Connect button — always shown; greyed when the server kill
+                // switch is off (ADR-0018).
+                IconButton(
+                    onClick = onConnectClick,
+                    modifier = Modifier.size(40.dp)
+                ) {
+                    Icon(
+                        painter = IconResources.Content.Cast(),
+                        contentDescription = "Connect",
+                        tint = when {
+                            !connectAvailable -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+                            connectDeviceName != null -> MaterialTheme.colorScheme.primary
+                            else -> MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                        modifier = Modifier.size(20.dp)
+                    )
                 }
 
                 // Play/Pause button (NOT clickable for expansion)

--- a/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/components/PlayerSecondaryControls.kt
+++ b/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/components/PlayerSecondaryControls.kt
@@ -25,39 +25,46 @@ fun PlayerSecondaryControls(
     onEqualizerClick: () -> Unit,
     onConnectClick: () -> Unit,
     onShareClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    showConnect: Boolean = true
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        // Left section - Connect (icon + device label share one tap target)
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .height(40.dp)
-                .clip(RoundedCornerShape(20.dp))
-                .clickable(onClick = onConnectClick)
-                .padding(horizontal = 8.dp)
-        ) {
-            Icon(
-                painter = IconResources.Content.Cast(),
-                contentDescription = "Connect",
-                tint = if (connectDeviceName != null) MaterialTheme.colorScheme.primary
-                       else MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            if (connectDeviceName != null) {
-                Spacer(Modifier.width(8.dp))
-                Text(
-                    text = connectDeviceName,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.primary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.widthIn(max = 100.dp)
+        // Left section - Connect (icon + device label share one tap target).
+        // Hidden when Connect is disabled on this device (off by default); an
+        // empty placeholder keeps the right cluster right-aligned (SpaceBetween).
+        if (showConnect) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .height(40.dp)
+                    .clip(RoundedCornerShape(20.dp))
+                    .clickable(onClick = onConnectClick)
+                    .padding(horizontal = 8.dp)
+            ) {
+                Icon(
+                    painter = IconResources.Content.Cast(),
+                    contentDescription = "Connect",
+                    tint = if (connectDeviceName != null) MaterialTheme.colorScheme.primary
+                           else MaterialTheme.colorScheme.onSurfaceVariant
                 )
+                if (connectDeviceName != null) {
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = connectDeviceName,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.widthIn(max = 100.dp)
+                    )
+                }
             }
+        } else {
+            Spacer(Modifier)
         }
 
         // Right section — inline per-show actions

--- a/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/components/PlayerSecondaryControls.kt
+++ b/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/components/PlayerSecondaryControls.kt
@@ -26,7 +26,7 @@ fun PlayerSecondaryControls(
     onConnectClick: () -> Unit,
     onShareClick: () -> Unit,
     modifier: Modifier = Modifier,
-    showConnect: Boolean = true
+    connectAvailable: Boolean = true
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -34,9 +34,9 @@ fun PlayerSecondaryControls(
         verticalAlignment = Alignment.CenterVertically
     ) {
         // Left section - Connect (icon + device label share one tap target).
-        // Hidden when Connect is disabled on this device (off by default); an
-        // empty placeholder keeps the right cluster right-aligned (SpaceBetween).
-        if (showConnect) {
+        // Always shown (ADR-0018): greyed when the server kill switch is off, but
+        // still tappable so the sheet can explain it's unavailable.
+        run {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier
@@ -48,8 +48,11 @@ fun PlayerSecondaryControls(
                 Icon(
                     painter = IconResources.Content.Cast(),
                     contentDescription = "Connect",
-                    tint = if (connectDeviceName != null) MaterialTheme.colorScheme.primary
-                           else MaterialTheme.colorScheme.onSurfaceVariant
+                    tint = when {
+                        !connectAvailable -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+                        connectDeviceName != null -> MaterialTheme.colorScheme.primary
+                        else -> MaterialTheme.colorScheme.onSurfaceVariant
+                    }
                 )
                 if (connectDeviceName != null) {
                     Spacer(Modifier.width(8.dp))
@@ -63,8 +66,6 @@ fun PlayerSecondaryControls(
                     )
                 }
             }
-        } else {
-            Spacer(Modifier)
         }
 
         // Right section — inline per-show actions

--- a/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/models/PlayerViewModel.kt
+++ b/androidApp/feature/player/src/main/java/com/grateful/deadly/feature/player/screens/main/models/PlayerViewModel.kt
@@ -76,6 +76,9 @@ class PlayerViewModel @Inject constructor(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0)
 
+    /** Server global Connect flag — greys the Connect icon when off (ADR-0018). */
+    val serverConnectEnabled: StateFlow<Boolean> = connectService.serverConnectEnabled
+
     val connectRemoteDeviceName: StateFlow<String?> = combine(
         connectService.connectState,
         connectService.isActiveDevice

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/navigation/SettingsNavigation.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/navigation/SettingsNavigation.kt
@@ -64,10 +64,11 @@ fun NavGraphBuilder.equalizerScreen(
 }
 
 fun NavGraphBuilder.developerScreen(
-    onNavigateBack: () -> Unit
+    onNavigateBack: () -> Unit,
+    onNavigateToConnect: () -> Unit
 ) {
     composable(route = DEVELOPER_ROUTE) {
-        DeveloperScreen(onNavigateBack = onNavigateBack)
+        DeveloperScreen(onNavigateBack = onNavigateBack, onNavigateToConnect = onNavigateToConnect)
     }
 }
 
@@ -129,7 +130,8 @@ fun NavGraphBuilder.settingsGraph(navController: NavController) {
     )
 
     developerScreen(
-        onNavigateBack = { navController.popBackStack() }
+        onNavigateBack = { navController.popBackStack() },
+        onNavigateToConnect = { navController.navigate(CONNECT_ROUTE) }
     )
 
     privacyDataScreen(

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/connect/ConnectSheet.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/connect/ConnectSheet.kt
@@ -24,11 +24,46 @@ import kotlinx.coroutines.delay
 
 private const val VOLUME_STEP = 2
 
+/**
+ * The Connect entry point. Renders one of three modes (ADR-0018):
+ *  - server kill switch OFF      → "unavailable" note
+ *  - server ON, device opted out → "Enable Connect (Beta)" promo + confirm
+ *  - server ON, device opted in  → the full device picker
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ConnectSheet(
     onDismiss: () -> Unit,
     viewModel: ConnectViewModel = hiltViewModel()
+) {
+    val serverConnectEnabled by viewModel.serverConnectEnabled.collectAsState()
+    val connectEnabled by viewModel.connectEnabled.collectAsState()
+
+    // Re-check the global kill switch every time the sheet opens, so the correct
+    // mode (unavailable / promo / devices) is shown at this critical moment even
+    // if the cached value is stale (ADR-0018).
+    LaunchedEffect(Unit) { viewModel.refreshServerConnectEnabled() }
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        when {
+            !serverConnectEnabled -> ConnectUnavailableContent()
+            !connectEnabled -> ConnectEnablePromoContent(
+                onEnable = { viewModel.setConnectEnabled(true) },
+                onNotNow = onDismiss,
+            )
+            else -> ConnectFullContent(onDisableConnect = {
+                viewModel.setConnectEnabled(false)
+                onDismiss()
+            }, viewModel = viewModel)
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ConnectFullContent(
+    onDisableConnect: () -> Unit,
+    viewModel: ConnectViewModel,
 ) {
     val devices by viewModel.devices.collectAsState()
     val connectState by viewModel.connectState.collectAsState()
@@ -55,8 +90,7 @@ fun ConnectSheet(
     val volumeFocusRequester = remember { FocusRequester() }
     LaunchedEffect(Unit) { volumeFocusRequester.requestFocus() }
 
-    ModalBottomSheet(onDismissRequest = onDismiss) {
-        Column(
+    Column(
             modifier = Modifier
                 .focusRequester(volumeFocusRequester)
                 .focusable()
@@ -229,8 +263,23 @@ fun ConnectSheet(
                     }
                 )
             }
+
+            // Per-device beta opt-out. Turning Connect off here only affects this
+            // device — others stay in the session (ADR-0018).
+            HorizontalDivider()
+            ListItem(
+                headlineContent = { Text("Turn off Connect") },
+                supportingContent = {
+                    Text(
+                        "Stops Connect on this device only. Your other devices stay connected — turn it off there too to fully stop syncing.",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                trailingContent = {
+                    TextButton(onClick = onDisableConnect) { Text("Turn off") }
+                },
+            )
         }
-    }
 }
 
 @Composable
@@ -292,4 +341,91 @@ internal fun ConnectDeviceRow(
         } else null,
         modifier = Modifier.clickable(enabled = isTappable, onClick = onTransfer)
     )
+}
+
+/** Server kill switch is OFF — Connect can't be used right now (ADR-0018). */
+@Composable
+private fun ConnectUnavailableContent() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp)
+            .padding(top = 8.dp, bottom = 48.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(
+            painter = IconResources.Content.Cast(),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(40.dp),
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = "Connect is unavailable",
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = "Connect (cross-device playback) is temporarily turned off. Check back later.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/**
+ * Server is ON but this device hasn't opted in — the "Enable Connect (Beta)"
+ * promo with the confirmation gate (ADR-0018).
+ */
+@Composable
+private fun ConnectEnablePromoContent(
+    onEnable: () -> Unit,
+    onNotNow: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp)
+            .padding(top = 8.dp, bottom = 32.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                painter = IconResources.Content.Cast(),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(28.dp),
+            )
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text = "Enable Connect (Beta)",
+                style = MaterialTheme.typography.titleLarge,
+            )
+        }
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = "Connect keeps playback in sync across your devices — start a show on your phone, pick it up on another device.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = "It's a beta feature and may occasionally skip, pause, or fall out of sync. You'll need to enable Connect on your other devices too for them to appear here.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(24.dp))
+        Button(
+            onClick = onEnable,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("Enable Connect")
+        }
+        Spacer(Modifier.height(8.dp))
+        TextButton(
+            onClick = onNotNow,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("Not now")
+        }
+    }
 }

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/connect/ConnectViewModel.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/connect/ConnectViewModel.kt
@@ -23,6 +23,22 @@ class ConnectViewModel @Inject constructor(
     val activeDeviceVolume: StateFlow<Int> = connectService.activeDeviceVolume
     val installId: String = appPreferences.installId
 
+    // ADR-0018: the three Connect-sheet modes are derived from these two flags —
+    // server off ⇒ unavailable; server on + opted out ⇒ beta promo; both on ⇒
+    // full device picker.
+    val serverConnectEnabled: StateFlow<Boolean> = connectService.serverConnectEnabled
+    val connectEnabled: StateFlow<Boolean> = appPreferences.connectEnabled
+
+    /** Opt this device in/out of Connect (the per-device beta toggle). */
+    fun setConnectEnabled(enabled: Boolean) {
+        connectService.setEnabled(enabled)
+    }
+
+    /** Re-check the global kill switch (called when the Connect sheet opens). */
+    fun refreshServerConnectEnabled() {
+        connectService.refreshServerConnectEnabled()
+    }
+
     fun sendVolume(volume: Int) {
         connectService.sendVolume(volume)
     }

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/developer/DeveloperScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/developer/DeveloperScreen.kt
@@ -21,9 +21,11 @@ import com.grateful.deadly.feature.settings.SettingsViewModel
 @Composable
 fun DeveloperScreen(
     viewModel: SettingsViewModel = hiltViewModel(),
-    onNavigateBack: () -> Unit = {}
+    onNavigateBack: () -> Unit = {},
+    onNavigateToConnect: () -> Unit = {}
 ) {
     val forceOnline by viewModel.forceOnline.collectAsState()
+    val connectEnabled by viewModel.connectEnabled.collectAsState()
 
     val serverEnvironment by viewModel.serverEnvironment.collectAsState()
     val customServerUrl by viewModel.customServerUrl.collectAsState()
@@ -95,6 +97,26 @@ fun DeveloperScreen(
                 checked = forceOnline,
                 onCheckedChange = { viewModel.toggleForceOnline() }
             )
+        }
+
+        item { HorizontalDivider() }
+
+        item {
+            DevToggleRow(
+                title = "Enable Connect (Beta)",
+                subtitle = "Play in sync across your devices. Off by default; the server may also disable it globally.",
+                checked = connectEnabled,
+                onCheckedChange = { viewModel.toggleConnectEnabled() }
+            )
+        }
+
+        if (connectEnabled) {
+            item {
+                DevRow(
+                    title = "Connected Devices",
+                    onClick = onNavigateToConnect
+                )
+            }
         }
 
         item { HorizontalDivider() }

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/developer/DeveloperScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/developer/DeveloperScreen.kt
@@ -25,7 +25,6 @@ fun DeveloperScreen(
     onNavigateToConnect: () -> Unit = {}
 ) {
     val forceOnline by viewModel.forceOnline.collectAsState()
-    val connectEnabled by viewModel.connectEnabled.collectAsState()
 
     val serverEnvironment by viewModel.serverEnvironment.collectAsState()
     val customServerUrl by viewModel.customServerUrl.collectAsState()
@@ -97,26 +96,6 @@ fun DeveloperScreen(
                 checked = forceOnline,
                 onCheckedChange = { viewModel.toggleForceOnline() }
             )
-        }
-
-        item { HorizontalDivider() }
-
-        item {
-            DevToggleRow(
-                title = "Enable Connect (Beta)",
-                subtitle = "Play in sync across your devices. Off by default; the server may also disable it globally.",
-                checked = connectEnabled,
-                onCheckedChange = { viewModel.toggleConnectEnabled() }
-            )
-        }
-
-        if (connectEnabled) {
-            item {
-                DevRow(
-                    title = "Connected Devices",
-                    onClick = onNavigateToConnect
-                )
-            }
         }
 
         item { HorizontalDivider() }

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
@@ -476,6 +476,8 @@ private fun PlaybackAudioSettingsScreen(
 ) {
     val sourceBadgeStyle by viewModel.sourceBadgeStyle.collectAsState()
     val playerControlsStyle by viewModel.playerControlsStyle.collectAsState()
+    val connectEnabled by viewModel.connectEnabled.collectAsState()
+    val serverConnectEnabled by viewModel.serverConnectEnabled.collectAsState()
 
     SubscreenScaffold("Playback & Audio", onBack) {
         item { SectionHeader("Controls") }
@@ -513,8 +515,23 @@ private fun PlaybackAudioSettingsScreen(
             )
         }
 
-        // Connect (cross-device sync) moved to Developer settings — it's a
-        // dev/beta opt-in, off by default, gated globally by the server.
+        item { HorizontalDivider() }
+        item { SectionHeader("Connect (Beta)") }
+
+        // Per-device Connect opt-in (ADR-0018). Off by default; the server can
+        // also disable Connect globally, in which case the copy says so.
+        item {
+            PreferenceToggleRow(
+                title = "Enable Connect",
+                subtitle = if (serverConnectEnabled) {
+                    "Play in sync across your devices. Enable it on each device you want to use together."
+                } else {
+                    "Cross-device playback sync. Currently unavailable — it's been turned off on the server."
+                },
+                checked = connectEnabled,
+                onCheckedChange = { viewModel.toggleConnectEnabled() }
+            )
+        }
     }
 }
 

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/SettingsScreen.kt
@@ -83,8 +83,7 @@ fun SettingsScreen(
             PlaybackAudioSettingsScreen(
                 viewModel,
                 onBack = { category = null },
-                onNavigateToEqualizer = onNavigateToEqualizer,
-                onNavigateToConnect = onNavigateToConnect
+                onNavigateToEqualizer = onNavigateToEqualizer
             )
         SettingsCategory.HomeLayout ->
             HomeLayoutSettingsScreen(viewModel, onBack = { category = null })
@@ -473,12 +472,10 @@ private fun AccountSettingsScreen(viewModel: SettingsViewModel, onBack: () -> Un
 private fun PlaybackAudioSettingsScreen(
     viewModel: SettingsViewModel,
     onBack: () -> Unit,
-    onNavigateToEqualizer: () -> Unit,
-    onNavigateToConnect: () -> Unit
+    onNavigateToEqualizer: () -> Unit
 ) {
     val sourceBadgeStyle by viewModel.sourceBadgeStyle.collectAsState()
     val playerControlsStyle by viewModel.playerControlsStyle.collectAsState()
-    val connectEnabled by viewModel.connectEnabled.collectAsState()
 
     SubscreenScaffold("Playback & Audio", onBack) {
         item { SectionHeader("Controls") }
@@ -516,35 +513,8 @@ private fun PlaybackAudioSettingsScreen(
             )
         }
 
-        item { HorizontalDivider() }
-        item { SectionHeader("Connect") }
-
-        item {
-            PreferenceToggleRow(
-                title = "Enable Connect (Beta)",
-                subtitle = "Play in sync across your devices. Turn off to keep this device out of Connect.",
-                checked = connectEnabled,
-                onCheckedChange = { viewModel.toggleConnectEnabled() }
-            )
-        }
-
-        item {
-            Box(modifier = Modifier.alpha(if (connectEnabled) 1f else 0.38f)) {
-                PreferenceRow(
-                    title = "Connected Devices",
-                    subtitle = "View devices connected to your account",
-                    leading = { LeadingIcon(IconResources.Content.Cast()) },
-                    onClick = { if (connectEnabled) onNavigateToConnect() },
-                    trailing = {
-                        Icon(
-                            painter = IconResources.Navigation.ChevronRight(),
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                )
-            }
-        }
+        // Connect (cross-device sync) moved to Developer settings — it's a
+        // dev/beta opt-in, off by default, gated globally by the server.
     }
 }
 

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/main/models/SettingsViewModel.kt
@@ -85,6 +85,9 @@ class SettingsViewModel @Inject constructor(
 
     val connectEnabled: StateFlow<Boolean> = appPreferences.connectEnabled
 
+    /** Server global Connect flag (ADR-0018) — informs the Playback toggle's copy. */
+    val serverConnectEnabled: StateFlow<Boolean> = connectService.serverConnectEnabled
+
     fun toggleConnectEnabled() {
         val newValue = !appPreferences.connectEnabled.value
         connectService.setEnabled(newValue)

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -12,6 +12,7 @@ import { userRoutes } from "./routes/user.js";
 import { authMiddleware } from "./auth/middleware.js";
 import { connectRoutes } from "./connect/routes.js";
 import { connectAdminRoutes } from "./routes/connectAdmin.js";
+import { connectPublicRoutes } from "./routes/connectPublic.js";
 import { analyticsRoutes } from "./routes/analytics.js";
 import { trendingRoutes } from "./routes/trending.js";
 import { popularRoutes } from "./routes/popular.js";
@@ -68,6 +69,7 @@ export function buildApp() {
   app.register(userRoutes);
   app.register(connectRoutes);
   app.register(connectAdminRoutes);
+  app.register(connectPublicRoutes);
   app.register(analyticsRoutes);
   app.register(trendingRoutes);
   app.register(popularRoutes);

--- a/api/src/connect/__tests__/disabled-gate.test.ts
+++ b/api/src/connect/__tests__/disabled-gate.test.ts
@@ -6,7 +6,7 @@ import crypto from "node:crypto";
 // Throwaway users-db so the app_settings flag persists to a real (temp) file.
 process.env.USERS_DB_PATH = path.join(os.tmpdir(), `connect-gate-test-${crypto.randomUUID()}.db`);
 
-const { getConnectEnabled, setConnectEnabled } = await import("../../db/appSettings.js");
+const { getConnectEnabled, setConnectEnabled, getConnectMinProtocol, setConnectMinProtocol } = await import("../../db/appSettings.js");
 const { connectDisabledCloseCode } = await import("../protocol.js");
 
 describe("connect global kill switch", () => {
@@ -25,6 +25,27 @@ describe("connect global kill switch", () => {
     expect(getConnectEnabled()).toBe(true);
     setConnectEnabled(false);
     expect(getConnectEnabled()).toBe(false);
+  });
+});
+
+describe("connect minimum-protocol gate", () => {
+  it("defaults to 0 (allow all) when no row has ever been written", () => {
+    expect(getConnectMinProtocol()).toBe(0);
+  });
+
+  it("persists an explicit floor, then a reset to 0", () => {
+    setConnectMinProtocol(2);
+    expect(getConnectMinProtocol()).toBe(2);
+    setConnectMinProtocol(0);
+    expect(getConnectMinProtocol()).toBe(0);
+  });
+
+  it("a floor of 2 admits proto >= 2 and excludes the proto-1 fleet", () => {
+    setConnectMinProtocol(2);
+    const min = getConnectMinProtocol();
+    expect(1 < min).toBe(true); // proto-1 store fleet rejected
+    expect(2 < min).toBe(false); // proto-2 beta build admitted
+    setConnectMinProtocol(0);
   });
 });
 

--- a/api/src/connect/routes.ts
+++ b/api/src/connect/routes.ts
@@ -21,7 +21,7 @@ import {
   startHeartbeatSweep,
 } from "./state.js";
 import type { ClientMessage, DeviceType, SessionTrack } from "./types.js";
-import { getConnectEnabled } from "../db/appSettings.js";
+import { getConnectEnabled, getConnectMinProtocol } from "../db/appSettings.js";
 import { connectDisabledCloseCode } from "./protocol.js";
 
 // Terminal close codes the client must NOT reconnect after (see protocol.ts):
@@ -100,6 +100,18 @@ export async function connectRoutes(app: FastifyInstance): Promise<void> {
             const code = connectDisabledCloseCode(protocolVersion);
             request.log.info({ userId, deviceId: msg.deviceId, protocolVersion, code }, "ws/connect: Connect disabled — closing");
             socket.close(code, "Connect disabled");
+            return;
+          }
+
+          // Minimum-protocol gate: even when Connect is enabled, refuse clients
+          // below the admin-configured floor (0 = allow all). Lets the old fleet
+          // be excluded without a global off. Reuses the disabled close code so
+          // proto < 2 gets terminal 4003 and proto >= 2 gets 4005.
+          const minProtocol = getConnectMinProtocol();
+          if (protocolVersion < minProtocol) {
+            const code = connectDisabledCloseCode(protocolVersion);
+            request.log.info({ userId, deviceId: msg.deviceId, protocolVersion, minProtocol, code }, "ws/connect: protocol below minimum — closing");
+            socket.close(code, "Connect minimum protocol");
             return;
           }
 

--- a/api/src/connect/state.ts
+++ b/api/src/connect/state.ts
@@ -1,6 +1,7 @@
 import type { WebSocket } from "ws";
 import type { ConnectState, ConnectDevice, DeviceType, SessionTrack } from "./types.js";
 import { LEGACY_PROTOCOL_VERSION } from "./types.js";
+import { connectDisabledCloseCode } from "./protocol.js";
 import { upsertPlaybackPosition as dbUpsertPlaybackPosition, getPlaybackPosition } from "../db/userdata.js";
 
 const log = (msg: string) => console.log(`[Connect] ${msg}`);
@@ -238,6 +239,27 @@ export function registerDevice(
   logProtocolDistribution(userId);
   sendJson(socket, { type: "state", state });
   broadcastDevices(userId);
+}
+
+// Apply the global Connect gate to already-connected devices so an admin change
+// takes effect immediately, not on the next client poll. Closes every live
+// socket that the current settings would no longer admit: all of them when
+// Connect is disabled, or those below `minProtocol` when it's enabled. Closing
+// fires the socket's `close` handler, which unregisters the device and cascades
+// broadcasts. Returns the number of sockets closed. See ADR-0018.
+export function reconcileLiveDevices(enabled: boolean, minProtocol: number): number {
+  let closed = 0;
+  // Snapshot first: closing mutates liveDevices via the close handler.
+  for (const entry of [...liveDevices.values()]) {
+    const inadmissible = !enabled || entry.protocolVersion < minProtocol;
+    if (!inadmissible) continue;
+    const code = connectDisabledCloseCode(entry.protocolVersion);
+    const reason = enabled ? "Connect minimum protocol raised" : "Connect disabled";
+    log(`reconcileLiveDevices: closing ${entry.device.name}[${entry.device.type}] proto=${entry.protocolVersion} code=${code} (${reason})`);
+    entry.socket.close(code, reason);
+    closed++;
+  }
+  return closed;
 }
 
 // Telemetry (ADR-0011 §3, Chunk A): per-session distribution of the connected

--- a/api/src/db/appSettings.ts
+++ b/api/src/db/appSettings.ts
@@ -5,10 +5,17 @@ import { getUsersDb } from "./users.js";
 // (or a key an admin has never touched) behaves predictably across restarts.
 
 const CONNECT_ENABLED_KEY = "connect_enabled";
+const CONNECT_MIN_PROTOCOL_KEY = "connect_min_protocol";
 
 // Connect (cross-device playback sync) ships OFF by default. An admin must
 // explicitly enable it; until then the server refuses ws/connect upgrades.
 const CONNECT_ENABLED_DEFAULT = false;
+
+// Minimum wire-protocol version a client must advertise on register to be
+// allowed in (when Connect is enabled). 0 = allow all. Lets an admin gate out
+// the old fleet (e.g. set to 2 so only proto-2+ builds connect) without a
+// global off. See connect/protocol.ts and ADR-0018.
+const CONNECT_MIN_PROTOCOL_DEFAULT = 0;
 
 function getBool(key: string, fallback: boolean): boolean {
   const db = getUsersDb();
@@ -27,10 +34,36 @@ function setBool(key: string, value: boolean): void {
   ).run(key, value ? "1" : "0");
 }
 
+function getInt(key: string, fallback: number): number {
+  const db = getUsersDb();
+  const row = db.prepare(`SELECT value FROM app_settings WHERE key = ?`).get(key) as
+    | { value: string }
+    | undefined;
+  if (!row) return fallback;
+  const n = parseInt(row.value, 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function setInt(key: string, value: number): void {
+  const db = getUsersDb();
+  db.prepare(
+    `INSERT INTO app_settings (key, value) VALUES (?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+  ).run(key, String(value));
+}
+
 export function getConnectEnabled(): boolean {
   return getBool(CONNECT_ENABLED_KEY, CONNECT_ENABLED_DEFAULT);
 }
 
 export function setConnectEnabled(enabled: boolean): void {
   setBool(CONNECT_ENABLED_KEY, enabled);
+}
+
+export function getConnectMinProtocol(): number {
+  return getInt(CONNECT_MIN_PROTOCOL_KEY, CONNECT_MIN_PROTOCOL_DEFAULT);
+}
+
+export function setConnectMinProtocol(minProtocol: number): void {
+  setInt(CONNECT_MIN_PROTOCOL_KEY, minProtocol);
 }

--- a/api/src/routes/__tests__/connectPublic.test.ts
+++ b/api/src/routes/__tests__/connectPublic.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import Fastify from "fastify";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+
+// Throwaway users-db so the app_settings flag persists to a real (temp) file.
+process.env.USERS_DB_PATH = path.join(os.tmpdir(), `connect-public-test-${crypto.randomUUID()}.db`);
+
+const { setConnectEnabled } = await import("../../db/appSettings.js");
+const { connectPublicRoutes } = await import("../connectPublic.js");
+
+// Register the route in isolation (no auth stack) — it must be reachable without
+// any session/admin credentials and reflect the persisted flag. See ADR-0018.
+async function buildBareApp() {
+  const app = Fastify();
+  await app.register(connectPublicRoutes);
+  await app.ready();
+  return app;
+}
+
+describe("GET /api/connect/enabled (public)", () => {
+  it("is reachable with no auth and reports the flag", async () => {
+    const app = await buildBareApp();
+
+    setConnectEnabled(false);
+    let res = await app.inject({ method: "GET", url: "/api/connect/enabled" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ connectEnabled: false });
+
+    setConnectEnabled(true);
+    res = await app.inject({ method: "GET", url: "/api/connect/enabled" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ connectEnabled: true });
+
+    await app.close();
+  });
+});

--- a/api/src/routes/connectAdmin.ts
+++ b/api/src/routes/connectAdmin.ts
@@ -1,10 +1,18 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import { requireAdmin } from "../auth/middleware.js";
-import { getConnectEnabled, setConnectEnabled } from "../db/appSettings.js";
+import {
+  getConnectEnabled,
+  setConnectEnabled,
+  getConnectMinProtocol,
+  setConnectMinProtocol,
+} from "../db/appSettings.js";
+import { reconcileLiveDevices } from "../connect/state.js";
 
-// Admin control for the global Connect (cross-device playback) kill switch.
-// The flag is persisted in app_settings and defaults OFF; flipping it here
-// takes effect immediately for new ws/connect registrations (no restart).
+// Admin control for the global Connect (cross-device playback) kill switch and
+// the minimum-protocol gate. Both are persisted in app_settings and default to
+// the most permissive-when-off state (Connect off, minProtocol 0). Changes take
+// effect immediately: new ws/connect registrations are gated, and any already-
+// connected devices the new settings would no longer admit are disconnected.
 export async function connectAdminRoutes(app: FastifyInstance): Promise<void> {
   // GET /api/admin/connect/settings
   app.get(
@@ -17,11 +25,16 @@ export async function connectAdminRoutes(app: FastifyInstance): Promise<void> {
       preHandler: requireAdmin,
     },
     async () => {
-      return { connectEnabled: getConnectEnabled() };
+      return {
+        connectEnabled: getConnectEnabled(),
+        connectMinProtocol: getConnectMinProtocol(),
+      };
     },
   );
 
-  // POST /api/admin/connect/settings { connectEnabled: boolean }
+  // POST /api/admin/connect/settings { connectEnabled?: boolean, connectMinProtocol?: number }
+  // Both fields are optional and applied independently — the min-protocol floor
+  // can be set while Connect is off, so it's already in place when it's flipped on.
   app.post(
     "/api/admin/connect/settings",
     {
@@ -30,19 +43,36 @@ export async function connectAdminRoutes(app: FastifyInstance): Promise<void> {
         summary: "Set global Connect settings (admin)",
         body: {
           type: "object",
-          required: ["connectEnabled"],
           properties: {
             connectEnabled: { type: "boolean" },
+            connectMinProtocol: { type: "integer", minimum: 0 },
           },
         },
       },
       preHandler: requireAdmin,
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
-      const { connectEnabled } = request.body as { connectEnabled: boolean };
-      setConnectEnabled(connectEnabled);
-      request.log.info({ connectEnabled }, "admin: set global Connect enabled");
-      return { connectEnabled: getConnectEnabled() };
+      const body = request.body as {
+        connectEnabled?: boolean;
+        connectMinProtocol?: number;
+      };
+      if (typeof body.connectEnabled === "boolean") {
+        setConnectEnabled(body.connectEnabled);
+      }
+      if (typeof body.connectMinProtocol === "number") {
+        setConnectMinProtocol(body.connectMinProtocol);
+      }
+
+      // Apply the resulting gate to live sessions immediately so a change "takes
+      // effect now" rather than on the next client poll.
+      const connectEnabled = getConnectEnabled();
+      const connectMinProtocol = getConnectMinProtocol();
+      const closed = reconcileLiveDevices(connectEnabled, connectMinProtocol);
+      request.log.info(
+        { connectEnabled, connectMinProtocol, closed },
+        "admin: set global Connect settings",
+      );
+      return { connectEnabled, connectMinProtocol };
     },
   );
 }

--- a/api/src/routes/connectPublic.ts
+++ b/api/src/routes/connectPublic.ts
@@ -1,0 +1,25 @@
+import type { FastifyInstance } from "fastify";
+import { getConnectEnabled } from "../db/appSettings.js";
+
+// Public (unauthenticated) read of the global Connect kill switch. Clients use
+// this to decide whether to render the Connect UI at all: greyed/"unavailable"
+// when off, the beta opt-in / full UI when on. See ADR-0018.
+//
+// The flag is not secret — it only controls whether a feature is offered — so
+// this needs no auth, unlike the admin GET in connectAdmin.ts which is the same
+// value behind requireAdmin (and also exposes the setter).
+export async function connectPublicRoutes(app: FastifyInstance): Promise<void> {
+  // GET /api/connect/enabled
+  app.get(
+    "/api/connect/enabled",
+    {
+      schema: {
+        tags: ["connect"],
+        summary: "Get whether Connect is globally enabled (public)",
+      },
+    },
+    async () => {
+      return { connectEnabled: getConnectEnabled() };
+    },
+  );
+}

--- a/docs/adr/0018-connect-beta-opt-in-and-server-gated-ui.md
+++ b/docs/adr/0018-connect-beta-opt-in-and-server-gated-ui.md
@@ -1,0 +1,140 @@
+# ADR-0018: Connect — user-facing beta opt-in + server-gated UI discovery
+
+## Status
+
+Proposed (2026-06-19). Builds directly on the global Connect kill switch shipped
+in PR #86 (`app_settings.connect_enabled`, default OFF) and the Phase-3 client
+changes in `e64b1f7c` (per-device toggle default OFF, UI hidden, toggle moved to
+Developer, `protocolVersion` 2 understands 4005). This ADR **reverses the "hide
+the UI / Developer-only toggle" half** of `e64b1f7c` while keeping everything
+else: Connect stays default-OFF and server-gated, but becomes a discoverable,
+user-facing **beta opt-in** instead of a hidden developer setting.
+
+Relates to [ADR-0006](0006-connect-v2.md) (server is transport source of truth),
+[ADR-0011](0011-connect-session-ownership-and-protocol-versioning.md) (protocol
+versioning), and [ADR-0016](0016-connect-liveness-detection-and-connect-handshake.md)
+(close-code handling). Does **not** un-defer
+[ADR-0008](0008-connect-cloud-coordination-deferred.md): no new server state
+beyond the existing `connect_enabled` flag.
+
+## Context
+
+We disabled Connect by default because of cross-device skipping/playback bugs.
+`e64b1f7c` took the conservative route: hide every Connect icon and bury the
+per-device toggle in the Developer screen. That stops the bug, but it also makes
+Connect undiscoverable — nobody can opt into the beta, and we lose the signal of
+willing testers.
+
+We want a middle path: **keep it off by default and keep the server kill switch
+as master, but let users discover and opt into the beta themselves**, with
+honest "this is beta" messaging and a clear path to disable.
+
+### The three states we need to express
+
+| State | Decided by | Icons | Tap behavior |
+|---|---|---|---|
+| **Server OFF** | global `connect_enabled` (false) | shown but **greyed/disabled** | "Connect is currently unavailable" note |
+| **Server ON, device OFF** (default) | per-device/per-install toggle (false) | shown, enabled (promo) | enable sheet: "Enable Connect (Beta)" + info + confirm + "turn it on on your other devices too" |
+| **Server ON, device ON** | per-device/per-install toggle (true) | shown, full UI | device-picker UI + a "Turn off Connect" row → "Your other devices stay connected…" |
+
+### The gap `e64b1f7c` left: 4005 cannot drive icon discovery
+
+The 4005 "Connect disabled" close code only arrives **in response to a `register`
+attempt**, and a client only attempts to register when its *local* toggle is
+already ON. In the default state (device OFF) the client never connects, never
+receives 4005, and therefore has **no way to know the server's flag state** — so
+it cannot decide whether to show the icon as enabled (server ON) or greyed
+(server OFF).
+
+**4005 is a runtime enforcement signal, not a discovery mechanism.** It is exactly
+right for "admin flips the switch off while I am actively connected" → kill the
+session and flip the UI. It cannot answer "what should a *disconnected* device
+render."
+
+## Decision
+
+### 1. A public read endpoint for the server flag (the missing discovery gate)
+
+Add an unauthenticated read of the existing flag:
+
+```
+GET /api/connect/enabled  →  { "connectEnabled": boolean }
+```
+
+The admin GET `/api/admin/connect/settings` already returns this shape behind
+`requireAdmin`; this is the same value with no auth requirement (the flag is not
+secret — it only controls whether a feature is offered). Clients cache the boolean
+as `serverConnectEnabled`.
+
+**When clients fetch it:**
+
+- **At startup**, so the Connect UI renders in the correct state without a flash.
+  Use a **short timeout** (~2–3s) so a slow/unreachable API never blocks app
+  launch.
+- **Fallback to a foreground fetch** if the startup read timed out or failed —
+  and as the ongoing refresh on app foreground.
+- **Periodically, on the same focus/navigation-change trigger** the app already
+  uses for userdata refresh (focus-refresh, not real-time polling), so an admin
+  flipping the flag mid-session is reflected without a relaunch.
+
+Until the first successful read resolves, fall back to the **last cached value**,
+defaulting to `false` (greyed) on a truly fresh install — fail safe toward "not
+offered" rather than showing an enable affordance that would immediately fail.
+
+This boolean is the **primary icon-visibility/enabled gate**. 4005 remains the
+**runtime enforcement path**: an active client that receives 4005 kills its
+session and writes `serverConnectEnabled = false` (same local state the REST call
+feeds), flipping the UI to the greyed state without needing a refetch.
+
+Both signals write the same local state; they agree. REST exists only so a
+*disconnected* device can learn it.
+
+### 2. Per-device / per-install opt-in becomes user-facing (reverses `e64b1f7c`)
+
+- Default stays **OFF**. The bug stays fixed for everyone who does nothing.
+- The toggle moves out of Developer and into **two** user-facing homes:
+  - the **Connect-icon bottom sheet** (primary, with the beta confirmation), and
+  - **Settings → Playback & Audio** (mirror, for later toggling).
+- First enable shows the **"Enable Connect (Beta)"** confirmation: what it does,
+  that it is beta and may misbehave, and that the user must enable it on their
+  **other devices too**. Subsequent toggles can be quiet.
+- Disabling from the full UI shows: "Your other devices are still connected — turn
+  Connect off there too if you want to fully stop syncing."
+
+### 3. Server-OFF renders greyed, not hidden
+
+When `serverConnectEnabled` is false the icon is shown **disabled/greyed**; tapping
+surfaces a short "Connect is currently unavailable" message rather than the enable
+sheet. Greyed-not-gone tells users the feature exists and is coming back, and
+avoids layout shift when the flag flips.
+
+### 4. Web gets the same treatment, as a per-install local setting
+
+`e64b1f7c` made web rely solely on the server flag with no per-install opt-in.
+This ADR gives web parity:
+
+- Web reads `GET /api/connect/enabled` (same gate as mobile).
+- The opt-in is a **per-web-install** setting stored locally (`localStorage`),
+  because a user may have several browsers/installs and each is a distinct
+  "device" in a Connect session. It is **not** a server/account setting.
+- Surface it in a **Settings → Connect (Beta)** section in `/me` settings, plus the
+  same enable affordance from the web Connect icon. Greyed when server is OFF.
+
+## Consequences
+
+- **Reverses** the hide-UI / Developer-only-toggle decision from `e64b1f7c`;
+  keeps default-OFF, server-gating, and protocol-2 4005 handling.
+- One new **public** endpoint; no new persisted server state, no un-deferral of
+  ADR-0008.
+- Web's "device" identity is now explicitly per-install (localStorage), which is
+  the correct mental model for multiple browsers but means clearing site data
+  resets the opt-in.
+- Discovery is decoupled from connection: a device can show the correct icon
+  state without ever opening a socket, which also avoids needless WS attempts
+  from the default (OFF) state.
+- Android's reconnect-churn fix from `e64b1f7c` (the `onClosing` override) is
+  unaffected and still required for the 4005 runtime path.
+
+## Open questions
+
+- Exact copy for the beta confirmation and the "unavailable" note.

--- a/iosApp/deadly/App/deadlyApp.swift
+++ b/iosApp/deadly/App/deadlyApp.swift
@@ -122,6 +122,9 @@ struct deadlyApp: App {
                             ShowArtworkService.shared.populate(sourceTypes)
                         }
                         ShowArtworkService.shared.badgeStyle = SourceBadgeStyle.fromString(container.appPreferences.sourceBadgeStyle)
+                        // Refresh the global Connect flag so the Connect UI renders
+                        // in the right state from launch (ADR-0018).
+                        container.connectService.refreshServerConnectEnabled()
                         // Start Connect first so it can receive shared state before local restore.
                         container.connectService.startIfAuthenticated()
                         // Brief wait for the WebSocket to connect and receive state.
@@ -160,6 +163,9 @@ struct deadlyApp: App {
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
                     // Reconnect Connect on foreground (scenePhase .active is
                     // unreliable with the delegate adaptor in use, see above).
+                    // Also re-check the server kill switch so the UI reflects an
+                    // admin flipping it without a relaunch (ADR-0018).
+                    container.connectService.refreshServerConnectEnabled()
                     container.connectService.startIfAuthenticated()
                     if container.authService.isSignedIn {
                         Task {

--- a/iosApp/deadly/Core/Service/AppPreferences.swift
+++ b/iosApp/deadly/Core/Service/AppPreferences.swift
@@ -16,9 +16,10 @@ final class AppPreferences {
     private static let connectEnabledKey = "connect_enabled"
     private static let sourceBadgeStyleKey = "source_badge_style"
 
-    /// Default for the per-device Connect toggle. Flip to `false` to disable
-    /// cross-device Connect by default across all installs (see settings toggle).
-    static let connectEnabledDefault = true
+    /// Default for the per-device Connect toggle. OFF by default: Connect is a
+    /// dev/beta opt-in living under Developer settings, and the server gates it
+    /// globally too. A user must explicitly turn it on to participate.
+    static let connectEnabledDefault = false
     private static let useBetaShareLinksKey = "use_beta_share_links"
     private static let useBetaModeKey = "use_beta_mode"
     private static let serverEnvironmentKey = "server_environment"

--- a/iosApp/deadly/Core/Service/AppPreferences.swift
+++ b/iosApp/deadly/Core/Service/AppPreferences.swift
@@ -14,11 +14,12 @@ final class AppPreferences {
     private static let shareAttachImageKey = "share_attach_image"
     private static let autoAdvanceEnabledKey = "auto_advance_enabled"
     private static let connectEnabledKey = "connect_enabled"
+    private static let serverConnectEnabledKey = "server_connect_enabled_cached"
     private static let sourceBadgeStyleKey = "source_badge_style"
 
     /// Default for the per-device Connect toggle. OFF by default: Connect is a
-    /// dev/beta opt-in living under Developer settings, and the server gates it
-    /// globally too. A user must explicitly turn it on to participate.
+    /// beta opt-in the user explicitly turns on, and the server gates it globally
+    /// too. See ADR-0018.
     static let connectEnabledDefault = false
     private static let useBetaShareLinksKey = "use_beta_share_links"
     private static let useBetaModeKey = "use_beta_mode"
@@ -135,6 +136,13 @@ final class AppPreferences {
     /// when off, this device never opens the Connect WebSocket. See ConnectService.
     var connectEnabled: Bool {
         didSet { UserDefaults.standard.set(connectEnabled, forKey: Self.connectEnabledKey) }
+    }
+
+    /// Last-known value of the server's global Connect flag, cached so the UI can
+    /// render the correct icon state on launch before the network read resolves.
+    /// The live source of truth is ConnectService.serverConnectEnabled (ADR-0018).
+    var serverConnectEnabledCached: Bool {
+        didSet { UserDefaults.standard.set(serverConnectEnabledCached, forKey: Self.serverConnectEnabledKey) }
     }
 
     var analyticsEnabled: Bool {
@@ -288,6 +296,9 @@ final class AppPreferences {
         connectEnabled = UserDefaults.standard.object(forKey: Self.connectEnabledKey) == nil
             ? Self.connectEnabledDefault
             : UserDefaults.standard.bool(forKey: Self.connectEnabledKey)
+        // Default false: a fresh install fails safe to "not offered" (icon greyed)
+        // until the first GET /api/connect/enabled resolves. ADR-0018.
+        serverConnectEnabledCached = UserDefaults.standard.bool(forKey: Self.serverConnectEnabledKey)
         sourceBadgeStyle = UserDefaults.standard.string(forKey: Self.sourceBadgeStyleKey) ?? "LONG"
         playerControlsStyle = UserDefaults.standard.string(forKey: Self.playerControlsStyleKey) ?? "skipTrack"
         homeTrendingWindow = UserDefaults.standard.string(forKey: Self.homeTrendingWindowKey) ?? "now"

--- a/iosApp/deadly/Core/Service/ConnectService.swift
+++ b/iosApp/deadly/Core/Service/ConnectService.swift
@@ -80,7 +80,8 @@ final class ConnectService: NSObject {
 
     // Connect WS wire-contract version. See docs/PROTOCOL.md for semantics.
     // Bump in lockstep with the documented protocol; the server may branch on it.
-    private static let protocolVersion = 1
+    // v2: understands the 4005 "Connect disabled" terminal close code.
+    private static let protocolVersion = 2
     private static let reconnectDelays: [Double] = [1, 2, 4, 8, 30]
     private static let heartbeatInterval: UInt64 = 15_000_000_000 // 15s in nanoseconds
     // WS keep-alive ping. URLSessionWebSocketTask has no built-in keep-alive: a
@@ -950,8 +951,10 @@ final class ConnectService: NSObject {
         timeSyncBestRttMs = .infinity
         webSocket = nil
 
-        // 4003 = Unauthorized (terminal — token invalid)
-        if !shouldConnect || closeCode == 4003 {
+        // Terminal closes (don't reconnect): 4003 = Unauthorized (token invalid),
+        // 4005 = Connect globally disabled by the server. iOS delivers custom
+        // close codes intact via didCloseWith, so this guard is reached.
+        if !shouldConnect || closeCode == 4003 || closeCode == 4005 {
             logger.info("handleDisconnect: not reconnecting (shouldConnect=\(self.shouldConnect, privacy: .public) code=\(closeCode ?? -1, privacy: .public))")
             return
         }

--- a/iosApp/deadly/Core/Service/ConnectService.swift
+++ b/iosApp/deadly/Core/Service/ConnectService.swift
@@ -29,6 +29,12 @@ final class ConnectService: NSObject {
     /// docs/connect-v2-architecture.md "Clock Sync".
     private(set) var serverTimeOffsetMs: Double = 0
 
+    /// Whether the server's global Connect kill switch is ON (ADR-0018). Drives
+    /// UI discovery: when false the Connect icon renders greyed/"unavailable" and
+    /// no session can form. Seeded from the last cached value, refreshed by
+    /// `refreshServerConnectEnabled()`, and forced false on a 4005 close.
+    private(set) var serverConnectEnabled: Bool
+
     var isActiveDevice: Bool {
         guard let state = connectState else { return false }
         return state.activeDeviceId == appPreferences.installId
@@ -102,6 +108,7 @@ final class ConnectService: NSObject {
         self.appPreferences = appPreferences
         self.authService = authService
         self.streamPlayer = streamPlayer
+        self.serverConnectEnabled = appPreferences.serverConnectEnabledCached
         super.init()
 
         // Forward LOCAL play/pause that bypassed the in-app buttons — the lock
@@ -154,6 +161,36 @@ final class ConnectService: NSObject {
         shouldConnect = true
         reconnectAttempt = 0
         Task { await connect() }
+    }
+
+    /// Fetch the global Connect flag (`GET /api/connect/enabled`) and update
+    /// `serverConnectEnabled`. Short-timeout, best-effort: on failure the last
+    /// cached value is kept. Call on startup and on foreground (ADR-0018).
+    func refreshServerConnectEnabled() {
+        let base = appPreferences.apiBaseUrl
+        guard !base.isEmpty, let url = URL(string: "\(base)/api/connect/enabled") else { return }
+        Task { [weak self] in
+            var request = URLRequest(url: url)
+            request.timeoutInterval = 3
+            request.httpMethod = "GET"
+            do {
+                let (data, response) = try await URLSession.shared.data(for: request)
+                guard let http = response as? HTTPURLResponse, http.statusCode == 200,
+                      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let enabled = json["connectEnabled"] as? Bool else { return }
+                await MainActor.run { self?.setServerConnectEnabled(enabled) }
+            } catch {
+                logger.debug("refreshServerConnectEnabled failed (keeping cached): \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    private func setServerConnectEnabled(_ enabled: Bool) {
+        serverConnectEnabled = enabled
+        appPreferences.serverConnectEnabledCached = enabled
+        // If the server just turned Connect off, tear down any live session too
+        // (mirrors the 4005 runtime path for a currently-connected client).
+        if !enabled && shouldConnect { stop() }
     }
 
     /// Toggle the per-device Connect kill switch (Settings). Persists the choice
@@ -950,6 +987,11 @@ final class ConnectService: NSObject {
         serverTimeOffsetMs = 0
         timeSyncBestRttMs = .infinity
         webSocket = nil
+
+        // The server refused us because Connect is globally disabled — flip the
+        // cached flag so every Connect icon greys out immediately, without waiting
+        // for the next refresh (the runtime-enforcement half of ADR-0018).
+        if closeCode == 4005 { setServerConnectEnabled(false) }
 
         // Terminal closes (don't reconnect): 4003 = Unauthorized (token invalid),
         // 4005 = Connect globally disabled by the server. iOS delivers custom

--- a/iosApp/deadly/Feature/Connect/ConnectSheet.swift
+++ b/iosApp/deadly/Feature/Connect/ConnectSheet.swift
@@ -12,6 +12,41 @@ struct ConnectSheet: View {
 
     var body: some View {
         NavigationStack {
+            content
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { dismiss() }
+                    }
+                }
+        }
+        .presentationDetents([.medium, .large])
+        // Re-check the global kill switch every time the sheet opens, so the
+        // correct mode (unavailable / promo / devices) is shown at this critical
+        // moment even if the cached value is stale (ADR-0018).
+        .onAppear { service.refreshServerConnectEnabled() }
+    }
+
+    // Three modes (ADR-0018): server off → unavailable; server on + opted out →
+    // beta promo; both on → the full device picker.
+    @ViewBuilder
+    private var content: some View {
+        if !service.serverConnectEnabled {
+            ConnectUnavailableView()
+                .navigationTitle("Connect")
+        } else if !container.appPreferences.connectEnabled {
+            ConnectEnablePromoView(
+                onEnable: { service.setEnabled(true) },
+                onNotNow: { dismiss() }
+            )
+            .navigationTitle("Connect")
+        } else {
+            fullDeviceList
+                .navigationTitle("Devices")
+        }
+    }
+
+    private var fullDeviceList: some View {
             List {
                 if !container.authService.isSignedIn {
                     ContentUnavailableView(
@@ -119,17 +154,20 @@ struct ConnectSheet: View {
                             }
                         }
                     }
+
+                    // Per-device beta opt-out (ADR-0018). Affects this device only.
+                    Section {
+                        Button("Turn off Connect", role: .destructive) {
+                            service.setEnabled(false)
+                            dismiss()
+                        }
+                    } footer: {
+                        Text("Stops Connect on this device only. Your other devices stay connected — turn it off there too to fully stop syncing.")
+                    }
                 }
             }
-            .navigationTitle("Devices")
-            .navigationBarTitleDisplayMode(.inline)
             .onAppear {
                 localVolume = Double(service.activeDeviceVolume)
-            }
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
-                }
             }
             .confirmationDialog("Stop Session?", isPresented: $showingStopConfirm, titleVisibility: .visible) {
                 Button("Stop Session", role: .destructive) {
@@ -137,8 +175,60 @@ struct ConnectSheet: View {
                 }
                 Button("Cancel", role: .cancel) {}
             }
+    }
+}
+
+// MARK: - Unavailable / Promo modes
+
+/// Server kill switch is OFF — Connect can't be used right now (ADR-0018).
+private struct ConnectUnavailableView: View {
+    var body: some View {
+        ContentUnavailableView(
+            "Connect is unavailable",
+            systemImage: "airplayaudio",
+            description: Text("Connect (cross-device playback) is temporarily turned off. Check back later.")
+        )
+    }
+}
+
+/// Server is ON but this device hasn't opted in — the "Enable Connect (Beta)"
+/// promo with the confirmation gate (ADR-0018).
+private struct ConnectEnablePromoView: View {
+    let onEnable: () -> Void
+    let onNotNow: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 12) {
+                Image(systemName: "airplayaudio")
+                    .font(.title)
+                    .foregroundStyle(DeadlyColors.primary)
+                Text("Enable Connect (Beta)")
+                    .font(.title2.bold())
+            }
+
+            Text("Connect keeps playback in sync across your devices — start a show on your phone, pick it up on another device.")
+                .foregroundStyle(.secondary)
+
+            Text("It's a beta feature and may occasionally skip, pause, or fall out of sync. You'll need to enable Connect on your other devices too for them to appear here.")
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            Button(action: onEnable) {
+                Text("Enable Connect")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+
+            Button(action: onNotNow) {
+                Text("Not now")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.plain)
         }
-        .presentationDetents([.medium, .large])
+        .padding(24)
     }
 }
 

--- a/iosApp/deadly/Feature/Player/MiniPlayerOverlay.swift
+++ b/iosApp/deadly/Feature/Player/MiniPlayerOverlay.swift
@@ -123,16 +123,19 @@ struct MiniPlayerOverlay: View {
                         .font(.title3)
                         .foregroundStyle(.red)
                 } else {
-                    // Connect / AirPlay device picker
-                    Button {
-                        showConnectSheet = true
-                    } label: {
-                        Image(systemName: "airplayaudio")
-                            .font(.title3)
-                            .foregroundStyle(container.connectService.isRemoteControlling ? DeadlyColors.primary : .secondary)
-                            .frame(width: 32, height: 32)
+                    // Connect / AirPlay device picker. Hidden when Connect is
+                    // disabled on this device (off by default).
+                    if container.appPreferences.connectEnabled {
+                        Button {
+                            showConnectSheet = true
+                        } label: {
+                            Image(systemName: "airplayaudio")
+                                .font(.title3)
+                                .foregroundStyle(container.connectService.isRemoteControlling ? DeadlyColors.primary : .secondary)
+                                .frame(width: 32, height: 32)
+                        }
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(.plain)
 
                     if service.isPendingCommand
                         || service.isSkeleton || service.isPreparing || service.isRetrying

--- a/iosApp/deadly/Feature/Player/MiniPlayerOverlay.swift
+++ b/iosApp/deadly/Feature/Player/MiniPlayerOverlay.swift
@@ -123,19 +123,20 @@ struct MiniPlayerOverlay: View {
                         .font(.title3)
                         .foregroundStyle(.red)
                 } else {
-                    // Connect / AirPlay device picker. Hidden when Connect is
-                    // disabled on this device (off by default).
-                    if container.appPreferences.connectEnabled {
-                        Button {
-                            showConnectSheet = true
-                        } label: {
-                            Image(systemName: "airplayaudio")
-                                .font(.title3)
-                                .foregroundStyle(container.connectService.isRemoteControlling ? DeadlyColors.primary : .secondary)
-                                .frame(width: 32, height: 32)
-                        }
-                        .buttonStyle(.plain)
+                    // Connect / AirPlay device picker. Always shown (ADR-0018);
+                    // greyed when the server kill switch is off.
+                    Button {
+                        showConnectSheet = true
+                    } label: {
+                        Image(systemName: "airplayaudio")
+                            .font(.title3)
+                            .foregroundStyle(
+                                !container.connectService.serverConnectEnabled ? Color.secondary.opacity(0.4) :
+                                container.connectService.isRemoteControlling ? DeadlyColors.primary : Color.secondary
+                            )
+                            .frame(width: 32, height: 32)
                     }
+                    .buttonStyle(.plain)
 
                     if service.isPendingCommand
                         || service.isSkeleton || service.isPreparing || service.isRetrying

--- a/iosApp/deadly/Feature/Player/PlayerScreen.swift
+++ b/iosApp/deadly/Feature/Player/PlayerScreen.swift
@@ -351,32 +351,39 @@ struct PlayerScreen: View {
         .padding(.bottom, 8)
     }
 
+    // Connect icon tint (ADR-0018): greyed when the server kill switch is off,
+    // primary when controlling a remote device, secondary otherwise.
+    private var connectIconColor: Color {
+        if !container.connectService.serverConnectEnabled { return Color.secondary.opacity(0.4) }
+        return container.connectService.isRemoteControlling ? DeadlyColors.primary : Color.secondary
+    }
+
     @ViewBuilder
     private var actionButtons: some View {
         HStack {
-            // Left section — Connect / AirPlay device picker. Hidden entirely
-            // when Connect is disabled on this device (off by default).
-            if container.appPreferences.connectEnabled {
-                Button {
-                    showConnectSheet = true
-                } label: {
-                    HStack(spacing: 4) {
-                        Image(systemName: "airplayaudio")
-                            .font(.title2)
-                            .foregroundStyle(container.connectService.isRemoteControlling ? DeadlyColors.primary : .secondary)
-                            .frame(width: 44, height: 44)
-                        if container.connectService.isRemoteControlling,
-                           let name = container.connectService.connectState?.activeDeviceName {
-                            Text(name)
-                                .font(.caption2)
-                                .foregroundStyle(DeadlyColors.primary)
-                                .lineLimit(1)
-                                .frame(maxWidth: 100, alignment: .leading)
-                        }
+            // Left section — Connect / AirPlay device picker. Always shown
+            // (ADR-0018); greyed when the server kill switch is off. The sheet
+            // itself handles unavailable / enable / full modes.
+            Button {
+                showConnectSheet = true
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "airplayaudio")
+                        .font(.title2)
+                        .foregroundStyle(connectIconColor)
+                        .frame(width: 44, height: 44)
+                    if container.connectService.serverConnectEnabled,
+                       container.connectService.isRemoteControlling,
+                       let name = container.connectService.connectState?.activeDeviceName {
+                        Text(name)
+                            .font(.caption2)
+                            .foregroundStyle(DeadlyColors.primary)
+                            .lineLimit(1)
+                            .frame(maxWidth: 100, alignment: .leading)
                     }
                 }
-                .buttonStyle(.plain)
             }
+            .buttonStyle(.plain)
 
             Spacer()
 

--- a/iosApp/deadly/Feature/Player/PlayerScreen.swift
+++ b/iosApp/deadly/Feature/Player/PlayerScreen.swift
@@ -354,26 +354,29 @@ struct PlayerScreen: View {
     @ViewBuilder
     private var actionButtons: some View {
         HStack {
-            // Left section — Connect / AirPlay device picker
-            Button {
-                showConnectSheet = true
-            } label: {
-                HStack(spacing: 4) {
-                    Image(systemName: "airplayaudio")
-                        .font(.title2)
-                        .foregroundStyle(container.connectService.isRemoteControlling ? DeadlyColors.primary : .secondary)
-                        .frame(width: 44, height: 44)
-                    if container.connectService.isRemoteControlling,
-                       let name = container.connectService.connectState?.activeDeviceName {
-                        Text(name)
-                            .font(.caption2)
-                            .foregroundStyle(DeadlyColors.primary)
-                            .lineLimit(1)
-                            .frame(maxWidth: 100, alignment: .leading)
+            // Left section — Connect / AirPlay device picker. Hidden entirely
+            // when Connect is disabled on this device (off by default).
+            if container.appPreferences.connectEnabled {
+                Button {
+                    showConnectSheet = true
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "airplayaudio")
+                            .font(.title2)
+                            .foregroundStyle(container.connectService.isRemoteControlling ? DeadlyColors.primary : .secondary)
+                            .frame(width: 44, height: 44)
+                        if container.connectService.isRemoteControlling,
+                           let name = container.connectService.connectState?.activeDeviceName {
+                            Text(name)
+                                .font(.caption2)
+                                .foregroundStyle(DeadlyColors.primary)
+                                .lineLimit(1)
+                                .frame(maxWidth: 100, alignment: .leading)
+                        }
                     }
                 }
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
 
             Spacer()
 

--- a/iosApp/deadly/Feature/Player/SidePlayerView.swift
+++ b/iosApp/deadly/Feature/Player/SidePlayerView.swift
@@ -271,23 +271,26 @@ struct SidePlayerView: View {
     private var secondaryActions: some View {
         HStack(spacing: 0) {
             // Connect / AirPlay — left, with optional active-device label.
-            Button {
-                showConnectSheet = true
-            } label: {
-                HStack(spacing: 6) {
-                    Image(systemName: "airplayaudio")
-                        .font(.title3)
-                    if let name = container.connectService.connectState?.activeDeviceName,
-                       container.connectService.isRemoteControlling {
-                        Text(name)
-                            .font(.caption2)
-                            .lineLimit(1)
-                            .frame(maxWidth: 80, alignment: .leading)
+            // Hidden when Connect is disabled on this device (off by default).
+            if container.appPreferences.connectEnabled {
+                Button {
+                    showConnectSheet = true
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "airplayaudio")
+                            .font(.title3)
+                        if let name = container.connectService.connectState?.activeDeviceName,
+                           container.connectService.isRemoteControlling {
+                            Text(name)
+                                .font(.caption2)
+                                .lineLimit(1)
+                                .frame(maxWidth: 80, alignment: .leading)
+                        }
                     }
+                    .foregroundStyle(container.connectService.isRemoteControlling ? DeadlyColors.primary : .secondary)
                 }
-                .foregroundStyle(container.connectService.isRemoteControlling ? DeadlyColors.primary : .secondary)
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
 
             Spacer()
 

--- a/iosApp/deadly/Feature/Player/SidePlayerView.swift
+++ b/iosApp/deadly/Feature/Player/SidePlayerView.swift
@@ -270,27 +270,29 @@ struct SidePlayerView: View {
 
     private var secondaryActions: some View {
         HStack(spacing: 0) {
-            // Connect / AirPlay — left, with optional active-device label.
-            // Hidden when Connect is disabled on this device (off by default).
-            if container.appPreferences.connectEnabled {
-                Button {
-                    showConnectSheet = true
-                } label: {
-                    HStack(spacing: 6) {
-                        Image(systemName: "airplayaudio")
-                            .font(.title3)
-                        if let name = container.connectService.connectState?.activeDeviceName,
-                           container.connectService.isRemoteControlling {
-                            Text(name)
-                                .font(.caption2)
-                                .lineLimit(1)
-                                .frame(maxWidth: 80, alignment: .leading)
-                        }
+            // Connect / AirPlay — left, with optional active-device label. Always
+            // shown (ADR-0018); greyed when the server kill switch is off.
+            Button {
+                showConnectSheet = true
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "airplayaudio")
+                        .font(.title3)
+                    if container.connectService.serverConnectEnabled,
+                       let name = container.connectService.connectState?.activeDeviceName,
+                       container.connectService.isRemoteControlling {
+                        Text(name)
+                            .font(.caption2)
+                            .lineLimit(1)
+                            .frame(maxWidth: 80, alignment: .leading)
                     }
-                    .foregroundStyle(container.connectService.isRemoteControlling ? DeadlyColors.primary : .secondary)
                 }
-                .buttonStyle(.plain)
+                .foregroundStyle(
+                    !container.connectService.serverConnectEnabled ? Color.secondary.opacity(0.4) :
+                    container.connectService.isRemoteControlling ? DeadlyColors.primary : Color.secondary
+                )
             }
+            .buttonStyle(.plain)
 
             Spacer()
 

--- a/iosApp/deadly/Feature/Settings/DeveloperView.swift
+++ b/iosApp/deadly/Feature/Settings/DeveloperView.swift
@@ -43,6 +43,43 @@ struct DeveloperView: View {
                 }
             }
 
+            if container.authService.isSignedIn {
+                Section {
+                    Toggle(isOn: Binding(
+                        get: { container.appPreferences.connectEnabled },
+                        set: { newValue in
+                            container.connectService.setEnabled(newValue)
+                            container.analyticsService.track("feature_use", props: [
+                                "feature": "set_connect_enabled",
+                                "category": "preference",
+                                "value": newValue ? "on" : "off",
+                            ])
+                        }
+                    )) {
+                        Label("Enable Connect (Beta)", systemImage: "iphone.and.arrow.forward")
+                    }
+
+                    NavigationLink {
+                        ConnectScreen()
+                    } label: {
+                        HStack {
+                            Label("Connected Devices", systemImage: "rectangle.connected.to.line.below")
+                            if container.connectService.isConnected && !container.connectService.devices.isEmpty {
+                                Spacer()
+                                Text("\(container.connectService.devices.count)")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .disabled(!container.appPreferences.connectEnabled)
+                } header: {
+                    Text("Connect")
+                } footer: {
+                    Text("Play in sync across your devices. Off by default; the server may also disable it globally.")
+                }
+            }
+
             Section {
                 Picker("Server", selection: Binding(
                     get: { container.appPreferences.serverEnvironment },

--- a/iosApp/deadly/Feature/Settings/DeveloperView.swift
+++ b/iosApp/deadly/Feature/Settings/DeveloperView.swift
@@ -43,43 +43,6 @@ struct DeveloperView: View {
                 }
             }
 
-            if container.authService.isSignedIn {
-                Section {
-                    Toggle(isOn: Binding(
-                        get: { container.appPreferences.connectEnabled },
-                        set: { newValue in
-                            container.connectService.setEnabled(newValue)
-                            container.analyticsService.track("feature_use", props: [
-                                "feature": "set_connect_enabled",
-                                "category": "preference",
-                                "value": newValue ? "on" : "off",
-                            ])
-                        }
-                    )) {
-                        Label("Enable Connect (Beta)", systemImage: "iphone.and.arrow.forward")
-                    }
-
-                    NavigationLink {
-                        ConnectScreen()
-                    } label: {
-                        HStack {
-                            Label("Connected Devices", systemImage: "rectangle.connected.to.line.below")
-                            if container.connectService.isConnected && !container.connectService.devices.isEmpty {
-                                Spacer()
-                                Text("\(container.connectService.devices.count)")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                    }
-                    .disabled(!container.appPreferences.connectEnabled)
-                } header: {
-                    Text("Connect")
-                } footer: {
-                    Text("Play in sync across your devices. Off by default; the server may also disable it globally.")
-                }
-            }
-
             Section {
                 Picker("Server", selection: Binding(
                     get: { container.appPreferences.serverEnvironment },

--- a/iosApp/deadly/Feature/Settings/SettingsScreen.swift
+++ b/iosApp/deadly/Feature/Settings/SettingsScreen.swift
@@ -330,42 +330,8 @@ struct PlaybackAudioSettingsView: View {
                 }
             }
 
-            if container.authService.isSignedIn {
-                Section {
-                    Toggle(isOn: Binding(
-                        get: { container.appPreferences.connectEnabled },
-                        set: { newValue in
-                            container.connectService.setEnabled(newValue)
-                            container.analyticsService.track("feature_use", props: [
-                                "feature": "set_connect_enabled",
-                                "category": "preference",
-                                "value": newValue ? "on" : "off",
-                            ])
-                        }
-                    )) {
-                        Label("Enable Connect (Beta)", systemImage: "iphone.and.arrow.forward")
-                    }
-
-                    NavigationLink {
-                        ConnectScreen()
-                    } label: {
-                        HStack {
-                            settingsRow("Connected Devices", systemImage: "rectangle.connected.to.line.below")
-                            if container.connectService.isConnected && !container.connectService.devices.isEmpty {
-                                Text("\(container.connectService.devices.count)")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                    }
-                    .foregroundStyle(.primary)
-                    .disabled(!container.appPreferences.connectEnabled)
-                } header: {
-                    Text("Connect")
-                } footer: {
-                    Text("Play in sync across your devices. Turn off to keep this device out of Connect.")
-                }
-            }
+            // Connect (cross-device sync) moved to Developer settings — it's a
+            // dev/beta opt-in, off by default, gated globally by the server.
         }
         .navigationTitle("Playback & Audio")
         .navigationBarTitleDisplayMode(.inline)

--- a/iosApp/deadly/Feature/Settings/SettingsScreen.swift
+++ b/iosApp/deadly/Feature/Settings/SettingsScreen.swift
@@ -330,8 +330,31 @@ struct PlaybackAudioSettingsView: View {
                 }
             }
 
-            // Connect (cross-device sync) moved to Developer settings — it's a
-            // dev/beta opt-in, off by default, gated globally by the server.
+            // Per-device Connect opt-in (ADR-0018). Off by default; the server
+            // can also disable Connect globally, in which case the footer says so.
+            Section {
+                Toggle(isOn: Binding(
+                    get: { container.appPreferences.connectEnabled },
+                    set: { newValue in
+                        container.connectService.setEnabled(newValue)
+                        container.analyticsService.track("feature_use", props: [
+                            "feature": "set_connect_enabled",
+                            "category": "preference",
+                            "value": newValue ? "on" : "off",
+                        ])
+                    }
+                )) {
+                    Label("Enable Connect", systemImage: "airplayaudio")
+                }
+            } header: {
+                Text("Connect (Beta)")
+            } footer: {
+                if container.connectService.serverConnectEnabled {
+                    Text("Play in sync across your devices. Enable it on each device you want to use together.")
+                } else {
+                    Text("Cross-device playback sync. Currently unavailable — it's been turned off on the server.")
+                }
+            }
         }
         .navigationTitle("Playback & Audio")
         .navigationBarTitleDisplayMode(.inline)

--- a/ui/src/app/admin/page.tsx
+++ b/ui/src/app/admin/page.tsx
@@ -9,6 +9,7 @@ const ADMIN_PAGES = [
   { href: "/admin/analytics-versions", title: "Analytics Watershed", description: "Per-platform reliable-from versions for each event/prop" },
   { href: "/admin/beta", title: "Beta", description: "Manage TestFlight beta applicants and invitations" },
   { href: "/admin/notifications", title: "Notifications", description: "Publish in-app messages to everybody" },
+  { href: "/admin/settings", title: "Global Settings", description: "Server-wide feature switches (Connect)" },
 ];
 
 export default function AdminPage() {

--- a/ui/src/app/admin/settings/page.tsx
+++ b/ui/src/app/admin/settings/page.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useAuth } from "@/contexts/AuthContext";
+import { useRouter } from "next/navigation";
+import { useEffect, useState, useCallback } from "react";
+
+export default function GlobalSettingsPage() {
+  const { user, isLoading: authLoading } = useAuth();
+  const router = useRouter();
+  const [connectEnabled, setConnectEnabled] = useState<boolean | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const fetchSettings = useCallback(async () => {
+    try {
+      const res = await fetch("/api/admin/connect/settings", { credentials: "include" });
+      if (res.status === 403) {
+        setError("Forbidden");
+        return;
+      }
+      if (!res.ok) throw new Error("Failed to load");
+      const data = await res.json();
+      setConnectEnabled(data.connectEnabled);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user?.isAdmin) {
+      router.replace("/");
+      return;
+    }
+    fetchSettings();
+  }, [authLoading, user?.isAdmin, router, fetchSettings]);
+
+  const toggleConnect = async () => {
+    if (connectEnabled == null || saving) return;
+    setSaving(true);
+    const next = !connectEnabled;
+    try {
+      const res = await fetch("/api/admin/connect/settings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ connectEnabled: next }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        alert(body.error || `Failed to save (${res.status})`);
+        return;
+      }
+      const data = await res.json();
+      setConnectEnabled(data.connectEnabled);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (authLoading || loading) {
+    return (
+      <div className="min-h-screen bg-deadly-bg flex items-center justify-center">
+        <p className="text-zinc-400">Loading...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-deadly-bg flex items-center justify-center">
+        <p className="text-red-400">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-deadly-bg text-zinc-100 p-6">
+      <div className="max-w-2xl mx-auto space-y-6">
+        {/* Nav */}
+        <nav className="flex gap-4 text-sm">
+          <a href="/admin" className="text-zinc-400 hover:text-zinc-200">
+            Admin
+          </a>
+          <span className="text-deadly-red font-medium">Global Settings</span>
+        </nav>
+
+        <h1 className="text-2xl font-bold">Global Settings</h1>
+
+        <div className="bg-deadly-surface rounded-lg border border-zinc-800 divide-y divide-zinc-800">
+          <div className="p-4 flex items-center justify-between gap-4">
+            <div className="min-w-0">
+              <div className="text-sm font-medium text-zinc-100">Connect</div>
+              <p className="text-sm text-zinc-400 mt-1">
+                Cross-device playback sync. When off, the server refuses all
+                Connect/WebSocket sessions — clients hide Connect entirely. Takes
+                effect immediately for new connections; no restart needed.
+              </p>
+            </div>
+            <button
+              onClick={toggleConnect}
+              disabled={saving}
+              aria-label="Toggle Connect"
+              className={`w-10 h-5 rounded-full relative inline-flex items-center transition-colors shrink-0 disabled:opacity-50 ${
+                connectEnabled ? "bg-green-600" : "bg-zinc-600"
+              }`}
+            >
+              <span
+                className={`w-4 h-4 rounded-full bg-white transition-transform ${
+                  connectEnabled ? "translate-x-[22px]" : "translate-x-[2px]"
+                }`}
+              />
+            </button>
+          </div>
+        </div>
+
+        <p className="text-xs text-zinc-500">
+          Connect is{" "}
+          <span className={connectEnabled ? "text-green-400" : "text-zinc-400"}>
+            {connectEnabled ? "enabled" : "disabled"}
+          </span>{" "}
+          globally.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/app/admin/settings/page.tsx
+++ b/ui/src/app/admin/settings/page.tsx
@@ -4,13 +4,26 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useRouter } from "next/navigation";
 import { useEffect, useState, useCallback } from "react";
 
+interface ConnectSettings {
+  connectEnabled: boolean;
+  connectMinProtocol: number;
+}
+
 export default function GlobalSettingsPage() {
   const { user, isLoading: authLoading } = useAuth();
   const router = useRouter();
   const [connectEnabled, setConnectEnabled] = useState<boolean | null>(null);
+  const [minProtocol, setMinProtocol] = useState<number | null>(null);
+  const [minDraft, setMinDraft] = useState<string>("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+
+  const applySettings = useCallback((data: ConnectSettings) => {
+    setConnectEnabled(data.connectEnabled);
+    setMinProtocol(data.connectMinProtocol);
+    setMinDraft(String(data.connectMinProtocol));
+  }, []);
 
   const fetchSettings = useCallback(async () => {
     try {
@@ -20,15 +33,14 @@ export default function GlobalSettingsPage() {
         return;
       }
       if (!res.ok) throw new Error("Failed to load");
-      const data = await res.json();
-      setConnectEnabled(data.connectEnabled);
+      applySettings(await res.json());
       setError(null);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load");
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [applySettings]);
 
   useEffect(() => {
     if (authLoading) return;
@@ -39,27 +51,42 @@ export default function GlobalSettingsPage() {
     fetchSettings();
   }, [authLoading, user?.isAdmin, router, fetchSettings]);
 
-  const toggleConnect = async () => {
-    if (connectEnabled == null || saving) return;
+  // Persist a partial change; the server applies it and returns the full state
+  // (and disconnects any live device the new gate no longer admits).
+  const save = useCallback(async (patch: Partial<ConnectSettings>) => {
+    if (saving) return;
     setSaving(true);
-    const next = !connectEnabled;
     try {
       const res = await fetch("/api/admin/connect/settings", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ connectEnabled: next }),
+        body: JSON.stringify(patch),
       });
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
         alert(body.error || `Failed to save (${res.status})`);
         return;
       }
-      const data = await res.json();
-      setConnectEnabled(data.connectEnabled);
+      applySettings(await res.json());
     } finally {
       setSaving(false);
     }
+  }, [saving, applySettings]);
+
+  const toggleConnect = () => {
+    if (connectEnabled == null) return;
+    save({ connectEnabled: !connectEnabled });
+  };
+
+  const saveMinProtocol = () => {
+    const n = parseInt(minDraft, 10);
+    if (!Number.isFinite(n) || n < 0) {
+      setMinDraft(String(minProtocol ?? 0));
+      return;
+    }
+    if (n === minProtocol) return;
+    save({ connectMinProtocol: n });
   };
 
   if (authLoading || loading) {
@@ -78,6 +105,8 @@ export default function GlobalSettingsPage() {
     );
   }
 
+  const minDirty = minDraft !== String(minProtocol ?? "");
+
   return (
     <div className="min-h-screen bg-deadly-bg text-zinc-100 p-6">
       <div className="max-w-2xl mx-auto space-y-6">
@@ -92,13 +121,14 @@ export default function GlobalSettingsPage() {
         <h1 className="text-2xl font-bold">Global Settings</h1>
 
         <div className="bg-deadly-surface rounded-lg border border-zinc-800 divide-y divide-zinc-800">
+          {/* Connect on/off */}
           <div className="p-4 flex items-center justify-between gap-4">
             <div className="min-w-0">
               <div className="text-sm font-medium text-zinc-100">Connect</div>
               <p className="text-sm text-zinc-400 mt-1">
                 Cross-device playback sync. When off, the server refuses all
                 Connect/WebSocket sessions — clients hide Connect entirely. Takes
-                effect immediately for new connections; no restart needed.
+                effect immediately; live sessions are disconnected.
               </p>
             </div>
             <button
@@ -116,6 +146,37 @@ export default function GlobalSettingsPage() {
               />
             </button>
           </div>
+
+          {/* Minimum protocol */}
+          <div className="p-4 flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <div className="text-sm font-medium text-zinc-100">Minimum protocol version</div>
+              <p className="text-sm text-zinc-400 mt-1">
+                Lowest client wire-protocol version allowed to connect. <span className="text-zinc-300">0</span> allows
+                all. Raise it to gate out older app builds (e.g. <span className="text-zinc-300">2</span> excludes the
+                pre-beta fleet) without turning Connect off globally. Can be set
+                while Connect is off. Applied immediately — connected clients
+                below the floor are disconnected.
+              </p>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <input
+                type="number"
+                min={0}
+                value={minDraft}
+                onChange={(e) => setMinDraft(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Enter") saveMinProtocol(); }}
+                className="w-16 bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-sm text-center"
+              />
+              <button
+                onClick={saveMinProtocol}
+                disabled={saving || !minDirty}
+                className="px-3 py-1 text-sm rounded border border-zinc-700 text-zinc-300 hover:border-zinc-500 disabled:opacity-40 disabled:hover:border-zinc-700"
+              >
+                Save
+              </button>
+            </div>
+          </div>
         </div>
 
         <p className="text-xs text-zinc-500">
@@ -123,7 +184,11 @@ export default function GlobalSettingsPage() {
           <span className={connectEnabled ? "text-green-400" : "text-zinc-400"}>
             {connectEnabled ? "enabled" : "disabled"}
           </span>{" "}
-          globally.
+          globally
+          {connectEnabled && (minProtocol ?? 0) > 0 && (
+            <> for protocol ≥ <span className="text-zinc-300">{minProtocol}</span></>
+          )}
+          .
         </p>
       </div>
     </div>

--- a/ui/src/app/me/_components/SettingsTab.tsx
+++ b/ui/src/app/me/_components/SettingsTab.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { usePlayer } from "@/contexts/PlayerContext";
+import { useConnect } from "@/contexts/ConnectContext";
 import { deleteAccount } from "@/lib/userDataApi";
 import { SUBREDDIT_HANDLE, SUBREDDIT_URL } from "@/lib/community";
 
@@ -13,6 +14,7 @@ const DATA_VERSION = process.env.NEXT_PUBLIC_DATA_VERSION ?? "dev";
 export default function SettingsTab() {
   const { user, signOut } = useAuth();
   const { autoAdvanceEnabled, toggleAutoAdvance } = usePlayer();
+  const { serverConnectEnabled, connectOptedIn, setConnectOptedIn } = useConnect();
   const router = useRouter();
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [confirmText, setConfirmText] = useState("");
@@ -86,6 +88,36 @@ export default function SettingsTab() {
           </button>
         </div>
 
+      </section>
+
+      {/* Connect (Beta) — per-install opt-in (ADR-0018) */}
+      <section className="rounded-lg border border-white/10 bg-deadly-surface p-5">
+        <h3 className="mb-3 font-medium text-white">Connect (Beta)</h3>
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <p className="text-sm text-white/80">Enable Connect</p>
+            <p className="mt-0.5 text-xs text-white/40">
+              {serverConnectEnabled
+                ? "Play in sync across your devices. This is a per-browser setting — enable it on each device you want to use together."
+                : "Cross-device playback sync. Currently unavailable — it's been turned off on the server."}
+            </p>
+          </div>
+          <button
+            role="switch"
+            aria-checked={connectOptedIn}
+            aria-label="Enable Connect"
+            onClick={() => setConnectOptedIn(!connectOptedIn)}
+            className={`inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
+              connectOptedIn ? "bg-deadly-highlight" : "bg-white/15"
+            }`}
+          >
+            <span
+              className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
+                connectOptedIn ? "translate-x-[1.375rem]" : "translate-x-0.5"
+              }`}
+            />
+          </button>
+        </div>
       </section>
 
       {/* Community */}

--- a/ui/src/app/me/_components/SettingsTab.tsx
+++ b/ui/src/app/me/_components/SettingsTab.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 import { usePlayer } from "@/contexts/PlayerContext";
-import { useConnect } from "@/contexts/ConnectContext";
 import { deleteAccount } from "@/lib/userDataApi";
 import { SUBREDDIT_HANDLE, SUBREDDIT_URL } from "@/lib/community";
 
@@ -14,7 +13,6 @@ const DATA_VERSION = process.env.NEXT_PUBLIC_DATA_VERSION ?? "dev";
 export default function SettingsTab() {
   const { user, signOut } = useAuth();
   const { autoAdvanceEnabled, toggleAutoAdvance } = usePlayer();
-  const { connectEnabled, setConnectEnabled } = useConnect();
   const router = useRouter();
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [confirmText, setConfirmText] = useState("");
@@ -88,29 +86,6 @@ export default function SettingsTab() {
           </button>
         </div>
 
-        <div className="mt-4 flex items-center justify-between gap-4 border-t border-white/10 pt-4">
-          <div className="min-w-0">
-            <p className="text-sm text-white/80">Enable Connect (Beta)</p>
-            <p className="mt-0.5 text-xs text-white/40">
-              Play in sync across your devices. Turn off to keep this browser out of Connect.
-            </p>
-          </div>
-          <button
-            role="switch"
-            aria-checked={connectEnabled}
-            aria-label="Enable Connect"
-            onClick={() => setConnectEnabled(!connectEnabled)}
-            className={`inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
-              connectEnabled ? "bg-deadly-highlight" : "bg-white/15"
-            }`}
-          >
-            <span
-              className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
-                connectEnabled ? "translate-x-[1.375rem]" : "translate-x-0.5"
-              }`}
-            />
-          </button>
-        </div>
       </section>
 
       {/* Community */}

--- a/ui/src/components/connect/ConnectProvider.tsx
+++ b/ui/src/components/connect/ConnectProvider.tsx
@@ -10,17 +10,19 @@ import { randomUUID } from "@/lib/uuid";
 
 // Connect WS wire-contract version. See docs/PROTOCOL.md for semantics.
 // Bump in lockstep with the documented protocol; the server may branch on it.
-const CONNECT_PROTOCOL_VERSION = 1;
+// v2: understands the 4005 "Connect disabled" terminal close code.
+const CONNECT_PROTOCOL_VERSION = 2;
 // Build identity for telemetry only — never branched on. Mirrors analytics.ts.
 const APP_VERSION = (process.env.NEXT_PUBLIC_DATA_VERSION ?? "web").slice(0, 20);
 
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const RECONNECT_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 30_000];
 const DEVICE_ID_KEY = "deadly-device-id";
-const CONNECT_ENABLED_KEY = "deadly-connect-enabled";
-// Default for the per-device Connect toggle. Flip to false to disable
-// cross-device Connect by default across all browsers (see Settings).
-const CONNECT_ENABLED_DEFAULT = true;
+// Connect close codes the client must NOT reconnect after. 4003 Unauthorized,
+// 4000 replaced-by-newer-connection, 4005 Connect globally disabled (server
+// kill switch). The browser surfaces server-initiated close codes to onclose
+// directly, so unlike Android no special handshake handling is needed.
+const TERMINAL_CLOSE_CODES = new Set([4000, 4003, 4005]);
 const TIME_SYNC_REFRESH_MS = 5 * 60 * 1000;
 const TIME_SYNC_SAMPLES = 3;
 const TIME_SYNC_SAMPLE_SPACING_MS = 200;
@@ -73,13 +75,6 @@ export default function ConnectProvider({
 
   const [activeDeviceVolume, setActiveDeviceVolume] = useState<number | null>(null);
   const [serverTimeOffsetMs, setServerTimeOffsetMs] = useState(0);
-  // Per-device kill switch for cross-device Connect (Beta). On by default; when
-  // off, this browser never opens the Connect WebSocket. Persisted to localStorage.
-  const [connectEnabled, setConnectEnabledState] = useState<boolean>(() => {
-    if (typeof window === "undefined") return CONNECT_ENABLED_DEFAULT;
-    const stored = localStorage.getItem(CONNECT_ENABLED_KEY);
-    return stored === null ? CONNECT_ENABLED_DEFAULT : stored === "1";
-  });
 
   const wsRef = useRef<WebSocket | null>(null);
   const heartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -265,14 +260,11 @@ export default function ConnectProvider({
       setConnected(false);
       wsRef.current = null;
 
-      // 4003 = Unauthorized (terminal). 4001 = heartbeat timeout (reconnect).
-      // 4000 = "replaced by new connection": the server already has a newer
-      // socket for this deviceId (e.g. a second tab sharing the localStorage
-      // deviceId, or a stale reconnect). Reconnecting here would re-register
-      // and kick that newer socket, whose onclose reconnects and kicks us back
-      // — a self-perpetuating churn. The newer socket is the rightful owner, so
-      // treat 4000 as terminal and stay down.
-      if (!shouldConnectRef.current || event.code === 4003 || event.code === 4000) {
+      // Terminal codes (don't reconnect): 4003 Unauthorized, 4000 replaced-by-
+      // newer-connection (reconnecting would kick the rightful newer socket and
+      // self-perpetuate churn), 4005 Connect globally disabled by the server.
+      // 4001 (heartbeat timeout) and clean drops fall through to reconnect.
+      if (!shouldConnectRef.current || TERMINAL_CLOSE_CODES.has(event.code)) {
         log(`Not reconnecting: shouldConnect=${shouldConnectRef.current} code=${event.code}`);
         return;
       }
@@ -343,44 +335,21 @@ export default function ConnectProvider({
     currentVersionRef.current = 0;
   }, [clearHeartbeat, clearReconnectTimer, clearTimeSyncRefresh]);
 
-  // Toggle the per-device Connect kill switch (Settings). When turning off
-  // while this browser is the active player, send an explicit `stop` first so
-  // followers pause cleanly before the socket closes (the gate effect below
-  // tears it down on the resulting re-render).
-  const setConnectEnabled = useCallback(
-    (enabled: boolean) => {
-      log(`setConnectEnabled(${enabled})`);
-      if (
-        !enabled &&
-        connectState?.activeDeviceId === myDeviceId &&
-        wsRef.current?.readyState === WebSocket.OPEN
-      ) {
-        sendCommand("stop");
-      }
-      if (typeof window !== "undefined") {
-        localStorage.setItem(CONNECT_ENABLED_KEY, enabled ? "1" : "0");
-      }
-      setConnectEnabledState(enabled);
-    },
-    [connectState, myDeviceId, sendCommand],
-  );
 
   useEffect(() => {
     if (isLoading) return;
 
-    if (user && !onAdmin && connectEnabled) {
+    // No per-device toggle on web: Connect is gated globally by the server. We
+    // always attempt when signed in; if the server has Connect disabled the
+    // socket closes terminally (4005) and `connected` stays false, which hides
+    // all Connect UI (the device-picker buttons are gated on `connected`).
+    if (user && !onAdmin) {
       log(`User authenticated, starting connect`);
       shouldConnectRef.current = true;
       reconnectAttemptRef.current = 0;
       connect();
     } else {
-      log(
-        !connectEnabled
-          ? `Connect disabled, disconnecting`
-          : onAdmin
-            ? `On admin route, disconnecting`
-            : `No user, disconnecting`,
-      );
+      log(onAdmin ? `On admin route, disconnecting` : `No user, disconnecting`);
       disconnect();
     }
 
@@ -388,10 +357,10 @@ export default function ConnectProvider({
       disconnect();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user, isLoading, onAdmin, connectEnabled]);
+  }, [user, isLoading, onAdmin]);
 
   return (
-    <ConnectContext.Provider value={{ devices, state: connectState, myDeviceId, connected, sendCommand, activeDeviceVolume, onVolumeMessage, reportVolume, setLocalPlaybackSource, serverTimeOffsetMs, connectEnabled, setConnectEnabled }}>
+    <ConnectContext.Provider value={{ devices, state: connectState, myDeviceId, connected, sendCommand, activeDeviceVolume, onVolumeMessage, reportVolume, setLocalPlaybackSource, serverTimeOffsetMs }}>
       {children}
     </ConnectContext.Provider>
   );

--- a/ui/src/components/connect/ConnectProvider.tsx
+++ b/ui/src/components/connect/ConnectProvider.tsx
@@ -18,6 +18,10 @@ const APP_VERSION = (process.env.NEXT_PUBLIC_DATA_VERSION ?? "web").slice(0, 20)
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const RECONNECT_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 30_000];
 const DEVICE_ID_KEY = "deadly-device-id";
+// Per-web-install Connect opt-in (ADR-0018). A user may run several browsers/
+// installs, each a distinct Connect device, so this is local — NOT an account
+// setting. Default OFF: a fresh install must explicitly opt into the beta.
+const OPTED_IN_KEY = "deadly-connect-opted-in";
 // Connect close codes the client must NOT reconnect after. 4003 Unauthorized,
 // 4000 replaced-by-newer-connection, 4005 Connect globally disabled (server
 // kill switch). The browser surfaces server-initiated close codes to onclose
@@ -75,6 +79,11 @@ export default function ConnectProvider({
 
   const [activeDeviceVolume, setActiveDeviceVolume] = useState<number | null>(null);
   const [serverTimeOffsetMs, setServerTimeOffsetMs] = useState(0);
+
+  // ADR-0018: server global flag (greys/hides the Connect UI) + per-install
+  // beta opt-in. Both must be true to attempt the socket.
+  const [serverConnectEnabled, setServerConnectEnabled] = useState(false);
+  const [connectOptedIn, setConnectOptedInState] = useState(false);
 
   const wsRef = useRef<WebSocket | null>(null);
   const heartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -260,6 +269,10 @@ export default function ConnectProvider({
       setConnected(false);
       wsRef.current = null;
 
+      // The server refused us because Connect is globally disabled — flip the
+      // flag so the Connect UI greys out immediately (ADR-0018 runtime path).
+      if (event.code === 4005) setServerConnectEnabled(false);
+
       // Terminal codes (don't reconnect): 4003 Unauthorized, 4000 replaced-by-
       // newer-connection (reconnecting would kick the rightful newer socket and
       // self-perpetuate churn), 4005 Connect globally disabled by the server.
@@ -308,6 +321,29 @@ export default function ConnectProvider({
     }
   }, []);
 
+  // ADR-0018: best-effort read of the global Connect flag. Short, no-store, and
+  // failures keep the current value. Called on mount and on focus/visibility so
+  // an admin flip is reflected without a reload.
+  const refreshServerConnectEnabled = useCallback(async () => {
+    try {
+      const res = await fetch("/api/connect/enabled", { cache: "no-store" });
+      if (!res.ok) return;
+      const json = (await res.json()) as { connectEnabled?: unknown };
+      if (typeof json.connectEnabled === "boolean") setServerConnectEnabled(json.connectEnabled);
+    } catch {
+      // keep the current value
+    }
+  }, []);
+
+  const setConnectOptedIn = useCallback((value: boolean) => {
+    try {
+      localStorage.setItem(OPTED_IN_KEY, value ? "1" : "0");
+    } catch {
+      // ignore storage failures (private mode); state still updates
+    }
+    setConnectOptedInState(value);
+  }, []);
+
   const setLocalPlaybackSource = useCallback(
     (source: (() => LocalPlaybackSnapshot | null) | null) => {
       localPlaybackRef.current = source ?? (() => null);
@@ -336,20 +372,41 @@ export default function ConnectProvider({
   }, [clearHeartbeat, clearReconnectTimer, clearTimeSyncRefresh]);
 
 
+  // Seed the per-install opt-in from localStorage, then refresh the server flag
+  // on mount and whenever the tab regains focus/visibility (ADR-0018).
+  useEffect(() => {
+    try {
+      setConnectOptedInState(localStorage.getItem(OPTED_IN_KEY) === "1");
+    } catch {
+      // ignore
+    }
+    void refreshServerConnectEnabled();
+    const onFocus = () => void refreshServerConnectEnabled();
+    const onVisible = () => {
+      if (document.visibilityState === "visible") void refreshServerConnectEnabled();
+    };
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [refreshServerConnectEnabled]);
+
   useEffect(() => {
     if (isLoading) return;
 
-    // No per-device toggle on web: Connect is gated globally by the server. We
-    // always attempt when signed in; if the server has Connect disabled the
-    // socket closes terminally (4005) and `connected` stays false, which hides
-    // all Connect UI (the device-picker buttons are gated on `connected`).
-    if (user && !onAdmin) {
-      log(`User authenticated, starting connect`);
+    // ADR-0018: attempt the socket only when signed in, opted into the beta on
+    // this install, AND the server kill switch is on. Any of these going false
+    // re-runs the effect and tears the socket down — so an admin disabling
+    // Connect (flag refresh flips serverConnectEnabled) disconnects every tab.
+    if (user && !onAdmin && connectOptedIn && serverConnectEnabled) {
+      log(`User authenticated + opted in + server enabled, starting connect`);
       shouldConnectRef.current = true;
       reconnectAttemptRef.current = 0;
       connect();
     } else {
-      log(onAdmin ? `On admin route, disconnecting` : `No user, disconnecting`);
+      log(`Not connecting (user=${!!user} admin=${onAdmin} optedIn=${connectOptedIn} serverEnabled=${serverConnectEnabled})`);
       disconnect();
     }
 
@@ -357,10 +414,10 @@ export default function ConnectProvider({
       disconnect();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user, isLoading, onAdmin]);
+  }, [user, isLoading, onAdmin, connectOptedIn, serverConnectEnabled]);
 
   return (
-    <ConnectContext.Provider value={{ devices, state: connectState, myDeviceId, connected, sendCommand, activeDeviceVolume, onVolumeMessage, reportVolume, setLocalPlaybackSource, serverTimeOffsetMs }}>
+    <ConnectContext.Provider value={{ devices, state: connectState, myDeviceId, connected, sendCommand, activeDeviceVolume, onVolumeMessage, reportVolume, setLocalPlaybackSource, serverTimeOffsetMs, serverConnectEnabled, refreshServerConnectEnabled, connectOptedIn, setConnectOptedIn }}>
       {children}
     </ConnectContext.Provider>
   );

--- a/ui/src/components/connect/DeviceList.tsx
+++ b/ui/src/components/connect/DeviceList.tsx
@@ -155,10 +155,48 @@ function deviceTypeLabel(type: DeviceType): string {
 }
 
 export default function DeviceList() {
-  const { devices, state: connectState, myDeviceId, connected, sendCommand, activeDeviceVolume } = useConnect();
+  const {
+    devices, state: connectState, myDeviceId, connected, sendCommand, activeDeviceVolume,
+    serverConnectEnabled, refreshServerConnectEnabled, connectOptedIn, setConnectOptedIn,
+  } = useConnect();
   const { pendingTransfer, transferTo, isActiveDevice, isRemoteControlling } = usePlayer();
 
-  if (devices.length === 0) return null;
+  // Re-check the global kill switch whenever the Connect UI is opened, so the
+  // correct mode is shown at this critical moment even if the value went stale.
+  useEffect(() => {
+    refreshServerConnectEnabled();
+  }, [refreshServerConnectEnabled]);
+
+  // ADR-0018 three modes: server off → unavailable; server on + opted out →
+  // beta promo; opted in → the device picker below.
+  if (!serverConnectEnabled && !connectOptedIn) {
+    return (
+      <div className="px-2.5 py-3">
+        <p className="text-sm font-medium text-white/80">Connect is unavailable</p>
+        <p className="mt-1 text-xs text-white/40">
+          Cross-device playback is temporarily turned off. Check back later.
+        </p>
+      </div>
+    );
+  }
+
+  if (!connectOptedIn) {
+    return (
+      <div className="px-2.5 py-3">
+        <p className="text-sm font-semibold text-white">Enable Connect (Beta)</p>
+        <p className="mt-2 text-xs text-white/50">
+          Keep playback in sync across your devices. It&apos;s a beta feature and may occasionally
+          skip or fall out of sync. Enable it on each device (and browser) you want to use together.
+        </p>
+        <button
+          onClick={() => setConnectOptedIn(true)}
+          className="mt-3 w-full rounded-lg bg-deadly-highlight px-3 py-2 text-sm font-medium text-black transition-opacity hover:opacity-90"
+        >
+          Enable Connect
+        </button>
+      </div>
+    );
+  }
 
   const hasSession = connectState?.showId != null;
   const myDevice = devices.find((d) => d.deviceId === myDeviceId);
@@ -225,6 +263,13 @@ export default function DeviceList() {
         </div>
       )}
 
+      {/* No other devices hint */}
+      {devices.length === 0 && (
+        <p className="px-2.5 py-2 text-xs text-white/30">
+          {connected ? "Looking for devices…" : "Connecting…"} Other devices that have enabled Connect will appear here.
+        </p>
+      )}
+
       {/* Stop session */}
       {hasSession && (
         <div className="mt-1.5 pt-1.5 border-t border-white/10">
@@ -237,6 +282,17 @@ export default function DeviceList() {
           </button>
         </div>
       )}
+
+      {/* Turn off Connect (per-install opt-out, ADR-0018) */}
+      <div className="mt-1.5 pt-1.5 border-t border-white/10">
+        <button
+          onClick={() => setConnectOptedIn(false)}
+          className="w-full rounded-lg px-2.5 py-2 text-left text-xs text-white/30 hover:bg-white/5 hover:text-white/60 transition-colors"
+          title="Turn Connect off on this browser only"
+        >
+          Turn off Connect on this device
+        </button>
+      </div>
     </div>
   );
 }

--- a/ui/src/components/player/HeaderPlayer.tsx
+++ b/ui/src/components/player/HeaderPlayer.tsx
@@ -429,7 +429,10 @@ export default function HeaderPlayer() {
     toggleAutoAdvance,
   } = usePlayer();
 
-  const { connected: isConnected, state: connectState, serverTimeOffsetMs } = useConnect();
+  const { connected: isConnected, state: connectState, serverTimeOffsetMs, serverConnectEnabled, connectOptedIn } = useConnect();
+  // ADR-0018: always offer the Connect control once the user has opted in OR the
+  // server has it enabled; greyed when the server kill switch is off.
+  const connectVisible = serverConnectEnabled || connectOptedIn;
   const { getReview } = useUserData();
 
   // Factoid cards for the fullscreen ambient view: the AI review + the user's
@@ -913,15 +916,17 @@ export default function HeaderPlayer() {
             </svg>
           </button>
         )}
-        {isConnected && (
+        {connectVisible && (
           <button
             onClick={() => setRailMode((m) => (m === "devices" ? null : "devices"))}
             className={`rounded-full p-2 transition-colors ${
-              railMode === "devices"
-                ? "text-deadly-highlight"
-                : isRemoteActive
-                  ? "text-deadly-highlight/70 hover:text-deadly-highlight"
-                  : "text-white/50 hover:text-white/80"
+              !serverConnectEnabled
+                ? "text-white/25 hover:text-white/40"
+                : railMode === "devices"
+                  ? "text-deadly-highlight"
+                  : isRemoteActive
+                    ? "text-deadly-highlight/70 hover:text-deadly-highlight"
+                    : "text-white/50 hover:text-white/80"
             }`}
             aria-label="Devices"
             title="Connect to a device"
@@ -998,12 +1003,14 @@ export default function HeaderPlayer() {
             )}
           </div>
           <div className="relative">
-            {isConnected ? (
+            {connectVisible ? (
               <button
                 onClick={() => setDevicePickerOpen((o) => !o)}
                 aria-label="Connect to device"
                 className={`rounded-full p-2 transition-colors ${
-                  isRemoteActive ? "text-deadly-highlight" : "text-white/60 hover:text-white"
+                  !serverConnectEnabled
+                    ? "text-white/25 hover:text-white/40"
+                    : isRemoteActive ? "text-deadly-highlight" : "text-white/60 hover:text-white"
                 }`}
               >
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">

--- a/ui/src/components/player/HeaderPlayer.tsx
+++ b/ui/src/components/player/HeaderPlayer.tsx
@@ -932,7 +932,7 @@ export default function HeaderPlayer() {
             title="Connect to a device"
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M1 18v3h4v-3H1zm0-6v3h8v-3H1zm0-6v3h12V6H1zm20 12.59L17.42 15 16 16.41 21 21.41l5-5L24.59 15 21 18.59z" />
+              <path d="M21 3H3c-1.1 0-2 .9-2 2v3h2V5h18v14h-7v2h7c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM1 18v3h3c0-1.66-1.34-3-3-3zm0-4v2c2.76 0 5 2.24 5 5h2c0-3.87-3.13-7-7-7zm0-4v2c4.97 0 9 4.03 9 9h2c0-6.08-4.93-11-11-11z" />
             </svg>
           </button>
         )}
@@ -1014,7 +1014,7 @@ export default function HeaderPlayer() {
                 }`}
               >
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M1 18v3h4v-3H1zm0-6v3h8v-3H1zm0-6v3h12V6H1zm20 12.59L17.42 15 16 16.41 21 21.41l5-5L24.59 15 21 18.59z" />
+                  <path d="M21 3H3c-1.1 0-2 .9-2 2v3h2V5h18v14h-7v2h7c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM1 18v3h3c0-1.66-1.34-3-3-3zm0-4v2c2.76 0 5 2.24 5 5h2c0-3.87-3.13-7-7-7zm0-4v2c4.97 0 9 4.03 9 9h2c0-6.08-4.93-11-11-11z" />
                 </svg>
               </button>
             ) : (

--- a/ui/src/contexts/ConnectContext.ts
+++ b/ui/src/contexts/ConnectContext.ts
@@ -28,6 +28,14 @@ export interface ConnectContextValue {
   // server's current wall-clock. 0 until the first time_sync round-trip
   // completes. See docs/connect-v2-architecture.md "Clock Sync".
   serverTimeOffsetMs: number;
+  // ADR-0018: global server kill switch (greys the Connect UI when off) and the
+  // per-install beta opt-in + its setter.
+  serverConnectEnabled: boolean;
+  // Re-fetch the global kill switch. Called when the Connect UI is opened so the
+  // correct mode is shown at that critical moment even if the value went stale.
+  refreshServerConnectEnabled: () => void;
+  connectOptedIn: boolean;
+  setConnectOptedIn: (value: boolean) => void;
 }
 
 export const ConnectContext = createContext<ConnectContextValue | null>(null);

--- a/ui/src/contexts/ConnectContext.ts
+++ b/ui/src/contexts/ConnectContext.ts
@@ -28,10 +28,6 @@ export interface ConnectContextValue {
   // server's current wall-clock. 0 until the first time_sync round-trip
   // completes. See docs/connect-v2-architecture.md "Clock Sync".
   serverTimeOffsetMs: number;
-  // Per-device kill switch for cross-device Connect (Beta). When false, this
-  // browser never opens the Connect WebSocket. Persisted to localStorage.
-  connectEnabled: boolean;
-  setConnectEnabled: (enabled: boolean) => void;
 }
 
 export const ConnectContext = createContext<ConnectContextValue | null>(null);


### PR DESCRIPTION
## Summary

Makes Connect (cross-device playback sync) a **server-gated, opt-in beta** with admin controls, so it can be rolled out safely and the buggy pre-beta fleet can be excluded without shipping a new build.

Two independent gates, both default **off/permissive**:
- **Global kill switch** (`app_settings.connect_enabled`, default off) — server refuses all `ws/connect` sessions when off.
- **Minimum-protocol floor** (`app_settings.connect_min_protocol`, default 0 = allow all) — when Connect is on, refuses clients below the floor. Setting it to `2` excludes the proto-1 store fleet **without** a global off or a protocol bump.

Plus the per-device beta opt-in (default off) on all clients, and an admin **Global Settings** page to drive both server flags.

## Changes
- **api** — public `GET /api/connect/enabled`; admin `GET/POST /api/admin/connect/settings` (both `connectEnabled` + `connectMinProtocol`, settable independently); register-time min-protocol gate; `reconcileLiveDevices` so settings changes evict ineligible live sessions immediately (terminal `4003` for proto<2, `4005` for proto>=2).
- **web** — `/admin/settings` Global Settings page (kill switch + min-protocol field, editable while off); Connect UI re-checks the flag on open; standard Material **Cast** icon.
- **iOS / Android** — Connect defaults off, surfaced as a discoverable beta opt-in; UI hidden/gated when the server flag is off; refresh-on-open of the global flag.

## Device verification (real hardware, both platforms)
With `connectEnabled=true, minProtocol=2`, a proto-1 `2.40.2` client is refused with `4003` (`protocol below minimum`) and **no session forms** (no double-play — the real bug):
- **iOS** (2.40.2, proto 1): cleanly terminal — one refusal, no reconnect. ✅
- **Android** (Pixel 6, 2.40.2, proto 1): refused identically; exhibits the known ~41s reconnect churn + cosmetic "Connected" label (missing `onClosing` override on shipped builds — future Android-only Phase-3 fix). Harmless: no session.

## Notes
- No protocol bump needed — store fleet is proto 1, new builds are proto 2, so `minProtocol=2` cleanly separates them.
- New API setting test coverage added (`disabled-gate.test.ts`). API typecheck + 182 tests pass; UI builds; iOS/Android compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)