### PR TITLE
Front The Starlight Loft through Caddy (additive)

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -128,6 +128,10 @@ jobs:
           # only where the shop is hosted (prod). Empty elsewhere — compose then
           # falls back to an inert default, so beta is unaffected.
           SHOP_ADDRESS="${{ vars.SHOP_ADDRESS }}"
+          # Optional: The Starlight Loft public host. Set as a per-environment
+          # variable only where the loft is hosted. Empty elsewhere — compose then
+          # falls back to an inert default, so other envs are unaffected.
+          LOFT_ADDRESS="${{ vars.LOFT_ADDRESS }}"
           if [ -z "$SITE_ADDRESS" ] || [ -z "$SHARE_ADDRESS" ]; then
             echo "::error::SITE_ADDRESS or SHARE_ADDRESS not set for environment '${{ inputs.environment }}'"
             exit 1
@@ -142,6 +146,7 @@ jobs:
             "SITE_ADDRESS=${SITE_ADDRESS}" \
             "SHARE_ADDRESS=${SHARE_ADDRESS}" \
             "SHOP_ADDRESS=${SHOP_ADDRESS}" \
+            "LOFT_ADDRESS=${LOFT_ADDRESS}" \
             "AUTH_SECRET=${AUTH_SECRET}" \
             "AUTH_URL=${AUTH_URL}" \
             "GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}" \

--- a/Caddyfile
+++ b/Caddyfile
@@ -66,3 +66,13 @@ www.{$SITE_ADDRESS} {
 {$SHOP_ADDRESS} {
 	reverse_proxy emma-shop:3000
 }
+
+# The Starlight Loft — a separate, independently-deployed Next.js app on the same
+# box, fronted by this Caddy via the shared external `web` network. Additive: does
+# not touch deadly's or the shop's sites. LOFT_ADDRESS is set per environment (the
+# real domain) and defaults to `loft.localhost` where the loft isn't hosted — an
+# inert, internal-cert host so this block is always valid and never triggers a
+# public cert. See docs/docs/developer/hosting-the-starlight-loft.md.
+{$LOFT_ADDRESS} {
+	reverse_proxy starlight-loft:3000
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,10 @@ services:
       # the Caddy site block is never empty/invalid where the shop isn't hosted.
       # See docs/docs/developer/hosting-emma-shop.md.
       - SHOP_ADDRESS=${SHOP_ADDRESS:-shop.localhost}
+      # The Starlight Loft public host, fronted by this Caddy. Set per environment
+      # via LOFT_ADDRESS; defaults to an inert internal name where not hosted.
+      # See docs/docs/developer/hosting-the-starlight-loft.md.
+      - LOFT_ADDRESS=${LOFT_ADDRESS:-loft.localhost}
     ports:
       - "80:80"
       - "443:443"

--- a/docs/docs/developer/hosting-the-starlight-loft.md
+++ b/docs/docs/developer/hosting-the-starlight-loft.md
@@ -1,0 +1,37 @@
+# Hosting The Starlight Loft
+
+The Starlight Loft (`ds17f/the-starlight-loft`) is a separate, independently-deployed
+Next.js app fronted by deadly's Caddy via the shared external `web` network —
+**exactly the same pattern as the shop**. For the full rationale, safety model, and
+gotchas, read [Hosting Emma Shop](hosting-emma-shop.md); this page only records the
+loft-specific bits.
+
+## What's wired here (additive, deadly's + shop's sites untouched)
+
+- **Caddy block** (`Caddyfile`): `{$LOFT_ADDRESS} { reverse_proxy starlight-loft:3000 }`.
+- **Compose** (`docker-compose.yml`): `LOFT_ADDRESS=${LOFT_ADDRESS:-loft.localhost}`
+  on the `caddy` service — inert `*.localhost` default so the block is always valid
+  and never requests a public cert where the loft isn't hosted.
+- **Deploy** (`web-deploy.yml`): `LOFT_ADDRESS` is read from a per-environment
+  GitHub **variable** and written into the server `.env`.
+
+The loft container (`starlight-loft`, `expose: 3000`, joined to `web`) is deployed
+from its own repo — deadly only provides the route.
+
+## Specifics
+
+- Container name Caddy targets: **`starlight-loft:3000`**.
+- Public host variable: **`LOFT_ADDRESS`** (e.g. `beta.thestarlightloft.com` on
+  beta, `thestarlightloft.com` on prod).
+
+## To publish the loft (per environment)
+
+1. Set the GitHub **variable** `LOFT_ADDRESS` on the target environment = the real
+   domain (leave unset elsewhere → inert default).
+2. DNS A record for that domain → box IP, `:80` reachable for ACME.
+3. `make web-deploy ENV=<env>` — deadly's Caddy picks up the route.
+4. Deploy the loft from `ds17f/the-starlight-loft` (`make deploy ENV=<env>`); it
+   joins `web` and the cert issues on first hit.
+
+Until the loft container is up, `{$LOFT_ADDRESS}` returns 502 **only for that host**
+— deadly's and the shop's sites are unaffected.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
       - Version Management: developer/version-management.md
       - CI/CD: developer/ci-cd.md
       - Hosting Emma Shop: developer/hosting-emma-shop.md
+      - Hosting The Starlight Loft: developer/hosting-the-starlight-loft.md
       - API Integration: developer/api-integration.md
       - User-Data Sync: developer/user-data-sync.md
       - Domain Models: developer/domain-models.md


### PR DESCRIPTION
Adds the hosting route for a new sibling site — **The Starlight Loft**
(`ds17f/the-starlight-loft`, container `starlight-loft:3000`) — mirroring the
emma-shop pattern exactly. Follow-up to #89.

## Changes (all additive)
- **Caddyfile**: `{$LOFT_ADDRESS} { reverse_proxy starlight-loft:3000 }`
- **docker-compose.yml**: `LOFT_ADDRESS=${LOFT_ADDRESS:-loft.localhost}` on `caddy`
  — inert `*.localhost` default so the block is always valid and never requests a
  public cert where the loft isn't hosted
- **web-deploy.yml**: thread `LOFT_ADDRESS` from a per-environment GitHub variable
  into the server `.env`
- **docs**: `hosting-the-starlight-loft.md` (+ mkdocs nav)

## Safety
- Deadly's and the shop's sites are untouched (purely additive).
- With `LOFT_ADDRESS` unset, the block is inert — no route, no cert.
- The loft container is deployed from its own repo and joins the shared `web`
  network; this PR only provides the Caddy route.

## To activate (per environment)
Set the `LOFT_ADDRESS` GitHub **variable** on the env (e.g. `beta` =
`beta.thestarlightloft.com`) + DNS, then `make web-deploy ENV=<env>`. Until then it
stays dormant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)