### PR TITLE
Host emma-shop through Caddy + fix update_dns ordering

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -235,22 +235,10 @@ jobs:
             docker compose ps
           SCRIPT
 
-      - name: Health check
-        env:
-          SITE: https://${{ vars.SITE_ADDRESS }}
-        run: |
-          echo "Waiting for $SITE/api/health ..."
-          for i in $(seq 1 24); do
-            if curl -fsSk "$SITE/api/health" -o /dev/null 2>/dev/null; then
-              echo "Health check passed on attempt $i"
-              exit 0
-            fi
-            echo "  Attempt $i/24 — waiting 5s..."
-            sleep 5
-          done
-          echo "::warning::Health check did not pass within 2 minutes"
-          exit 1
-
+      # MUST run before the health check: on a first stand-up the box's DNS may
+      # still point at the old server, so the health check (which hits
+      # https://SITE_ADDRESS) can't pass until this repoints it. Skipped unless
+      # update_dns is set.
       - name: Update DNS (GoDaddy)
         if: inputs.update_dns
         env:
@@ -298,17 +286,47 @@ jobs:
           update_record "$SHARE_ADDRESS"
 
           echo "==> Polling dig @1.1.1.1 for $SITE_ADDRESS -> $NEW_IP (up to ~700s)"
+          PROPAGATED=0
           DEADLINE=$(( $(date +%s) + 700 ))
           while [ "$(date +%s)" -lt "$DEADLINE" ]; do
             RESOLVED=$(dig @1.1.1.1 +short "$SITE_ADDRESS" A | head -1)
             if [ "$RESOLVED" = "$NEW_IP" ]; then
               echo "    1.1.1.1 now resolves $SITE_ADDRESS to $NEW_IP"
-              exit 0
+              PROPAGATED=1
+              break
             fi
             echo "    currently resolves to '${RESOLVED:-<empty>}', sleeping 15s..."
             sleep 15
           done
-          echo "::warning::DNS did not propagate to 1.1.1.1 within 700s. The GoDaddy PATCH itself succeeded; propagation may still be in progress."
+          if [ "$PROPAGATED" -ne 1 ]; then
+            echo "::warning::DNS did not propagate to 1.1.1.1 within 700s. The GoDaddy PUT succeeded; propagation may still be in progress."
+          fi
+
+          # The box's Caddy is already up (Deploy step) and may be in ACME
+          # back-off from failing against the OLD IP. Now that DNS is correct,
+          # restart it so it re-obtains certs immediately instead of waiting out
+          # the back-off — otherwise the health check below races cert issuance.
+          echo "==> Restarting Caddy on $NEW_IP to re-obtain certs now that DNS is correct"
+          ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=accept-new deploy@"$NEW_IP" \
+            "cd /opt/deadly && docker compose restart caddy" || true
+          echo "==> Giving Caddy ~30s to obtain certificates"
+          sleep 30
+
+      - name: Health check
+        env:
+          SITE: https://${{ vars.SITE_ADDRESS }}
+        run: |
+          echo "Waiting for $SITE/api/health ..."
+          for i in $(seq 1 24); do
+            if curl -fsSk "$SITE/api/health" -o /dev/null 2>/dev/null; then
+              echo "Health check passed on attempt $i"
+              exit 0
+            fi
+            echo "  Attempt $i/24 — waiting 5s..."
+            sleep 5
+          done
+          echo "::warning::Health check did not pass within 2 minutes"
+          exit 1
 
       - name: Job summary
         if: always()

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -124,6 +124,10 @@ jobs:
         run: |
           SITE_ADDRESS="${{ vars.SITE_ADDRESS }}"
           SHARE_ADDRESS="${{ vars.SHARE_ADDRESS }}"
+          # Optional: the emma-shop public host. Set as a per-environment variable
+          # only where the shop is hosted (prod). Empty elsewhere — compose then
+          # falls back to an inert default, so beta is unaffected.
+          SHOP_ADDRESS="${{ vars.SHOP_ADDRESS }}"
           if [ -z "$SITE_ADDRESS" ] || [ -z "$SHARE_ADDRESS" ]; then
             echo "::error::SITE_ADDRESS or SHARE_ADDRESS not set for environment '${{ inputs.environment }}'"
             exit 1
@@ -137,6 +141,7 @@ jobs:
             "REGISTRY=${REGISTRY}" \
             "SITE_ADDRESS=${SITE_ADDRESS}" \
             "SHARE_ADDRESS=${SHARE_ADDRESS}" \
+            "SHOP_ADDRESS=${SHOP_ADDRESS}" \
             "AUTH_SECRET=${AUTH_SECRET}" \
             "AUTH_URL=${AUTH_URL}" \
             "GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}" \
@@ -198,6 +203,11 @@ jobs:
             cd /opt/deadly
 
             mkdir -p api-data ui-out
+
+            # Ensure the shared external `web` network exists (idempotent). The
+            # caddy service joins it to front the independently-deployed emma-shop;
+            # without it, `docker compose up` would fail. Safe on every env/deploy.
+            docker network create web 2>/dev/null || true
 
             # Pull new images
             echo "Pulling images..."

--- a/Caddyfile
+++ b/Caddyfile
@@ -56,3 +56,13 @@ www.{$SITE_ADDRESS} {
 		try_files {path} {path}/index.html /index.html
 	}
 }
+
+# Comet Tail Crafts (emma-shop) — a separate, independently-deployed app on the
+# same box, fronted by this Caddy via the shared external `web` network. Additive:
+# does not touch deadly's sites above. SHOP_ADDRESS is set per environment (the
+# real domain on prod) and defaults to `shop.localhost` where the shop isn't
+# hosted (e.g. beta) — an inert, internal-cert host so this block is always valid
+# and never triggers a public cert. See docs/docs/developer/hosting-emma-shop.md.
+{$SHOP_ADDRESS} {
+	reverse_proxy emma-shop:3000
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,11 @@ services:
       - SHARE_ADDRESS=${SHARE_ADDRESS}
       # Injected into /api/analytics requests so the browser never holds it.
       - ANALYTICS_API_KEY=${ANALYTICS_API_KEY}
+      # emma-shop (Comet Tail Crafts) public host, fronted by this Caddy. Set per
+      # environment (prod) via SHOP_ADDRESS; defaults to an inert internal name so
+      # the Caddy site block is never empty/invalid where the shop isn't hosted.
+      # See docs/docs/developer/hosting-emma-shop.md.
+      - SHOP_ADDRESS=${SHOP_ADDRESS:-shop.localhost}
     ports:
       - "80:80"
       - "443:443"
@@ -22,6 +27,12 @@ services:
       - ./ui-out:/srv/ui:ro
     depends_on:
       - api
+    # `default` MUST stay (Caddy reaches api/ui/ws here); `web` is the shared
+    # external network that lets Caddy reach the independently-deployed emma-shop
+    # container by name. Created idempotently during deploy.
+    networks:
+      - default
+      - web
 
   api:
     image: ${REGISTRY:-ghcr.io/ds17f/deadly-monorepo}/api:${IMAGE_TAG:-latest}
@@ -73,3 +84,10 @@ volumes:
   caddy_data:
   caddy_config:
   redis_data:
+
+networks:
+  # Shared with the independently-deployed emma-shop stack. Declared external so
+  # this compose never creates/owns it; the deploy runs `docker network create
+  # web` idempotently first. Only `caddy` joins it; api/ui/redis stay on default.
+  web:
+    external: true

--- a/docs/docs/developer/hosting-emma-shop.md
+++ b/docs/docs/developer/hosting-emma-shop.md
@@ -1,0 +1,117 @@
+# Hosting: Emma Shop (Comet Tail Crafts)
+
+deadly's Caddy is the **only** thing on the box that binds `:80`/`:443` and
+terminates TLS. A second, unrelated app — **emma-shop** (Comet Tail Crafts, a
+small e-commerce site, repo `ds17f/emma-shop`) — runs on the same Hetzner box and
+is published **through deadly's Caddy**. This integration is **built into deadly's
+normal deploy**: a standard `web-deploy` (beta or prod) sets up everything on
+deadly's side, idempotently, and never affects deadly's own sites.
+
+> **Why deadly maintainers care:** emma-shop is otherwise fully independent (its
+> own image, compose stack, deploy, volumes, database). The *only* shared surfaces
+> are (1) a Docker network and (2) one Caddy site block. The pieces below keep that
+> coupling safe on **both** environments.
+
+## The coupling (two things, both in this repo)
+
+1. **A shared external Docker network `web`.** deadly's `caddy` service joins it
+   (in addition to `default`); the deploy creates it idempotently. emma-shop joins
+   the same network. Nothing else of deadly's touches it.
+2. **One additive Caddy site block** for `{$SHOP_ADDRESS}` that reverse-proxies to
+   `emma-shop:3000`. Caddy auto-issues + renews the Let's Encrypt cert for that
+   host, stored alongside deadly's certs in the existing `caddy_data` volume.
+
+```
+  Caddy (deadly's image, owns :80/:443, auto Let's Encrypt)
+    ├── {$SITE_ADDRESS} / {$SHARE_ADDRESS}  → deadly ui/api  (network: default)
+    └── {$SHOP_ADDRESS}                      → emma-shop:3000 (network: web)   ◄── added
+```
+
+## How it stays safe across beta AND prod
+
+One caddy image (with one baked Caddyfile) serves both environments, so the shop
+host is **environment-driven** — not hardcoded — but can **never be empty**:
+
+- The shop host comes from `SHOP_ADDRESS`, a per-environment GitHub Actions
+  **variable**. Set it only where the shop is hosted (**prod** = the real domain).
+- Where it's unset (**beta**), `docker-compose.yml` substitutes a default:
+  `SHOP_ADDRESS=${SHOP_ADDRESS:-shop.localhost}`. `*.localhost` is an **inert,
+  internal-cert** host — Caddy never requests a public cert for it and nothing
+  routes to it, so beta is completely unaffected.
+- Because compose always passes a non-empty value, the Caddyfile's `{$SHOP_ADDRESS}`
+  block is **always valid** — it can never collapse into an empty site address
+  (which would be a fatal Caddy error that took deadly down too).
+
+## What's wired in (already applied on this branch)
+
+### 1. `docker-compose.yml` — caddy on `web`, with a safe default host
+```yaml
+  caddy:
+    environment:
+      - SHOP_ADDRESS=${SHOP_ADDRESS:-shop.localhost}   # real domain on prod; inert default elsewhere
+    networks:
+      - default   # MUST stay — this is how Caddy reaches api/ui/ws
+      - web       # shared external net to reach the emma-shop container
+
+networks:
+  web:
+    external: true   # never created by this compose; deploy makes it first
+```
+
+### 2. `Caddyfile` — one additive block (baked into the caddy image)
+```caddyfile
+{$SHOP_ADDRESS} {
+	reverse_proxy emma-shop:3000
+}
+```
+Pushing the `Caddyfile` triggers `build-images.yml` (it watches `Caddyfile`) to
+rebuild + push the caddy image; `web-deploy.yml` then redeploys it.
+
+### 3. `.github/workflows/web-deploy.yml` — idempotent + env-aware
+- Creates the network before bringing the stack up:
+  `docker network create web 2>/dev/null || true` (idempotent; runs every deploy,
+  both envs). Without it, `compose up` would fail because `web` is `external`.
+- Writes `SHOP_ADDRESS=${{ vars.SHOP_ADDRESS }}` into the server `.env` (empty on
+  beta → compose default applies).
+
+## What a deploy does — and doesn't
+
+- **`make web-deploy ENV=prod`** (or beta) prepares deadly's side completely:
+  network up, caddy joined to it, shop route present, `SHOP_ADDRESS` set. It is
+  **idempotent** — re-running changes nothing.
+- It does **not** start the shop container. emma-shop is deployed by **its own**
+  pipeline (`ds17f/emma-shop`), which joins the same `web` network. Until then,
+  `{$SHOP_ADDRESS}` simply returns 502 — deadly's sites are unaffected.
+
+## Rules that keep deadly safe (each avoidable)
+
+1. **Network first:** the deploy's `docker network create web || true` must run
+   before `compose up`. Already wired; if you hand-run compose, create it yourself.
+2. **Never drop `default`** from the caddy service — with only `web`, Caddy can't
+   reach `api`/`ui` and **deadly's site 502s**.
+3. **Keep the shop host env-driven with the compose default** — don't hardcode a
+   domain (breaks the other env) and don't remove the `:-shop.localhost` fallback
+   (an unset var would then yield an empty, fatal site address).
+4. **Keep the block additive** — never edit the `{$SITE_ADDRESS}` /
+   `{$SHARE_ADDRESS}` blocks.
+5. **Prod prerequisites:** `shop.<domain>` A record → box IP and `:80` reachable
+   before first hit so Caddy can complete the ACME challenge. A failed shop cert
+   does not affect deadly's existing certs (separate entries in `caddy_data`).
+
+## Blast radius if the shop misbehaves
+
+- emma-shop binds **no host ports** (`expose: 3000` only) — can't collide with
+  Caddy's `:80`/`:443`.
+- Its database/uploads live on its **own** volumes (`emma_db`, `emma_uploads`),
+  separate from `caddy_data`/`redis_data`/`api-data`.
+- If the shop container is down, Caddy returns 502 **for `{$SHOP_ADDRESS}` only**;
+  deadly's sites keep working.
+
+## To actually publish the shop on prod
+
+1. Set repo **variable** `SHOP_ADDRESS` (prod environment) = the shop's real domain.
+2. DNS A record `shop.<domain>` → box IP.
+3. Run `web-deploy` (prod) — deadly side is now ready.
+4. Deploy emma-shop from its own repo (joins `web`). Cert issues on first hit.
+
+The mirror of this page lives in `ds17f/emma-shop` → `DEPLOY.md` (Part B).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
       - Architecture: developer/architecture.md
       - Version Management: developer/version-management.md
       - CI/CD: developer/ci-cd.md
+      - Hosting Emma Shop: developer/hosting-emma-shop.md
       - API Integration: developer/api-integration.md
       - User-Data Sync: developer/user-data-sync.md
       - Domain Models: developer/domain-models.md


### PR DESCRIPTION
Publish the independently-deployed **emma-shop** (Comet Tail Crafts) through deadly's Caddy, wired into the normal `web-deploy` so a beta/prod deploy sets up the hosting side with no manual box steps. Additive — deadly's own sites are untouched. Verified end-to-end on **beta**.

## Changes
**emma-shop hosting (`bca630ba`)**
- `docker-compose.yml`: caddy joins the shared external `web` network (keeps `default`); `SHOP_ADDRESS=${SHOP_ADDRESS:-shop.localhost}` so the host is per-env but never empty; declare `web` external.
- `Caddyfile`: additive `{$SHOP_ADDRESS}` block → `reverse_proxy emma-shop:3000`.
- `web-deploy.yml`: idempotent `docker network create web || true` before `compose up`; write `SHOP_ADDRESS` from the per-env GitHub variable.
- Docs: `developer/hosting-emma-shop.md` (+ nav) — coupling, beta/prod safety model, guardrails.

**Deploy ordering fix (`44506729`)**
- On a first stand-up the new box's DNS still points at the old server, so the health check timed out and `exit 1`'d, which **skipped** the trailing `Update DNS` step — DNS could never cut over (chicken-and-egg).
- Reorder to **Deploy → Update DNS → Health check**; `exit 0` → `break`; restart Caddy once DNS is correct so it re-obtains certs immediately instead of waiting out ACME back-off.

## Safety on both environments
One baked Caddyfile serves beta + prod. `SHOP_ADDRESS` is a per-env variable set only where the shop runs (prod). Where unset (beta), compose falls back to `shop.localhost` — an inert internal-cert host, so Caddy never requests a public cert and nothing routes to it. The `{$SHOP_ADDRESS}` block can never collapse to an empty (fatal) site address.

## Verified on beta
- Deploy run fully green: Deploy ✓, Update DNS ✓, Health check ✓
- DNS cut over to the new box; valid Let's Encrypt certs for `beta` / `share.beta` / `www.beta.thedeadly.app`
- Caddy loads cleanly with the emma-shop block present (`shop.localhost` inert) — zero impact on deadly's sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)