### PR TITLE
feat(infra): add Starlight Loft redirect hosts (www + secondary domain → apex)

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -128,10 +128,13 @@ jobs:
           # only where the shop is hosted (prod). Empty elsewhere — compose then
           # falls back to an inert default, so beta is unaffected.
           SHOP_ADDRESS="${{ vars.SHOP_ADDRESS }}"
-          # Optional: The Starlight Loft public host. Set as a per-environment
-          # variable only where the loft is hosted. Empty elsewhere — compose then
-          # falls back to an inert default, so other envs are unaffected.
+          # Optional: The Starlight Loft public host, plus its redirect hosts
+          # (www + secondary domain → apex). Set as per-environment variables
+          # only where the loft is hosted. Empty elsewhere — compose then
+          # falls back to inert defaults, so other envs are unaffected.
           LOFT_ADDRESS="${{ vars.LOFT_ADDRESS }}"
+          LOFT_WWW_ADDRESS="${{ vars.LOFT_WWW_ADDRESS }}"
+          LOFT_ALT_ADDRESS="${{ vars.LOFT_ALT_ADDRESS }}"
           if [ -z "$SITE_ADDRESS" ] || [ -z "$SHARE_ADDRESS" ]; then
             echo "::error::SITE_ADDRESS or SHARE_ADDRESS not set for environment '${{ inputs.environment }}'"
             exit 1
@@ -147,6 +150,8 @@ jobs:
             "SHARE_ADDRESS=${SHARE_ADDRESS}" \
             "SHOP_ADDRESS=${SHOP_ADDRESS}" \
             "LOFT_ADDRESS=${LOFT_ADDRESS}" \
+            "LOFT_WWW_ADDRESS=${LOFT_WWW_ADDRESS}" \
+            "LOFT_ALT_ADDRESS=${LOFT_ALT_ADDRESS}" \
             "AUTH_SECRET=${AUTH_SECRET}" \
             "AUTH_URL=${AUTH_URL}" \
             "GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}" \

--- a/Caddyfile
+++ b/Caddyfile
@@ -76,3 +76,11 @@ www.{$SITE_ADDRESS} {
 {$LOFT_ADDRESS} {
 	reverse_proxy starlight-loft:3000
 }
+
+# Loft redirect hosts (loft repo ADR-010): www.<apex> and the secondary domain
+# (starlightloft.com) 301 to the loft's canonical host. Set per environment
+# alongside LOFT_ADDRESS; distinct inert defaults where the loft isn't hosted,
+# so the block stays valid and never requests a public cert.
+{$LOFT_WWW_ADDRESS}, {$LOFT_ALT_ADDRESS} {
+	redir https://{$LOFT_ADDRESS}{uri} permanent
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,10 @@ services:
       # via LOFT_ADDRESS; defaults to an inert internal name where not hosted.
       # See docs/docs/developer/hosting-the-starlight-loft.md.
       - LOFT_ADDRESS=${LOFT_ADDRESS:-loft.localhost}
+      # Loft redirect hosts (www + secondary domain → apex). Same per-environment
+      # pattern; distinct inert defaults so the addresses never collide.
+      - LOFT_WWW_ADDRESS=${LOFT_WWW_ADDRESS:-loft-www.localhost}
+      - LOFT_ALT_ADDRESS=${LOFT_ALT_ADDRESS:-loft-alt.localhost}
     ports:
       - "80:80"
       - "443:443"

--- a/docs/docs/developer/hosting-the-starlight-loft.md
+++ b/docs/docs/developer/hosting-the-starlight-loft.md
@@ -9,11 +9,15 @@ loft-specific bits.
 ## What's wired here (additive, deadly's + shop's sites untouched)
 
 - **Caddy block** (`Caddyfile`): `{$LOFT_ADDRESS} { reverse_proxy starlight-loft:3000 }`.
+- **Redirect block** (`Caddyfile`): `{$LOFT_WWW_ADDRESS}, {$LOFT_ALT_ADDRESS}`
+  301 to `https://{$LOFT_ADDRESS}` — covers `www.` and the secondary domain
+  (`starlightloft.com`) at launch (loft repo ADR-010).
 - **Compose** (`docker-compose.yml`): `LOFT_ADDRESS=${LOFT_ADDRESS:-loft.localhost}`
-  on the `caddy` service — inert `*.localhost` default so the block is always valid
-  and never requests a public cert where the loft isn't hosted.
-- **Deploy** (`web-deploy.yml`): `LOFT_ADDRESS` is read from a per-environment
-  GitHub **variable** and written into the server `.env`.
+  (+ `LOFT_WWW_ADDRESS`/`LOFT_ALT_ADDRESS` with distinct `*.localhost` defaults)
+  on the `caddy` service — inert defaults so the blocks are always valid
+  and never request a public cert where the loft isn't hosted.
+- **Deploy** (`web-deploy.yml`): all three are read from per-environment
+  GitHub **variables** and written into the server `.env`.
 
 The loft container (`starlight-loft`, `expose: 3000`, joined to `web`) is deployed
 from its own repo — deadly only provides the route.
@@ -23,6 +27,12 @@ from its own repo — deadly only provides the route.
 - Container name Caddy targets: **`starlight-loft:3000`**.
 - Public host variable: **`LOFT_ADDRESS`** (e.g. `beta.thestarlightloft.com` on
   beta, `thestarlightloft.com` on prod).
+- Redirect host variables (set on prod at launch, unset elsewhere):
+  **`LOFT_WWW_ADDRESS`** = `www.thestarlightloft.com`,
+  **`LOFT_ALT_ADDRESS`** = `starlightloft.com`. Each needs its own DNS record
+  pointing at the box (`:80` reachable for ACME). `www.` is a separate variable —
+  not derived from `LOFT_ADDRESS` — so beta never requests a cert for a
+  `www.beta.…` name that has no DNS record.
 
 ## To publish the loft (per environment)
 


### PR DESCRIPTION
Follow-up to #90 (fronting The Starlight Loft through Caddy). Adds a Caddy redirect block that 301s the Loft's `www` host and secondary domain (`starlightloft.com`) to the canonical apex (loft repo ADR-010).

### What changed
- **Caddyfile** — `{$LOFT_WWW_ADDRESS}, {$LOFT_ALT_ADDRESS}` → `redir https://{$LOFT_ADDRESS}{uri} permanent`.
- **docker-compose.yml** — `LOFT_WWW_ADDRESS` / `LOFT_ALT_ADDRESS` with distinct inert `*.localhost` defaults so the block stays valid and never requests a public cert where the Loft isn't hosted.
- **web-deploy.yml** — reads both from per-environment GitHub **variables** into the server `.env`.
- **docs** — documents the redirect block alongside the existing Loft hosting notes.

### Safety
Additive and beta/prod safe — same per-environment pattern as `LOFT_ADDRESS`; other sites and environments are unaffected. To activate for a given env, set the `LOFT_WWW_ADDRESS` / `LOFT_ALT_ADDRESS` GitHub variables (and the matching DNS); leaving them unset keeps the inert defaults.

> Provenance: this was uncommitted work-in-progress sitting in the working tree; committed here intact so it isn't lost. Independent of the Connect proto-3 PRs (#92/#93/#94).

🤖 Generated with [Claude Code](https://claude.com/claude-code)