### PR TITLE
feat(all/bug-reports): one-tap server bug reports + admin viewer

### DIFF
--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/bugreport/BugReportScreen.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/bugreport/BugReportScreen.kt
@@ -12,16 +12,20 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.IosShare
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
+import androidx.hilt.navigation.compose.hiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -39,6 +43,7 @@ import kotlinx.coroutines.withContext
 fun BugReportScreen(
     onBack: () -> Unit,
     headerBar: @Composable (title: String, onBack: () -> Unit) -> Unit,
+    viewModel: BugReportViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -46,10 +51,14 @@ fun BugReportScreen(
     var logText by remember { mutableStateOf("") }
     var isLoading by remember { mutableStateOf(true) }
     var copied by remember { mutableStateOf(false) }
+    var note by remember { mutableStateOf("") }
+    val sendState by viewModel.state.collectAsState()
+    val isSending = sendState is BugReportSendState.Sending
 
     suspend fun reload() {
         isLoading = true
         copied = false
+        viewModel.resetState()
         logText = withContext(Dispatchers.IO) { BugReportExporter.exportRecentLogs() }
         isLoading = false
     }
@@ -68,10 +77,19 @@ fun BugReportScreen(
             Text("Logs from the last hour", style = MaterialTheme.typography.titleMedium)
             Spacer(Modifier.height(4.dp))
             Text(
-                "Tap Share to send these logs to support. They contain URLs of tracks you " +
-                    "played and timing information — no account or personal data.",
+                "Tap Send Bug Report to send these logs straight to support. They contain URLs " +
+                    "of tracks you played and timing information — no account or personal data.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = note,
+                onValueChange = { note = it },
+                label = { Text("What happened? (optional)") },
+                modifier = Modifier.fillMaxWidth(),
+                minLines = 1,
+                maxLines = 3
             )
         }
 
@@ -105,50 +123,92 @@ fun BugReportScreen(
 
         HorizontalDivider()
 
-        Row(
+        Column(
             modifier = Modifier.fillMaxWidth().padding(16.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalAlignment = Alignment.CenterVertically
+            verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
-            OutlinedButton(
-                onClick = {
-                    copyToClipboard(context, logText)
-                    copied = true
-                    scope.launch { delay(1500); copied = false }
-                },
-                enabled = !isLoading && logText.isNotEmpty(),
-                modifier = Modifier.weight(1f)
-            ) {
-                Icon(
-                    imageVector = if (copied) Icons.Filled.Check else Icons.Filled.ContentCopy,
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp)
-                )
-                Spacer(Modifier.width(6.dp))
-                Text(if (copied) "Copied" else "Copy")
+            when (val s = sendState) {
+                is BugReportSendState.Success ->
+                    StatusRow(Icons.Filled.Check, "Sent — thank you!", Color(0xFF2E7D32))
+                is BugReportSendState.Failure ->
+                    StatusRow(Icons.Filled.Error, s.message, MaterialTheme.colorScheme.error)
+                else -> {}
             }
 
             Button(
-                onClick = { shareLogs(context, logText) },
-                enabled = !isLoading && logText.isNotEmpty(),
-                modifier = Modifier.weight(1f)
+                onClick = { viewModel.send(logText, note) },
+                enabled = !isLoading && !isSending && logText.isNotEmpty(),
+                modifier = Modifier.fillMaxWidth()
             ) {
-                Icon(
-                    imageVector = Icons.Filled.IosShare,
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp)
-                )
-                Spacer(Modifier.width(6.dp))
-                Text("Share")
+                if (isSending) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                } else {
+                    Icon(Icons.Filled.Send, contentDescription = null, modifier = Modifier.size(18.dp))
+                }
+                Spacer(Modifier.width(8.dp))
+                Text(if (isSending) "Sending…" else "Send Bug Report")
             }
 
-            OutlinedButton(
-                onClick = { scope.launch { reload() } },
-                enabled = !isLoading
+            // Fallback path — for when sending fails or the user prefers to send
+            // the logs themselves (e.g. via email).
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Icon(Icons.Filled.Refresh, contentDescription = "Refresh")
+                OutlinedButton(
+                    onClick = {
+                        copyToClipboard(context, logText)
+                        copied = true
+                        scope.launch { delay(1500); copied = false }
+                    },
+                    enabled = !isLoading && logText.isNotEmpty(),
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Icon(
+                        imageVector = if (copied) Icons.Filled.Check else Icons.Filled.ContentCopy,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Text(if (copied) "Copied" else "Copy")
+                }
+
+                OutlinedButton(
+                    onClick = { shareLogs(context, logText) },
+                    enabled = !isLoading && logText.isNotEmpty(),
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.IosShare,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Text("Share")
+                }
+
+                OutlinedButton(
+                    onClick = { scope.launch { reload() } },
+                    enabled = !isLoading && !isSending
+                ) {
+                    Icon(Icons.Filled.Refresh, contentDescription = "Refresh")
+                }
             }
         }
+    }
+}
+
+@Composable
+private fun StatusRow(icon: androidx.compose.ui.graphics.vector.ImageVector, text: String, tint: Color) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(icon, contentDescription = null, tint = tint, modifier = Modifier.size(18.dp))
+        Spacer(Modifier.width(8.dp))
+        Text(text, style = MaterialTheme.typography.bodyMedium, color = tint)
     }
 }
 

--- a/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/bugreport/BugReportViewModel.kt
+++ b/androidApp/feature/settings/src/main/java/com/grateful/deadly/feature/settings/screens/bugreport/BugReportViewModel.kt
@@ -1,0 +1,92 @@
+package com.grateful.deadly.feature.settings.screens.bugreport
+
+import android.os.Build
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.grateful.deadly.core.api.auth.AuthService
+import com.grateful.deadly.core.database.AppPreferences
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+import javax.inject.Inject
+import javax.inject.Named
+
+/** UI state for the one-tap "Send Bug Report" upload. */
+sealed interface BugReportSendState {
+    data object Idle : BugReportSendState
+    data object Sending : BugReportSendState
+    data object Success : BugReportSendState
+    data class Failure(val message: String) : BugReportSendState
+}
+
+/**
+ * Uploads the captured logs + metadata to the server. Gated by the same
+ * X-Analytics-Key the app already embeds; stamps the signed-in user when a
+ * token exists, otherwise the report is anonymous.
+ */
+@HiltViewModel
+class BugReportViewModel @Inject constructor(
+    private val appPreferences: AppPreferences,
+    private val authService: AuthService,
+    @Named("analyticsApiKey") private val apiKey: String,
+    @Named("appVersionName") private val appVersion: String,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<BugReportSendState>(BugReportSendState.Idle)
+    val state: StateFlow<BugReportSendState> = _state
+
+    fun resetState() {
+        _state.value = BugReportSendState.Idle
+    }
+
+    fun send(logs: String, note: String) {
+        if (logs.isBlank() || _state.value is BugReportSendState.Sending) return
+        _state.value = BugReportSendState.Sending
+        viewModelScope.launch {
+            _state.value = withContext(Dispatchers.IO) { upload(logs, note) }
+        }
+    }
+
+    private fun upload(logs: String, note: String): BugReportSendState {
+        val baseUrl = appPreferences.apiBaseUrl
+        val connection = URL("$baseUrl/api/bug-reports").openConnection() as HttpURLConnection
+        return try {
+            connection.requestMethod = "POST"
+            connection.setRequestProperty("Content-Type", "application/json")
+            connection.setRequestProperty("X-Analytics-Key", apiKey)
+            authService.getAuthToken()?.let {
+                connection.setRequestProperty("Authorization", "Bearer $it")
+            }
+            connection.doOutput = true
+            connection.connectTimeout = 15_000
+            connection.readTimeout = 15_000
+
+            val payload = JSONObject().apply {
+                put("logs", logs)
+                if (note.isNotBlank()) put("note", note.trim())
+                put("platform", "android")
+                put("appVersion", appVersion)
+                put("osVersion", "Android ${Build.VERSION.RELEASE} (SDK ${Build.VERSION.SDK_INT})")
+                put("device", "${Build.MANUFACTURER} ${Build.MODEL}")
+                put("installId", appPreferences.installId)
+            }
+            connection.outputStream.use { it.write(payload.toString().toByteArray(Charsets.UTF_8)) }
+
+            when (val code = connection.responseCode) {
+                in 200..299 -> BugReportSendState.Success
+                429 -> BugReportSendState.Failure("Too many reports — please try again later.")
+                else -> BugReportSendState.Failure("Send failed ($code). Try Copy or Share instead.")
+            }
+        } catch (e: Exception) {
+            BugReportSendState.Failure("Couldn't reach the server. Try Copy or Share instead.")
+        } finally {
+            connection.disconnect()
+        }
+    }
+}

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -19,6 +19,7 @@ import { popularRoutes } from "./routes/popular.js";
 import { showRoutes } from "./routes/shows.js";
 import { betaRoutes } from "./routes/beta.js";
 import { notificationRoutes } from "./routes/notifications.js";
+import { bugReportRoutes } from "./routes/bugReports.js";
 import { devTokenRoutes } from "./auth/dev-token.js";
 import { isDev } from "./env.js";
 
@@ -51,6 +52,7 @@ export function buildApp() {
         { name: "analytics", description: "Anonymous usage analytics" },
         { name: "beta", description: "Beta applicant management" },
         { name: "notifications", description: "In-app messaging / admin notifications" },
+        { name: "bug-reports", description: "User-submitted bug reports" },
       ],
     },
   });
@@ -76,6 +78,7 @@ export function buildApp() {
   app.register(showRoutes);
   app.register(betaRoutes);
   app.register(notificationRoutes);
+  app.register(bugReportRoutes);
 
   if (isDev) {
     app.register(devTokenRoutes);

--- a/api/src/db/bugReports.ts
+++ b/api/src/db/bugReports.ts
@@ -1,0 +1,151 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { getUsersDb } from "./users.js";
+
+// User-submitted bug reports. Metadata lives in users.db so the admin can list,
+// filter, and identify the reporter; the raw log text is stored as a sidecar
+// .txt file in a sibling `bugreports/` directory under the data volume. The
+// files are never served statically (see Caddyfile) — they're only reachable
+// through the admin-gated download route, so logs can't leak.
+
+const DATA_DIR = path.dirname(
+  process.env.USERS_DB_PATH ?? path.join(process.cwd(), "data", "users.db"),
+);
+const REPORTS_DIR = path.join(DATA_DIR, "bugreports");
+
+/** Max size of an uploaded log body we'll persist (bytes). */
+export const MAX_LOG_BYTES = 5 * 1024 * 1024; // 5 MB
+export const NOTE_MAX = 2000;
+
+export interface BugReport {
+  id: string;
+  user_id: string | null;
+  user_email: string | null;
+  note: string | null;
+  platform: string | null;
+  app_version: string | null;
+  os_version: string | null;
+  device: string | null;
+  install_id: string | null;
+  ip: string | null;
+  size_bytes: number;
+  created_at: number;
+}
+
+let schemaReady = false;
+
+function ensureSchema(): void {
+  if (schemaReady) return;
+  const db = getUsersDb();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS bug_reports (
+      id TEXT PRIMARY KEY,
+      user_id TEXT REFERENCES accounts(id) ON DELETE SET NULL,
+      user_email TEXT,
+      note TEXT,
+      platform TEXT,
+      app_version TEXT,
+      os_version TEXT,
+      device TEXT,
+      install_id TEXT,
+      ip TEXT,
+      size_bytes INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+    CREATE INDEX IF NOT EXISTS idx_bug_reports_created
+      ON bug_reports(created_at DESC);
+  `);
+  fs.mkdirSync(REPORTS_DIR, { recursive: true });
+  schemaReady = true;
+}
+
+/** Absolute path of the stored log file for a report id. */
+export function bugReportFilePath(id: string): string {
+  return path.join(REPORTS_DIR, `${id}.txt`);
+}
+
+export interface CreateBugReportInput {
+  logs: string;
+  note?: string | null;
+  platform?: string | null;
+  appVersion?: string | null;
+  osVersion?: string | null;
+  device?: string | null;
+  installId?: string | null;
+  userId?: string | null;
+  userEmail?: string | null;
+  ip?: string | null;
+}
+
+/** Persist a report's logs to disk and its metadata to the DB. Returns the row. */
+export function createBugReport(input: CreateBugReportInput): BugReport {
+  ensureSchema();
+  const db = getUsersDb();
+  const id = crypto.randomUUID();
+
+  const body = input.logs ?? "";
+  fs.writeFileSync(bugReportFilePath(id), body, "utf8");
+  const sizeBytes = Buffer.byteLength(body, "utf8");
+
+  const note = input.note?.trim() ? input.note.trim().slice(0, NOTE_MAX) : null;
+
+  db.prepare(
+    `INSERT INTO bug_reports
+       (id, user_id, user_email, note, platform, app_version, os_version,
+        device, install_id, ip, size_bytes)
+     VALUES (@id, @user_id, @user_email, @note, @platform, @app_version,
+             @os_version, @device, @install_id, @ip, @size_bytes)`,
+  ).run({
+    id,
+    user_id: input.userId ?? null,
+    user_email: input.userEmail ?? null,
+    note,
+    platform: input.platform ?? null,
+    app_version: input.appVersion ?? null,
+    os_version: input.osVersion ?? null,
+    device: input.device ?? null,
+    install_id: input.installId ?? null,
+    ip: input.ip ?? null,
+    size_bytes: sizeBytes,
+  });
+
+  return getBugReport(id)!;
+}
+
+/** Newest-first metadata list for the admin screen. */
+export function listBugReports(): BugReport[] {
+  ensureSchema();
+  return getUsersDb()
+    .prepare(`SELECT * FROM bug_reports ORDER BY created_at DESC`)
+    .all() as BugReport[];
+}
+
+export function getBugReport(id: string): BugReport | null {
+  ensureSchema();
+  const row = getUsersDb()
+    .prepare(`SELECT * FROM bug_reports WHERE id = ?`)
+    .get(id) as BugReport | undefined;
+  return row ?? null;
+}
+
+/** Read the stored log text, or null if the row/file is missing. */
+export function readBugReportLogs(id: string): string | null {
+  if (!getBugReport(id)) return null;
+  const file = bugReportFilePath(id);
+  if (!fs.existsSync(file)) return null;
+  return fs.readFileSync(file, "utf8");
+}
+
+/** Delete the row and its log file. Returns true if a row was removed. */
+export function deleteBugReport(id: string): boolean {
+  ensureSchema();
+  const file = bugReportFilePath(id);
+  try {
+    if (fs.existsSync(file)) fs.unlinkSync(file);
+  } catch {
+    // Best-effort file cleanup; still drop the row.
+  }
+  const info = getUsersDb().prepare(`DELETE FROM bug_reports WHERE id = ?`).run(id);
+  return info.changes > 0;
+}

--- a/api/src/routes/bugReports.ts
+++ b/api/src/routes/bugReports.ts
@@ -1,0 +1,162 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import { optionalAuth, requireAdmin } from "../auth/middleware.js";
+import {
+  createBugReport,
+  listBugReports,
+  getBugReport,
+  readBugReportLogs,
+  deleteBugReport,
+  MAX_LOG_BYTES,
+  NOTE_MAX,
+} from "../db/bugReports.js";
+
+// Per-IP rate limit for uploads (defense in depth; the app also sends the
+// shared X-Analytics-Key). A real user taps "Send Bug Report" a handful of
+// times at most.
+const RL_WINDOW = 60 * 60_000; // 1 hour
+const RL_MAX = 20;
+const buckets = new Map<string, { count: number; resetAt: number }>();
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const b = buckets.get(ip);
+  if (!b || now > b.resetAt) {
+    buckets.set(ip, { count: 1, resetAt: now + RL_WINDOW });
+    return false;
+  }
+  b.count++;
+  return b.count > RL_MAX;
+}
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, b] of buckets) if (now > b.resetAt) buckets.delete(ip);
+}, 600_000).unref();
+
+export async function bugReportRoutes(app: FastifyInstance): Promise<void> {
+  const apiKey = process.env.ANALYTICS_API_KEY;
+
+  // ── Submit (app) ────────────────────────────────────────────────────
+  // Gated by the same X-Analytics-Key the apps already embed, so random
+  // internet callers can't dump files. Login is optional: when present we
+  // stamp the reporter's identity, otherwise the report is anonymous.
+  app.post<{
+    Body: {
+      logs?: unknown; note?: unknown; platform?: unknown;
+      appVersion?: unknown; osVersion?: unknown; device?: unknown; installId?: unknown;
+    };
+  }>(
+    "/api/bug-reports",
+    {
+      bodyLimit: MAX_LOG_BYTES + 64 * 1024,
+      schema: {
+        tags: ["bug-reports"],
+        summary: "Submit a bug report (logs + metadata) from the app",
+        body: {
+          type: "object",
+          required: ["logs"],
+          properties: {
+            logs: { type: "string" },
+            note: { type: "string", nullable: true },
+            platform: { type: "string", nullable: true },
+            appVersion: { type: "string", nullable: true },
+            osVersion: { type: "string", nullable: true },
+            device: { type: "string", nullable: true },
+            installId: { type: "string", nullable: true },
+          },
+        },
+      },
+      preHandler: optionalAuth,
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      if (apiKey) {
+        const provided = request.headers["x-analytics-key"];
+        if (provided !== apiKey) {
+          return reply.code(401).send({ error: "Invalid key" });
+        }
+      }
+
+      if (isRateLimited(request.ip)) {
+        return reply.code(429).send({ error: "Rate limit exceeded" });
+      }
+
+      const body = request.body as {
+        logs?: unknown; note?: unknown; platform?: unknown;
+        appVersion?: unknown; osVersion?: unknown; device?: unknown; installId?: unknown;
+      };
+
+      const logs = typeof body.logs === "string" ? body.logs : "";
+      if (!logs.trim()) {
+        return reply.code(400).send({ error: "logs are required" });
+      }
+      if (Buffer.byteLength(logs, "utf8") > MAX_LOG_BYTES) {
+        return reply.code(413).send({ error: "logs too large" });
+      }
+
+      const str = (v: unknown): string | null =>
+        typeof v === "string" && v.trim() ? v.trim() : null;
+
+      const report = createBugReport({
+        logs,
+        note: typeof body.note === "string" ? body.note.slice(0, NOTE_MAX) : null,
+        platform: str(body.platform),
+        appVersion: str(body.appVersion),
+        osVersion: str(body.osVersion),
+        device: str(body.device),
+        installId: str(body.installId),
+        userId: request.user?.id ?? null,
+        userEmail: request.user?.email ?? null,
+        ip: request.ip,
+      });
+
+      return reply.code(201).send({ id: report.id });
+    },
+  );
+
+  // ── Admin (list / download / delete) ────────────────────────────────
+  app.get(
+    "/api/admin/bug-reports",
+    {
+      schema: { tags: ["bug-reports"], summary: "List submitted bug reports (admin)" },
+      preHandler: requireAdmin,
+    },
+    async () => {
+      return { reports: listBugReports() };
+    },
+  );
+
+  app.get<{ Params: { id: string } }>(
+    "/api/admin/bug-reports/:id",
+    {
+      schema: { tags: ["bug-reports"], summary: "Download a bug report's logs (admin)" },
+      preHandler: requireAdmin,
+    },
+    async (request, reply) => {
+      const { id } = request.params;
+      const meta = getBugReport(id);
+      const logs = readBugReportLogs(id);
+      if (!meta || logs == null) {
+        return reply.code(404).send({ error: "not found" });
+      }
+      reply.header("Content-Type", "text/plain; charset=utf-8");
+      reply.header(
+        "Content-Disposition",
+        `attachment; filename="bugreport-${id}.txt"`,
+      );
+      return reply.send(logs);
+    },
+  );
+
+  app.delete<{ Params: { id: string } }>(
+    "/api/admin/bug-reports/:id",
+    {
+      schema: { tags: ["bug-reports"], summary: "Delete a bug report (admin)" },
+      preHandler: requireAdmin,
+    },
+    async (request, reply) => {
+      const ok = deleteBugReport(request.params.id);
+      if (!ok) return reply.code(404).send({ error: "not found" });
+      return reply.code(204).send();
+    },
+  );
+}

--- a/iosApp/deadly/Feature/Settings/BugReportView.swift
+++ b/iosApp/deadly/Feature/Settings/BugReportView.swift
@@ -6,14 +6,25 @@ import SwiftAudioStreamEx
 /// by app + playback subsystems) via `LogExport`, shows a preview, and offers
 /// share + copy-to-clipboard actions so users can ship logs to support.
 struct BugReportView: View {
+    @Environment(\.appContainer) private var container
+
     @State private var logText: String = ""
     @State private var isLoading = true
     @State private var loadError: String?
     @State private var shareItem: ShareItem?
     @State private var copied = false
 
+    @State private var note: String = ""
+    @State private var isSending = false
+    @State private var sendStatus: SendStatus?
+
     /// Optional preset filter — e.g., `[PB]` to scope to playback lines only.
     var filterContains: String? = nil
+
+    private enum SendStatus: Equatable {
+        case success
+        case failure(String)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -70,40 +81,80 @@ struct BugReportView: View {
         VStack(alignment: .leading, spacing: 6) {
             Text("Logs from the last hour")
                 .font(.headline)
-            Text("Tap **Share** to send these logs to support. They contain URLs of tracks you played and timing information — no account or personal data.")
+            Text("Tap **Send Bug Report** to send these logs straight to support. They contain URLs of tracks you played and timing information — no account or personal data.")
                 .font(.callout)
                 .foregroundStyle(.secondary)
+
+            TextField("What happened? (optional)", text: $note, axis: .vertical)
+                .lineLimit(1...3)
+                .textFieldStyle(.roundedBorder)
+                .padding(.top, 4)
         }
     }
 
     private var actionBar: some View {
-        HStack(spacing: 12) {
-            Button {
-                copyToClipboard()
-            } label: {
-                Label(copied ? "Copied" : "Copy", systemImage: copied ? "checkmark" : "doc.on.doc")
-                    .frame(maxWidth: .infinity)
+        VStack(spacing: 10) {
+            switch sendStatus {
+            case .success:
+                Label("Sent — thank you!", systemImage: "checkmark.circle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.green)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            case .failure(let msg):
+                Label(msg, systemImage: "exclamationmark.triangle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.orange)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            case nil:
+                EmptyView()
             }
-            .buttonStyle(.bordered)
-            .disabled(isLoading || logText.isEmpty)
 
             Button {
-                prepareShare()
+                Task { await sendReport() }
             } label: {
-                Label("Share", systemImage: "square.and.arrow.up")
-                    .frame(maxWidth: .infinity)
+                HStack {
+                    if isSending {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Image(systemName: "paperplane.fill")
+                    }
+                    Text(isSending ? "Sending…" : "Send Bug Report")
+                }
+                .frame(maxWidth: .infinity)
             }
             .buttonStyle(.borderedProminent)
-            .disabled(isLoading || logText.isEmpty)
+            .disabled(isLoading || isSending || logText.isEmpty)
 
-            Button {
-                Task { await loadLogs() }
-            } label: {
-                Image(systemName: "arrow.clockwise")
-                    .frame(width: 44, height: 32)
+            // Fallback path — for when sending fails or the user prefers to send
+            // the logs themselves (e.g. via email/Reddit).
+            HStack(spacing: 12) {
+                Button {
+                    copyToClipboard()
+                } label: {
+                    Label(copied ? "Copied" : "Copy", systemImage: copied ? "checkmark" : "doc.on.doc")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .disabled(isLoading || logText.isEmpty)
+
+                Button {
+                    prepareShare()
+                } label: {
+                    Label("Share", systemImage: "square.and.arrow.up")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .disabled(isLoading || logText.isEmpty)
+
+                Button {
+                    Task { await loadLogs() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .frame(width: 44, height: 32)
+                }
+                .buttonStyle(.bordered)
+                .disabled(isLoading || isSending)
             }
-            .buttonStyle(.bordered)
-            .disabled(isLoading)
         }
     }
 
@@ -120,6 +171,59 @@ struct BugReportView: View {
             loadError = error.localizedDescription
         }
         isLoading = false
+    }
+
+    /// One-tap submit: POSTs the logs + metadata to the server. Gated by the
+    /// shared analytics key; stamps the signed-in user when a token exists,
+    /// otherwise the report is anonymous.
+    private func sendReport() async {
+        guard !logText.isEmpty else { return }
+        isSending = true
+        sendStatus = nil
+
+        let prefs = container.appPreferences
+        let baseURL = prefs.apiBaseUrl
+        guard let url = URL(string: "\(baseURL)/api/bug-reports") else {
+            sendStatus = .failure("Couldn't build request URL.")
+            isSending = false
+            return
+        }
+
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        let payload: [String: String?] = [
+            "logs": logText,
+            "note": note.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : note,
+            "platform": "ios",
+            "appVersion": appVersion,
+            "osVersion": "iOS \(UIDevice.current.systemVersion)",
+            "device": UIDevice.current.model,
+            "installId": prefs.installId,
+        ]
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(Secrets.analyticsApiKey, forHTTPHeaderField: "X-Analytics-Key")
+        if let token = container.authService.token {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        do {
+            request.httpBody = try JSONSerialization.data(
+                withJSONObject: payload.compactMapValues { $0 }
+            )
+            let (_, response) = try await URLSession.shared.data(for: request)
+            let code = (response as? HTTPURLResponse)?.statusCode ?? 0
+            if (200..<300).contains(code) {
+                sendStatus = .success
+            } else if code == 429 {
+                sendStatus = .failure("Too many reports — please try again later.")
+            } else {
+                sendStatus = .failure("Send failed (\(code)). Try Copy or Share instead.")
+            }
+        } catch {
+            sendStatus = .failure("Couldn't reach the server. Try Copy or Share instead.")
+        }
+        isSending = false
     }
 
     private func copyToClipboard() {

--- a/ui/src/app/admin/bug-reports/page.tsx
+++ b/ui/src/app/admin/bug-reports/page.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useAuth } from "@/contexts/AuthContext";
+import { useRouter } from "next/navigation";
+import { useEffect, useState, useCallback } from "react";
+
+interface BugReport {
+  id: string;
+  user_id: string | null;
+  user_email: string | null;
+  note: string | null;
+  platform: string | null;
+  app_version: string | null;
+  os_version: string | null;
+  device: string | null;
+  install_id: string | null;
+  size_bytes: number;
+  created_at: number;
+}
+
+function formatTs(ts: number): string {
+  return new Date(ts * 1000).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export default function BugReportsAdminPage() {
+  const { user, isLoading: authLoading } = useAuth();
+  const router = useRouter();
+  const [items, setItems] = useState<BugReport[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [preview, setPreview] = useState<{ id: string; text: string } | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const res = await fetch("/api/admin/bug-reports", { credentials: "include" });
+      if (res.status === 403) {
+        setError("Forbidden");
+        return;
+      }
+      if (!res.ok) throw new Error("Failed to load");
+      const data = await res.json();
+      setItems(data.reports);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user?.isAdmin) {
+      router.replace("/");
+      return;
+    }
+    fetchData();
+  }, [authLoading, user?.isAdmin, router, fetchData]);
+
+  const remove = async (id: string) => {
+    const res = await fetch(`/api/admin/bug-reports/${id}`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+    if (!res.ok && res.status !== 204) {
+      const b = await res.json().catch(() => ({}));
+      alert(b.error || `Delete failed (${res.status})`);
+    }
+    setConfirmDelete(null);
+    if (preview?.id === id) setPreview(null);
+    await fetchData();
+  };
+
+  const openPreview = async (id: string) => {
+    if (preview?.id === id) {
+      setPreview(null);
+      return;
+    }
+    setPreviewLoading(true);
+    try {
+      const res = await fetch(`/api/admin/bug-reports/${id}`, { credentials: "include" });
+      if (!res.ok) throw new Error(`Failed (${res.status})`);
+      setPreview({ id, text: await res.text() });
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "Failed to load logs");
+    } finally {
+      setPreviewLoading(false);
+    }
+  };
+
+  if (authLoading || loading) {
+    return (
+      <div className="min-h-screen bg-deadly-bg flex items-center justify-center">
+        <p className="text-zinc-400">Loading...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-deadly-bg flex items-center justify-center">
+        <p className="text-red-400">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-deadly-bg text-zinc-100 p-6">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <nav className="flex gap-4 text-sm">
+          <a href="/admin" className="text-zinc-400 hover:text-zinc-200">Admin</a>
+          <span className="text-deadly-red font-medium">Bug Reports</span>
+        </nav>
+
+        <div>
+          <h1 className="text-2xl font-bold">Bug Reports</h1>
+          <p className="mt-1 text-sm text-zinc-400">
+            Logs submitted from the apps. Preview inline, download the raw file, or
+            delete. Files are stored privately on the server and only reachable here.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          {items.length === 0 ? (
+            <div className="bg-deadly-surface rounded-lg border border-zinc-800 px-4 py-8 text-center text-zinc-500">
+              No bug reports yet.
+            </div>
+          ) : (
+            items.map((r) => (
+              <div key={r.id} className="bg-deadly-surface rounded-lg border border-zinc-800 p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      {r.platform && (
+                        <span className="px-2 py-0.5 rounded text-xs font-medium bg-blue-600/20 text-blue-300 capitalize">{r.platform}</span>
+                      )}
+                      {r.app_version && (
+                        <span className="px-2 py-0.5 rounded text-xs font-medium bg-zinc-700/40 text-zinc-300">v{r.app_version}</span>
+                      )}
+                      <span className="text-xs text-zinc-500">{formatTs(r.created_at)}</span>
+                      <span className="text-xs text-zinc-600">{formatSize(r.size_bytes)}</span>
+                    </div>
+                    <p className="mt-1.5 text-sm text-zinc-200">
+                      {r.user_email ? (
+                        <span className="font-medium">{r.user_email}</span>
+                      ) : (
+                        <span className="text-zinc-500 italic">anonymous</span>
+                      )}
+                    </p>
+                    {(r.device || r.os_version) && (
+                      <p className="mt-0.5 text-xs text-zinc-500">
+                        {[r.device, r.os_version].filter(Boolean).join(" · ")}
+                      </p>
+                    )}
+                    {r.note && (
+                      <p className="mt-1.5 text-sm text-zinc-300 whitespace-pre-wrap break-words bg-zinc-900/40 rounded px-2 py-1.5 border border-zinc-800">
+                        {r.note}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <button
+                      onClick={() => openPreview(r.id)}
+                      className="px-2 py-0.5 rounded text-xs bg-zinc-700/40 text-zinc-300 hover:bg-zinc-700/70"
+                    >
+                      {preview?.id === r.id ? "Hide" : "Preview"}
+                    </button>
+                    <a
+                      href={`/api/admin/bug-reports/${r.id}`}
+                      download={`bugreport-${r.id}.txt`}
+                      className="px-2 py-0.5 rounded text-xs bg-green-600/20 text-green-400 hover:bg-green-600/40"
+                    >
+                      Download
+                    </a>
+                    {confirmDelete === r.id ? (
+                      <>
+                        <button onClick={() => remove(r.id)} className="px-2 py-0.5 bg-red-600 text-white rounded text-xs hover:bg-red-700">Confirm</button>
+                        <button onClick={() => setConfirmDelete(null)} className="px-2 py-0.5 text-zinc-400 text-xs hover:text-zinc-200">Cancel</button>
+                      </>
+                    ) : (
+                      <button
+                        onClick={() => setConfirmDelete(r.id)}
+                        className="px-2 py-0.5 rounded text-xs bg-red-600/20 text-red-400 hover:bg-red-600/40"
+                      >
+                        Delete
+                      </button>
+                    )}
+                  </div>
+                </div>
+
+                {preview?.id === r.id && (
+                  <pre className="mt-3 max-h-96 overflow-auto rounded bg-zinc-950 border border-zinc-800 p-3 text-xs text-zinc-300 whitespace-pre-wrap break-words">
+                    {previewLoading ? "Loading…" : preview.text}
+                  </pre>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/app/admin/page.tsx
+++ b/ui/src/app/admin/page.tsx
@@ -9,6 +9,7 @@ const ADMIN_PAGES = [
   { href: "/admin/analytics-versions", title: "Analytics Watershed", description: "Per-platform reliable-from versions for each event/prop" },
   { href: "/admin/beta", title: "Beta", description: "Manage TestFlight beta applicants and invitations" },
   { href: "/admin/notifications", title: "Notifications", description: "Publish in-app messages to everybody" },
+  { href: "/admin/bug-reports", title: "Bug Reports", description: "View, download, and delete logs submitted from the apps" },
   { href: "/admin/settings", title: "Global Settings", description: "Server-wide feature switches (Connect)" },
 ];
 


### PR DESCRIPTION
## What

Adds the ability to send bug reports to the server. The happy path is now a single **Send Bug Report** tap; Copy/Save/Share remain as a fallback for anyone who can't post. Admin can view, download, and delete reports from the web.

## How

**API**
- `POST /api/bug-reports` — gated by the `X-Analytics-Key` the apps already embed (keeps random internet callers out without forcing login), `optionalAuth` stamps the signed-in user, 5MB body cap, per-IP rate limit (20/hr).
- Admin (`requireAdmin`): `GET /api/admin/bug-reports` (list), `GET /api/admin/bug-reports/:id` (download w/ `Content-Disposition`), `DELETE /:id` (row + file).
- Metadata in `users.db` (`bug_reports`); raw logs stored as files under the `api-data` volume. **Never served statically** — Caddy only exposes `/srv/ui` + `/srv/share`, so logs are only reachable through the admin-gated routes.

**Web admin**
- New `/admin/bug-reports` page: list with platform/version/user/device/size, inline preview, download, delete (with confirm). Linked from the admin landing.

**iOS + Android**
- Existing bug-report screens gain an optional "What happened?" note field and a primary **Send Bug Report** button (spinner + success/failure status). Sends logs + structured metadata, Bearer token when signed in, anonymous otherwise. Copy/Share/Refresh kept as the fallback row.

## Notes
- Anonymous allowed; reporter identity stamped only when logged in.
- Defense in depth: app key gate **and** per-IP rate limit.

## Test
- API: `npm test` → 182/182 pass.
- UI: `tsc --noEmit` clean.
- Android: `assembleDebug` builds (Hilt graph validated).
- iOS: wired; needs a remote Mac build to compile-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)